### PR TITLE
docs(extension): fix Edge Add-ons store URL with extension ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Expand-Archive -Path "pt-tools.zip" -DestinationPath "."
 
 **Edge Add-ons 扩展商店**（推荐）：
 
-- 前往 [Edge 扩展商店](https://microsoftedge.microsoft.com/addons/detail/pt-tools-helper) 搜索 "PT Tools Helper" 直接安装，支持自动更新
+- 前往 [Edge 扩展商店](https://microsoftedge.microsoft.com/addons/detail/pt-tools-helper/pgicnjkmgenmjfhlclodbpbedjmojbea) 搜索 "PT Tools Helper" 直接安装，支持自动更新
 
 **从 GitHub Release 手动安装**：
 

--- a/tools/browser-extension/README.md
+++ b/tools/browser-extension/README.md
@@ -6,7 +6,7 @@ PT 站点数据采集助手，一键采集站点数据、同步 Cookie 到 pt-to
 
 ### Edge 扩展商店（推荐）
 
-前往 [Edge Add-ons 商店](https://microsoftedge.microsoft.com/addons/detail/pt-tools-helper) 搜索 "PT Tools Helper" 直接安装，支持自动更新。
+前往 [Edge Add-ons 商店](https://microsoftedge.microsoft.com/addons/detail/pt-tools-helper/pgicnjkmgenmjfhlclodbpbedjmojbea) 搜索 "PT Tools Helper" 直接安装，支持自动更新。
 
 ### Chrome / Edge 手动安装
 


### PR DESCRIPTION
修复 Edge 扩展商店链接缺少 extension ID 导致 404 的问题。