### PR TITLE
fix(scheduler): remove restrictive qBittorrent check in RSS scheduler

### DIFF
--- a/scheduler/manager.go
+++ b/scheduler/manager.go
@@ -169,19 +169,12 @@ func (m *Manager) Reload(cfg *models.Config) {
 	m.initFreeEndMonitor()
 
 	// 重新启动：每次启动任务时从 DB 读取最新配置，保证一致性
-	store := core.NewConfigStore(global.GlobalDB)
-	qb, _ := store.GetQbitOnly()
 	for site, sc := range cfg.Sites {
 		if sc.Enabled != nil && *sc.Enabled {
 			// 使用统一的工厂函数创建站点实现
 			impl, err := internal.NewUnifiedSiteImpl(context.Background(), site)
 			if err != nil {
 				global.GetSlogger().Warnf("站点 %s 未注册或不支持，跳过: %v", string(site), err)
-				continue
-			}
-			// 检查下载器配置
-			if qb.URL == "" || qb.User == "" || qb.Password == "" {
-				global.GetSlogger().Warnf("跳过站点 %s：qbit 未配置", string(site))
 				continue
 			}
 			for _, r := range sc.RSS {


### PR DESCRIPTION
## Summary

- Remove the hardcoded qBittorrent configuration check in the RSS scheduler that was preventing RSS tasks from starting
- Previously, if qBittorrent wasn't configured, all RSS tasks would be skipped even when using Transmission as the downloader

## Test plan

- [x] Verified RSS tasks now start correctly when Transmission is configured without qBittorrent
- [x] Existing qBittorrent users continue to work as before