### PR TITLE
docs(extension): update install guide with Edge Add-ons store link

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,16 +243,16 @@ Expand-Archive -Path "pt-tools.zip" -DestinationPath "."
 
 ### 安装方式
 
-**从 GitHub Release 下载**（推荐）：
+**Edge Add-ons 扩展商店**（推荐）：
+
+- 前往 [Edge 扩展商店](https://microsoftedge.microsoft.com/addons/detail/pt-tools-helper) 搜索 "PT Tools Helper" 直接安装，支持自动更新
+
+**从 GitHub Release 手动安装**：
 
 1. 前往 [Releases](https://github.com/sunerpy/pt-tools/releases) 下载最新的 `pt-tools-helper.zip`
 2. 解压到任意目录
 3. Chrome → `chrome://extensions` / Edge → `edge://extensions`
 4. 开启「开发者模式」→「加载已解压的扩展程序」→ 选择解压目录
-
-**Edge Add-ons 扩展商店**（审核中）：
-
-- 审核通过后可在 Edge 扩展商店搜索 "PT Tools Helper" 直接安装
 
 详细使用说明见 [扩展 README](tools/browser-extension/README.md)。
 

--- a/tools/browser-extension/README.md
+++ b/tools/browser-extension/README.md
@@ -4,12 +4,17 @@ PT 站点数据采集助手，一键采集站点数据、同步 Cookie 到 pt-to
 
 ## 安装
 
-### Chrome / Edge
+### Edge 扩展商店（推荐）
 
-1. 下载 `pt-tools-helper.zip` 并解压
-2. 打开 `chrome://extensions`，开启「开发者模式」
-3. 点击「加载已解压的扩展程序」，选择解压目录
-4. 首次点击扩展图标时会请求权限，点击「授权并启用」
+前往 [Edge Add-ons 商店](https://microsoftedge.microsoft.com/addons/detail/pt-tools-helper) 搜索 "PT Tools Helper" 直接安装，支持自动更新。
+
+### Chrome / Edge 手动安装
+
+1. 前往 [Releases](https://github.com/sunerpy/pt-tools/releases) 下载最新的 `pt-tools-helper.zip` 并解压
+2. 打开 `chrome://extensions`（Chrome）或 `edge://extensions`（Edge）
+3. 开启「开发者模式」
+4. 点击「加载已解压的扩展程序」，选择解压目录
+5. 首次点击扩展图标时会请求权限，点击「授权并启用」
 
 ### Firefox
 


### PR DESCRIPTION
## Summary
- 浏览器扩展已通过 Edge Add-ons 商店审核，更新安装说明将商店安装设为推荐方式

## Changes
- `README.md` — 安装方式改为商店优先，GitHub Release 改为手动安装备选
- `tools/browser-extension/README.md` — 新增 Edge 扩展商店安装章节，重新组织安装步骤

> `docs` 类型 commit，不触发版本发布。