### PR TITLE
build(go): bump Go version from 1.26.0 to 1.26.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 参数区分构建环境与基础镜像来源
-ARG BUILD_IMAGE=golang:1.26.0
+ARG BUILD_IMAGE=golang:1.26.1
 ARG BASE_IMAGE=alpine:3.20.3
 ARG NODE_IMAGE=node:25.2.0-alpine
 ARG BUILD_ENV=local

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ HTTPS_PROXY ?= $(https_proxy)
 NO_PROXY ?= $(no_proxy)
 
 # 默认基础镜像
-BUILD_IMAGE ?= golang:1.26.0
+BUILD_IMAGE ?= golang:1.26.1
 BASE_IMAGE ?= alpine:3.20.3
 NODE_IMAGE ?= node:25.2.0-alpine
 BUILD_ENV ?= remote

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sunerpy/pt-tools
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0


### PR DESCRIPTION
## Summary
- 升级 Go 版本从 1.26.0 到 1.26.1，修复 govulncheck 检测到的 5 个标准库安全漏洞

## Changes
- `go.mod`: go 1.26.0 → 1.26.1
- `Dockerfile`: BUILD_IMAGE golang:1.26.0 → 1.26.1
- `Makefile`: BUILD_IMAGE golang:1.26.0 → 1.26.1

## Security Fixes
- GO-2026-4603: html/template URL escaping in meta content
- GO-2026-4602: os FileInfo Root escape
- GO-2026-4601: net/url IPv6 host literal parsing
- GO-2026-4600: crypto/x509 malformed certificate panic
- GO-2026-4599: crypto/x509 email constraint enforcement