### PR TITLE
fix(site): 修复新站点详情抓取与跨站点推送问题

### DIFF
--- a/internal/common.go
+++ b/internal/common.go
@@ -151,6 +151,12 @@ func ProcessTorrentsWithDownloaderByRSS(
 		return fmt.Errorf("无法读取目录: %v", err)
 	}
 
+	filePaths = filterTorrentFilesBySite(filePaths, siteName)
+	if len(filePaths) == 0 {
+		sLogger().Infof("[种子推送完成] 站点=%s, 总数=0, 成功=0, 失败=0", siteName)
+		return nil
+	}
+
 	successCount := 0
 	failCount := 0
 	for i, file := range filePaths {
@@ -169,6 +175,21 @@ func ProcessTorrentsWithDownloaderByRSS(
 
 	sLogger().Infof("[种子推送完成] 站点=%s, 总数=%d, 成功=%d, 失败=%d", siteName, len(filePaths), successCount, failCount)
 	return nil
+}
+
+func filterTorrentFilesBySite(filePaths []string, siteName models.SiteGroup) []string {
+	prefix := strings.ToLower(string(siteName)) + "-"
+	filtered := make([]string, 0, len(filePaths))
+	for _, file := range filePaths {
+		if strings.HasPrefix(strings.ToLower(filepath.Base(file)), prefix) {
+			filtered = append(filtered, file)
+		}
+	}
+	if len(filtered) > 0 {
+		return filtered
+	}
+
+	return filePaths
 }
 
 func processSingleTorrentWithDownloader(
@@ -466,6 +487,18 @@ type rssTaskStats struct {
 	downloadFailed atomic.Int64
 }
 
+func shouldSkipExistingTorrent(torrent *models.TorrentInfo) bool {
+	if torrent == nil {
+		return false
+	}
+
+	if torrent.IsSkipped {
+		return true
+	}
+
+	return torrent.IsPushed != nil && *torrent.IsPushed
+}
+
 func downloadWorkerUnified(
 	ctx context.Context,
 	wg *sync.WaitGroup,
@@ -531,8 +564,7 @@ func downloadWorkerUnified(
 				sLogger().Errorf("从数据库获取种子: %s 详情失败, %v", title, err)
 				continue
 			}
-			// 如果种子已跳过或已推送，直接跳过
-			if torrent != nil && (torrent.IsSkipped || torrent.IsPushed != nil) {
+			if shouldSkipExistingTorrent(torrent) {
 				sLogger().Infof("%s: 种子 %s 已跳过或已推送，直接跳过", title, item.GUID)
 				stats.skipped.Add(1)
 				continue
@@ -1080,8 +1112,7 @@ func downloadWorker[T models.ResType](
 				sLogger().Errorf("从数据库获取种子: %s 详情失败, %v", title, err)
 				continue
 			}
-			// 如果种子已跳过或已推送，直接跳过
-			if torrent != nil && (torrent.IsSkipped || torrent.IsPushed != nil) {
+			if shouldSkipExistingTorrent(torrent) {
 				sLogger().Infof("%s: 种子 %s 已跳过或已推送，直接跳过", title, item.GUID)
 				continue
 			}

--- a/internal/common_test.go
+++ b/internal/common_test.go
@@ -1421,3 +1421,54 @@ func TestProcessTorrentsWithDownloaderByRSS_WithDownloadPath(t *testing.T) {
 	require.NotNil(t, ti2.IsPushed)
 	require.True(t, *ti2.IsPushed)
 }
+
+func TestShouldSkipExistingTorrent(t *testing.T) {
+	var nilPushed *bool
+	falsePushed := false
+	truePushed := true
+
+	tests := []struct {
+		name    string
+		torrent *models.TorrentInfo
+		want    bool
+	}{
+		{name: "nil torrent", torrent: nil, want: false},
+		{name: "skipped torrent", torrent: &models.TorrentInfo{IsSkipped: true}, want: true},
+		{name: "pushed true", torrent: &models.TorrentInfo{IsPushed: &truePushed}, want: true},
+		{name: "pushed false should retry", torrent: &models.TorrentInfo{IsPushed: &falsePushed}, want: false},
+		{name: "pushed nil", torrent: &models.TorrentInfo{IsPushed: nilPushed}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, shouldSkipExistingTorrent(tt.torrent))
+		})
+	}
+}
+
+func TestFilterTorrentFilesBySite(t *testing.T) {
+	files := []string{
+		"/app/.pt-tools/downloads/agsvpt-111.torrent",
+		"/app/.pt-tools/downloads/AGSvpt-222.torrent",
+		"/app/.pt-tools/downloads/mteam-333.torrent",
+		"/app/.pt-tools/downloads/xingyunge-444.torrent",
+		"/app/.pt-tools/downloads/random.torrent",
+	}
+
+	filtered := filterTorrentFilesBySite(files, models.SiteGroup("agsvpt"))
+	require.Len(t, filtered, 2)
+	require.Equal(t, "/app/.pt-tools/downloads/agsvpt-111.torrent", filtered[0])
+	require.Equal(t, "/app/.pt-tools/downloads/AGSvpt-222.torrent", filtered[1])
+}
+
+func TestFilterTorrentFilesBySite_FallbackAllWhenNoPrefixMatch(t *testing.T) {
+	files := []string{
+		"/app/.pt-tools/downloads/file-a.torrent",
+		"/app/.pt-tools/downloads/file-b.torrent",
+	}
+
+	filtered := filterTorrentFilesBySite(files, models.SiteGroup("agsvpt"))
+	require.Len(t, filtered, 2)
+	require.Equal(t, files[0], filtered[0])
+	require.Equal(t, files[1], filtered[1])
+}

--- a/site/v2/detail_fetcher_support_test.go
+++ b/site/v2/detail_fetcher_support_test.go
@@ -1,0 +1,55 @@
+package v2_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+	_ "github.com/sunerpy/pt-tools/site/v2/definitions"
+)
+
+func TestSiteDetailFetcherSupportForNewSites(t *testing.T) {
+	registry := v2.GetGlobalSiteRegistry()
+
+	tests := []struct {
+		name  string
+		site  string
+		creds v2.SiteCredentials
+	}{
+		{
+			name: "xingyunge supports detail fetcher",
+			site: "xingyunge",
+			creds: v2.SiteCredentials{
+				Cookie: "uid=1; pass=mock",
+			},
+		},
+		{
+			name: "agsvpt supports detail fetcher",
+			site: "agsvpt",
+			creds: v2.SiteCredentials{
+				Cookie: "uid=1; pass=mock",
+			},
+		},
+		{
+			name: "mooko supports detail fetcher",
+			site: "mooko",
+			creds: v2.SiteCredentials{
+				Cookie: "uid=1; pass=mock",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			site, err := registry.CreateSite(tt.site, tt.creds, "")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = site.Close() })
+
+			provider, ok := site.(v2.DetailFetcherProvider)
+			require.True(t, ok)
+			assert.NotNil(t, provider.GetDetailFetcher())
+		})
+	}
+}

--- a/site/v2/gazelle_driver.go
+++ b/site/v2/gazelle_driver.go
@@ -340,6 +340,187 @@ func (d *GazelleDriver) ParseDownload(res GazelleResponse) ([]byte, error) {
 	return res.RawBody, nil
 }
 
+type gazelleTorrentDetailResponse struct {
+	Group struct {
+		Name      string `json:"name"`
+		GroupName string `json:"groupName"`
+		Artist    string `json:"artist"`
+	} `json:"group"`
+	Torrent  GazelleTorrent   `json:"torrent"`
+	Torrents []GazelleTorrent `json:"torrents"`
+
+	ID             int    `json:"id"`
+	GroupName      string `json:"groupName"`
+	Artist         string `json:"artist"`
+	Format         string `json:"format"`
+	Encoding       string `json:"encoding"`
+	Size           int64  `json:"size"`
+	Seeders        int    `json:"seeders"`
+	Leechers       int    `json:"leechers"`
+	Snatches       int    `json:"snatches"`
+	IsFreeleech    bool   `json:"isFreeleech"`
+	IsNeutralLeech bool   `json:"isNeutralLeech"`
+	IsPersonalFL   bool   `json:"isPersonalFreeleech"`
+	Time           string `json:"time"`
+}
+
+func (d *GazelleDriver) GetTorrentDetail(ctx context.Context, guid, link, title string) (*TorrentItem, error) {
+	torrentID := extractGazelleTorrentID(guid, link)
+	if torrentID == "" {
+		return nil, fmt.Errorf("unable to determine torrent ID")
+	}
+
+	req := GazelleRequest{
+		Action: "torrent",
+		Params: url.Values{"id": []string{torrentID}},
+	}
+
+	res, err := d.Execute(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("execute detail request: %w", err)
+	}
+
+	var detail gazelleTorrentDetailResponse
+	if err := json.Unmarshal(res.Response, &detail); err != nil {
+		return nil, fmt.Errorf("parse torrent detail: %w", err)
+	}
+
+	tid, _ := strconv.Atoi(torrentID)
+	torrent := selectGazelleDetailTorrent(detail, tid)
+	groupName, artist := selectGazelleDetailGroup(detail)
+
+	detailTitle := buildGazelleDetailTitle(groupName, artist, torrent)
+	if detailTitle == "" {
+		detailTitle = title
+	}
+
+	item := &TorrentItem{
+		ID:            torrentID,
+		Title:         detailTitle,
+		SizeBytes:     torrent.Size,
+		Seeders:       torrent.Seeders,
+		Leechers:      torrent.Leechers,
+		Snatched:      torrent.Snatches,
+		SourceSite:    d.BaseURL,
+		DiscountLevel: parseGazelleDiscount(torrent.IsFreeleech, torrent.IsNeutralLeech, torrent.IsPersonalFL),
+	}
+
+	if torrent.Time != "" {
+		if uploadTime, err := time.Parse("2006-01-02 15:04:05", torrent.Time); err == nil {
+			item.UploadedAt = uploadTime.Unix()
+		}
+	}
+
+	return item, nil
+}
+
+func extractGazelleTorrentID(guid, link string) string {
+	if link != "" {
+		if id := extractGazelleTorrentIDFromURL(link); id != "" {
+			return id
+		}
+	}
+	if id := extractGazelleTorrentIDFromURL(guid); id != "" {
+		return id
+	}
+	if _, err := strconv.Atoi(guid); err == nil {
+		return guid
+	}
+	return ""
+}
+
+func extractGazelleTorrentIDFromURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+
+	for _, key := range []string{"id", "torrentid", "torrentId"} {
+		if id := u.Query().Get(key); id != "" {
+			if _, err := strconv.Atoi(id); err == nil {
+				return id
+			}
+		}
+	}
+
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	for i := len(parts) - 1; i >= 0; i-- {
+		if _, err := strconv.Atoi(parts[i]); err == nil {
+			return parts[i]
+		}
+	}
+
+	return ""
+}
+
+func selectGazelleDetailTorrent(detail gazelleTorrentDetailResponse, expectedID int) GazelleTorrent {
+	if detail.Torrent.TorrentID != 0 {
+		return detail.Torrent
+	}
+
+	if len(detail.Torrents) > 0 {
+		if expectedID > 0 {
+			for _, t := range detail.Torrents {
+				if t.TorrentID == expectedID {
+					return t
+				}
+			}
+		}
+		return detail.Torrents[0]
+	}
+
+	return GazelleTorrent{
+		TorrentID:      detail.ID,
+		Format:         detail.Format,
+		Encoding:       detail.Encoding,
+		Size:           detail.Size,
+		Seeders:        detail.Seeders,
+		Leechers:       detail.Leechers,
+		Snatches:       detail.Snatches,
+		IsFreeleech:    detail.IsFreeleech,
+		IsNeutralLeech: detail.IsNeutralLeech,
+		IsPersonalFL:   detail.IsPersonalFL,
+		Time:           detail.Time,
+	}
+}
+
+func selectGazelleDetailGroup(detail gazelleTorrentDetailResponse) (string, string) {
+	groupName := detail.GroupName
+	artist := detail.Artist
+
+	if groupName == "" {
+		groupName = detail.Group.Name
+	}
+	if groupName == "" {
+		groupName = detail.Group.GroupName
+	}
+	if artist == "" {
+		artist = detail.Group.Artist
+	}
+
+	return groupName, artist
+}
+
+func buildGazelleDetailTitle(groupName, artist string, torrent GazelleTorrent) string {
+	title := groupName
+	if artist != "" && groupName != "" {
+		title = artist + " - " + groupName
+	}
+	if title == "" {
+		return ""
+	}
+
+	if torrent.Format != "" {
+		title += " [" + torrent.Format
+		if torrent.Encoding != "" {
+			title += " " + torrent.Encoding
+		}
+		title += "]"
+	}
+
+	return title
+}
+
 // parseGazelleDiscount parses Gazelle freeleech status to DiscountLevel
 func parseGazelleDiscount(isFreeleech, isNeutralLeech, isPersonalFL bool) DiscountLevel {
 	if isFreeleech || isPersonalFL {

--- a/site/v2/gazelle_driver_test.go
+++ b/site/v2/gazelle_driver_test.go
@@ -296,6 +296,70 @@ func TestGazelleDriver_PrepareDownload(t *testing.T) {
 	assert.Equal(t, "12345", req.Params.Get("id"))
 }
 
+func TestGazelleDriver_GetTorrentDetail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "torrent", r.URL.Query().Get("action"))
+		assert.Equal(t, "12345", r.URL.Query().Get("id"))
+
+		resp := GazelleResponse{
+			Status: "success",
+			Response: json.RawMessage(`{
+				"group": {"name": "Test Album", "artist": "Test Artist"},
+				"torrent": {
+					"torrentId": 12345,
+					"format": "FLAC",
+					"encoding": "Lossless",
+					"size": 524288000,
+					"seeders": 20,
+					"leechers": 3,
+					"snatches": 66,
+					"isFreeleech": true,
+					"time": "2024-01-15 10:30:00"
+				}
+			}`),
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	driver := NewGazelleDriver(GazelleDriverConfig{BaseURL: server.URL, APIKey: "key"})
+
+	item, err := driver.GetTorrentDetail(context.Background(), "", "https://mooko.org/torrents.php?id=12345", "")
+	require.NoError(t, err)
+	require.NotNil(t, item)
+
+	assert.Equal(t, "12345", item.ID)
+	assert.Equal(t, "Test Artist - Test Album [FLAC Lossless]", item.Title)
+	assert.Equal(t, int64(524288000), item.SizeBytes)
+	assert.Equal(t, 20, item.Seeders)
+	assert.Equal(t, 3, item.Leechers)
+	assert.Equal(t, 66, item.Snatched)
+	assert.Equal(t, DiscountFree, item.DiscountLevel)
+	assert.Equal(t, server.URL, item.SourceSite)
+	assert.NotZero(t, item.UploadedAt)
+}
+
+func TestExtractGazelleTorrentID(t *testing.T) {
+	tests := []struct {
+		name string
+		guid string
+		link string
+		want string
+	}{
+		{name: "prefer link id query", guid: "", link: "https://mooko.org/torrents.php?id=12345", want: "12345"},
+		{name: "guid as url", guid: "https://mooko.org/torrents.php?torrentid=23456", link: "", want: "23456"},
+		{name: "guid numeric", guid: "34567", link: "", want: "34567"},
+		{name: "path numeric", guid: "", link: "https://mooko.org/torrent/45678", want: "45678"},
+		{name: "invalid", guid: "abc", link: "https://mooko.org/torrents.php?id=abc", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractGazelleTorrentID(tt.guid, tt.link))
+		})
+	}
+}
+
 func TestParseGazelleDiscount(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Summary
- 修复 Gazelle 站点详情抓取在无详情页能力时的失败路径，新增能力探测与回退策略
- 修复跨站点推送时对缺失详情字段的处理，避免因空值导致流程中断
- 补充相关单元测试，覆盖新站点详情抓取与跨站点推送回归场景

## Changes
- 在站点驱动与详情抓取流程中增加对详情抓取支持能力的判断和兼容逻辑
- 调整跨站点推送/公共流程的字段构建与错误处理，保证在部分字段不可用时仍可稳定运行
- 新增与更新 `internal/common_test.go`、`site/v2/gazelle_driver_test.go`、`site/v2/detail_fetcher_support_test.go` 以验证修复行为