### PR TITLE
fix(docker): 升级构建镜像 Go 版本至 1.26.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 参数区分构建环境与基础镜像来源
-ARG BUILD_IMAGE=golang:1.25.7
+ARG BUILD_IMAGE=golang:1.26.0
 ARG BASE_IMAGE=alpine:3.20.3
 ARG NODE_IMAGE=node:25.2.0-alpine
 ARG BUILD_ENV=local

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ HTTPS_PROXY ?= $(https_proxy)
 NO_PROXY ?= $(no_proxy)
 
 # 默认基础镜像
-BUILD_IMAGE ?= golang:1.25.7
+BUILD_IMAGE ?= golang:1.26.0
 BASE_IMAGE ?= alpine:3.20.3
 NODE_IMAGE ?= node:25.2.0-alpine
 BUILD_ENV ?= remote


### PR DESCRIPTION
## Summary

- 修复 Docker 构建镜像中 Go 版本与 go.mod 不匹配的问题
- Dockerfile 和 Makefile 中的 Go 镜像从 `golang:1.25.7` 升级至 `golang:1.26.0`

## Context

v0.18.0 的 release pipeline 在 Docker 构建步骤失败，因为 `go.mod` 要求 `go >= 1.26.0` 而 Dockerfile 仍使用 `golang:1.25.7`。