### PR TITLE
feat(rss): 增加非免费跳过种子的定时重检与手动清理功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .kiro
 .pt-tools
+.sisyphus
 .trae
 AGENTS.md
 coverage.out
@@ -8,6 +9,7 @@ examples/docs
 examples/*.ts
 jsons
 node_modules
+pt-tools
 pt-tools-helper.zip
 vendor
 

--- a/internal/common.go
+++ b/internal/common.go
@@ -29,6 +29,10 @@ import (
 	"github.com/sunerpy/pt-tools/utils"
 )
 
+// SkipRecheckHours defines how long a skipped non-free torrent should remain skipped before re-checking
+// This allows torrents marked as non-free to be re-checked after becoming free during promotions
+const SkipRecheckHours = 6
+
 // buildSkipReason 构建种子跳过原因的可读描述
 func buildSkipReason(isFree, canFinished, shouldDownloadByFilter bool) string {
 	var reasons []string
@@ -490,6 +494,17 @@ type rssTaskStats struct {
 func shouldSkipExistingTorrent(torrent *models.TorrentInfo) bool {
 	if torrent == nil {
 		return false
+	}
+
+	// If skipped and non-free, allow re-check after SkipRecheckHours
+	if torrent.IsSkipped && !torrent.IsFree {
+		if torrent.LastCheckTime != nil {
+			elapsed := time.Since(*torrent.LastCheckTime)
+			if elapsed >= SkipRecheckHours*time.Hour {
+				return false // Allow re-check
+			}
+		}
+		return true
 	}
 
 	if torrent.IsSkipped {

--- a/internal/common_test.go
+++ b/internal/common_test.go
@@ -1427,16 +1427,42 @@ func TestShouldSkipExistingTorrent(t *testing.T) {
 	falsePushed := false
 	truePushed := true
 
+	// Timestamps for re-check tests
+	oldCheckTime := time.Now().Add(-7 * time.Hour)
+	recentCheckTime := time.Now().Add(-1 * time.Hour)
+
 	tests := []struct {
 		name    string
 		torrent *models.TorrentInfo
 		want    bool
 	}{
+		// Original test cases
 		{name: "nil torrent", torrent: nil, want: false},
-		{name: "skipped torrent", torrent: &models.TorrentInfo{IsSkipped: true}, want: true},
 		{name: "pushed true", torrent: &models.TorrentInfo{IsPushed: &truePushed}, want: true},
 		{name: "pushed false should retry", torrent: &models.TorrentInfo{IsPushed: &falsePushed}, want: false},
 		{name: "pushed nil", torrent: &models.TorrentInfo{IsPushed: nilPushed}, want: false},
+
+		// Re-check tests: skipped non-free torrents
+		{
+			name:    "skipped non-free last check > 6h should allow recheck",
+			torrent: &models.TorrentInfo{IsSkipped: true, IsFree: false, LastCheckTime: &oldCheckTime},
+			want:    false, // Allow re-check
+		},
+		{
+			name:    "skipped non-free last check < 6h should skip",
+			torrent: &models.TorrentInfo{IsSkipped: true, IsFree: false, LastCheckTime: &recentCheckTime},
+			want:    true, // Skip
+		},
+		{
+			name:    "skipped non-free nil LastCheckTime should skip",
+			torrent: &models.TorrentInfo{IsSkipped: true, IsFree: false, LastCheckTime: nil},
+			want:    true, // Skip for safety
+		},
+		{
+			name:    "skipped free torrent should skip regardless",
+			torrent: &models.TorrentInfo{IsSkipped: true, IsFree: true},
+			want:    true, // Skip (not affected by re-check logic)
+		},
 	}
 
 	for _, tt := range tests {

--- a/web/api_torrent_management.go
+++ b/web/api_torrent_management.go
@@ -2,10 +2,13 @@ package web
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"gorm.io/gorm"
 
 	"github.com/sunerpy/pt-tools/global"
 	"github.com/sunerpy/pt-tools/models"
@@ -39,6 +42,19 @@ type DeletePausedResponse struct {
 	Success      int      `json:"success"`       // 成功删除数量
 	Failed       int      `json:"failed"`        // 失败数量
 	FailedIDs    []uint   `json:"failed_ids"`    // 失败的种子 ID
+	FailedErrors []string `json:"failed_errors"` // 失败原因
+}
+
+// DeleteTasksRequest 批量删除任务请求
+type DeleteTasksRequest struct {
+	IDs []uint `json:"ids"` // 任务 ID 列表
+}
+
+// DeleteTasksResponse 批量删除任务响应
+type DeleteTasksResponse struct {
+	Success      int      `json:"success"`       // 成功删除数量
+	Failed       int      `json:"failed"`        // 失败数量
+	FailedIDs    []uint   `json:"failed_ids"`    // 失败的任务 ID
 	FailedErrors []string `json:"failed_errors"` // 失败原因
 }
 
@@ -217,6 +233,76 @@ func (s *Server) apiDeletePausedTorrents(w http.ResponseWriter, r *http.Request)
 	}
 
 	writeJSON(w, DeletePausedResponse{
+		Success:      success,
+		Failed:       failed,
+		FailedIDs:    failedIDs,
+		FailedErrors: failedErrors,
+	})
+}
+
+// apiDeleteTasks 批量删除任务记录
+// POST /api/tasks/batch-delete
+func (s *Server) apiDeleteTasks(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DeleteTasksRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "请求体解析失败: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	db := global.GlobalDB.DB
+
+	// 查询要删除的任务（只删除未推送的记录）
+	var torrents []models.TorrentInfo
+	tx := db.Where("is_pushed IS NULL OR is_pushed != ?", true) // 安全检查: 只删除未被推送的记录（含 NULL）
+	if len(req.IDs) > 0 {
+		tx = tx.Where("id IN ?", req.IDs)
+	}
+	if err := tx.Find(&torrents).Error; err != nil {
+		http.Error(w, "查询失败: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if len(torrents) == 0 {
+		writeJSON(w, DeleteTasksResponse{Success: 0, Failed: 0})
+		return
+	}
+
+	var success, failed int
+	var failedIDs []uint
+	var failedErrors []string
+
+	// 使用事务删除记录
+	err := db.Transaction(func(tx *gorm.DB) error {
+		for _, t := range torrents {
+			// 安全检查: 只删除未推送的记录
+			if t.IsPushed != nil && *t.IsPushed {
+				failed++
+				failedIDs = append(failedIDs, t.ID)
+				failedErrors = append(failedErrors, t.Title+": 已推送的记录无法删除")
+				continue
+			}
+
+			// 从数据库删除记录
+			if delErr := tx.Delete(&t).Error; delErr != nil {
+				return fmt.Errorf("删除失败: %w", delErr)
+			}
+
+			success++
+			global.GetSlogger().Infof("已删除任务记录: %s (ID:%d)", t.Title, t.ID)
+		}
+		return nil
+	})
+	if err != nil {
+		http.Error(w, "事务处理失败: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, DeleteTasksResponse{
 		Success:      success,
 		Failed:       failed,
 		FailedIDs:    failedIDs,

--- a/web/api_torrent_management_test.go
+++ b/web/api_torrent_management_test.go
@@ -1,0 +1,261 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+
+	"github.com/sunerpy/pt-tools/global"
+	"github.com/sunerpy/pt-tools/models"
+)
+
+// TestApiDeleteTasks 测试批量删除任务API
+func TestApiDeleteTasks(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(*testing.T, *gorm.DB)
+		request   *DeleteTasksRequest
+		checkResp func(*testing.T, *http.Response, *DeleteTasksResponse)
+	}{
+		{
+			name: "Delete single unpushed record",
+			setup: func(t *testing.T, db *gorm.DB) {
+				// 创建一条未推送的记录
+				torrent := models.TorrentInfo{
+					SiteName:     "test-site",
+					TorrentID:    "123",
+					Title:        "Test Torrent 1",
+					IsPushed:     boolPtr(false),
+					IsFree:       true,
+					IsDownloaded: false,
+				}
+				if err := db.Create(&torrent).Error; err != nil {
+					t.Fatalf("failed to create test torrent: %v", err)
+				}
+			},
+			request: &DeleteTasksRequest{IDs: []uint{1}},
+			checkResp: func(t *testing.T, resp *http.Response, body *DeleteTasksResponse) {
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				assert.Equal(t, 1, body.Success)
+				assert.Equal(t, 0, body.Failed)
+				assert.Empty(t, body.FailedIDs)
+				assert.Empty(t, body.FailedErrors)
+
+				// 验证数据库中记录已删除
+				var count int64
+				global.GlobalDB.DB.Model(&models.TorrentInfo{}).Where("id = ?", 1).Count(&count)
+				assert.Equal(t, int64(0), count)
+			},
+		},
+		{
+			name: "Delete multiple unpushed records",
+			setup: func(t *testing.T, db *gorm.DB) {
+				// 创建3条未推送的记录
+				torrents := []models.TorrentInfo{
+					{
+						SiteName:     "test-site",
+						TorrentID:    "123",
+						Title:        "Test Torrent 1",
+						IsPushed:     boolPtr(false),
+						IsFree:       true,
+						IsDownloaded: false,
+					},
+					{
+						SiteName:     "test-site",
+						TorrentID:    "124",
+						Title:        "Test Torrent 2",
+						IsPushed:     boolPtr(false),
+						IsFree:       false,
+						IsDownloaded: false,
+					},
+					{
+						SiteName:     "test-site",
+						TorrentID:    "125",
+						Title:        "Test Torrent 3",
+						IsPushed:     boolPtr(false),
+						IsFree:       true,
+						IsDownloaded: true,
+					},
+				}
+				for _, torr := range torrents {
+					if err := db.Create(&torr).Error; err != nil {
+						panic("failed to create test torrents")
+					}
+				}
+			},
+			request: &DeleteTasksRequest{IDs: []uint{1, 2, 3}},
+			checkResp: func(t *testing.T, resp *http.Response, body *DeleteTasksResponse) {
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				assert.Equal(t, 3, body.Success)
+				assert.Equal(t, 0, body.Failed)
+				assert.Empty(t, body.FailedIDs)
+				assert.Empty(t, body.FailedErrors)
+
+				// 验证所有记录已删除
+				var count int64
+				global.GlobalDB.DB.Model(&models.TorrentInfo{}).Count(&count)
+				assert.Equal(t, int64(0), count)
+			},
+		},
+		{
+			name: "Attempt to delete pushed record",
+			setup: func(t *testing.T, db *gorm.DB) {
+				// 创建2条记录：一条已推送，一条未推送
+				unpushed := models.TorrentInfo{
+					SiteName:     "test-site",
+					TorrentID:    "126",
+					Title:        "Unpushed Torrent",
+					IsPushed:     boolPtr(false),
+					IsFree:       true,
+					IsDownloaded: false,
+				}
+				pushed := models.TorrentInfo{
+					SiteName:     "test-site",
+					TorrentID:    "127",
+					Title:        "Pushed Torrent",
+					IsPushed:     boolPtr(true),
+					IsFree:       true,
+					IsDownloaded: false,
+				}
+				if err := db.Create(&unpushed).Error; err != nil {
+					t.Fatalf("failed to create unpushed torrent: %v", err)
+				}
+				if err := db.Create(&pushed).Error; err != nil {
+					t.Fatalf("failed to create pushed torrent: %v", err)
+				}
+			},
+			request: &DeleteTasksRequest{IDs: []uint{1, 2}},
+			checkResp: func(t *testing.T, resp *http.Response, body *DeleteTasksResponse) {
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				// Query filters is_pushed != true, so pushed record (ID:2) is not returned
+				// Only unpushed record (ID:1) is deleted
+				assert.Equal(t, 1, body.Success)
+				assert.Equal(t, 0, body.Failed)
+				assert.Empty(t, body.FailedIDs)
+				assert.Empty(t, body.FailedErrors)
+
+				// Verify pushed record still exists
+				var count int64
+				global.GlobalDB.DB.Model(&models.TorrentInfo{}).Count(&count)
+				assert.Equal(t, int64(1), count) // Only pushed record remains
+			},
+		},
+		{
+			name: "Delete with empty IDs array",
+			setup: func(t *testing.T, db *gorm.DB) {
+				// Create 2 unpushed records
+				torrents := []models.TorrentInfo{
+					{
+						SiteName:     "test-site",
+						TorrentID:    "128",
+						Title:        "Test Torrent 1",
+						IsPushed:     boolPtr(false),
+						IsFree:       true,
+						IsDownloaded: false,
+					},
+					{
+						SiteName:     "test-site",
+						TorrentID:    "129",
+						Title:        "Test Torrent 2",
+						IsPushed:     boolPtr(false),
+						IsFree:       false,
+						IsDownloaded: false,
+					},
+				}
+				for _, torr := range torrents {
+					if err := db.Create(&torr).Error; err != nil {
+						t.Fatalf("failed to create test torrent: %v", err)
+					}
+				}
+			},
+			request: &DeleteTasksRequest{IDs: []uint{}},
+			checkResp: func(t *testing.T, resp *http.Response, body *DeleteTasksResponse) {
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				// Empty IDs means delete ALL unpushed records (no ID filter)
+				assert.Equal(t, 2, body.Success)
+				assert.Equal(t, 0, body.Failed)
+				assert.Empty(t, body.FailedIDs)
+				assert.Empty(t, body.FailedErrors)
+
+				// Verify all records deleted
+				var count int64
+				global.GlobalDB.DB.Model(&models.TorrentInfo{}).Count(&count)
+				assert.Equal(t, int64(0), count)
+			},
+		},
+		{
+			name: "Delete record with nil IsPushed (default value)",
+			setup: func(t *testing.T, db *gorm.DB) {
+				// 创建 IsPushed 为 nil 的记录（真实场景默认值）
+				torrent := models.TorrentInfo{
+					SiteName:     "test-site",
+					TorrentID:    "130",
+					Title:        "Nil IsPushed Torrent",
+					IsPushed:     nil, // 未设置，数据库中为 NULL
+					IsFree:       true,
+					IsDownloaded: false,
+				}
+				if err := db.Create(&torrent).Error; err != nil {
+					t.Fatalf("failed to create test torrent: %v", err)
+				}
+			},
+			request: &DeleteTasksRequest{IDs: []uint{1}},
+			checkResp: func(t *testing.T, resp *http.Response, body *DeleteTasksResponse) {
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				assert.Equal(t, 1, body.Success)
+				assert.Equal(t, 0, body.Failed)
+				assert.Empty(t, body.FailedIDs)
+				assert.Empty(t, body.FailedErrors)
+
+				// 验证数据库中记录已删除
+				var count int64
+				global.GlobalDB.DB.Model(&models.TorrentInfo{}).Where("id = ?", 1).Count(&count)
+				assert.Equal(t, int64(0), count)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 建立测试服务器和数据库
+			server, db := setupTestServer(t)
+
+			// 迁移TorrentInfo表
+			if err := db.AutoMigrate(&models.TorrentInfo{}); err != nil {
+				t.Fatalf("failed to migrate table: %v", err)
+			}
+
+			// 设置测试数据
+			tt.setup(t, db)
+
+			// 准备请求
+			reqBody, _ := json.Marshal(tt.request)
+			req := httptest.NewRequest(http.MethodPost, "/api/tasks/batch-delete", bytes.NewReader(reqBody))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			// 执行API调用
+			server.apiDeleteTasks(w, req)
+
+			// 解析响应
+			var respBody DeleteTasksResponse
+			err := json.NewDecoder(w.Body).Decode(&respBody)
+			if err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+
+			// 验证响应
+			tt.checkResp(t, w.Result(), &respBody)
+		})
+	}
+}
+
+// boolPtr 辅助函数，将bool转换为*bool
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/web/frontend/pnpm-lock.yaml
+++ b/web/frontend/pnpm-lock.yaml
@@ -330,48 +330,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.36.0':
     resolution: {integrity: sha512-SPGLJkOIHSIC6ABUQ5V8NqJpvYhMJueJv26NYqfCnwi/Mn6A61amkpJJ9Suy0Nmvs+OWESJpcebrBUbXPGZyQQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.36.0':
     resolution: {integrity: sha512-3EuoyB8x9x8ysYJjbEO/M9fkSk72zQKnXCvpZMDHXlnY36/1qMp55Nm0PrCwjGO/1pen5hdOVkz9WmP3nAp2IQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.36.0':
     resolution: {integrity: sha512-MpY3itLwpGh8dnywtrZtaZ604T1m715SydCKy0+qTxetv+IHzuA+aO/AGzrlzUNYZZmtWtmDBrChZGibvZxbRQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.36.0':
     resolution: {integrity: sha512-mmDhe4Vtx+XwQPRPn/V25+APnkApYgZ23q+6GVsNYY98pf3aU0aI3Me96pbRs/AfJ1jIiGC+/6q71FEu8dHcHw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.36.0':
     resolution: {integrity: sha512-AYXhU+DmNWLSnvVwkHM92fuYhogtVHab7UQrPNaDf1sxadugg9gWVmcgJDlIwxJdpk5CVW/TFvwUKwI432zhhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.36.0':
     resolution: {integrity: sha512-H16QhhQ3usoakMleiAAQ2mg0NsBDAdyE9agUgfC8IHHh3jZEbr0rIKwjEqwbOHK5M0EmfhJmr+aGO/MgZPsneA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.36.0':
     resolution: {integrity: sha512-EFFGkixA39BcmHiCe2ECdrq02D6FCve5ka6ObbvrheXl4V+R0U/E+/uLyVx1X65LW8TA8QQHdnbdDallRekohw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.36.0':
     resolution: {integrity: sha512-zr/t369wZWFOj1qf06Z5gGNjFymfUNDrxKMmr7FKiDRVI1sNsdKRCuRL4XVjtcptKQ+ao3FfxLN1vrynivmCYg==}
@@ -444,48 +452,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.51.0':
     resolution: {integrity: sha512-YSJua5irtG4DoMAjUapDTPhkQLHhBIY0G9JqlZS6/SZPzqDkPku/1GdWs0D6h/wyx0Iz31lNCfIaWKBQhzP0wQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.51.0':
     resolution: {integrity: sha512-7L4Wj2IEUNDETKssB9IDYt16T6WlF+X2jgC/hBq3diGHda9vJLpAgb09+D3quFq7TdkFtI7hwz/jmuQmQFPc1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.51.0':
     resolution: {integrity: sha512-cBUHqtOXy76G41lOB401qpFoKx1xq17qYkhWrLSM7eEjiHM9sOtYqpr6ZdqCnN9s6ZpzudX4EkeHOFH2E9q0vA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.51.0':
     resolution: {integrity: sha512-WKbg8CysgZcHfZX0ixQFBRSBvFZUHa3SBnEjHY2FVYt2nbNJEjzTxA3ZR5wMU0NOCNKIAFUFvAh5/XJKPRJuJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.51.0':
     resolution: {integrity: sha512-N1QRUvJTxqXNSu35YOufdjsAVmKVx5bkrggOWAhTWBc3J4qjcBwr1IfyLh/6YCg8sYRSR1GraldS9jUgJL/U4A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.51.0':
     resolution: {integrity: sha512-e0Mz0DizsCoqNIjeOg6OUKe8JKJWZ5zZlwsd05Bmr51Jo3AOL4UJnPvwKumr4BBtBrDZkCmOLhCvDGm95nJM2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.51.0':
     resolution: {integrity: sha512-wD8HGTWhYBKXvRDvoBVB1y+fEYV01samhWQSy1Zkxq2vpezvMnjaFKRuiP6tBNITLGuffbNDEXOwcAhJ3gI5Ug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.51.0':
     resolution: {integrity: sha512-5NSwQ2hDEJ0GPXqikjWtwzgAQCsS7P9aLMNenjjKa+gknN3lTCwwwERsT6lKXSirfU3jLjexA2XQvQALh5h27w==}
@@ -540,36 +556,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -630,66 +652,79 @@ packages:
     resolution: {integrity: sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.55.1':
     resolution: {integrity: sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.55.1':
     resolution: {integrity: sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.55.1':
     resolution: {integrity: sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.55.1':
     resolution: {integrity: sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.55.1':
     resolution: {integrity: sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.55.1':
     resolution: {integrity: sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.55.1':
     resolution: {integrity: sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.55.1':
     resolution: {integrity: sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.55.1':
     resolution: {integrity: sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.55.1':
     resolution: {integrity: sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.55.1':
     resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.55.1':
     resolution: {integrity: sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.55.1':
     resolution: {integrity: sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==}

--- a/web/frontend/src/api/index.ts
+++ b/web/frontend/src/api/index.ts
@@ -114,6 +114,7 @@ export interface SiteConfig {
 }
 
 export interface TaskItem {
+  id: number;
   siteName: string;
   title: string;
   category: string;
@@ -147,6 +148,13 @@ export interface LogsResponse {
   truncated: boolean;
 }
 
+export interface DeleteTasksResponse {
+  success: number;
+  failed: number;
+  failed_ids: number[];
+  failed_errors: string[];
+}
+
 // API 方法
 export const globalApi = {
   get: () => api.get<GlobalSettings>("/api/global"),
@@ -169,6 +177,7 @@ export const sitesApi = {
 
 export const tasksApi = {
   list: (params: URLSearchParams) => api.get<TaskListResponse>(`/api/tasks?${params.toString()}`),
+  batchDelete: (ids: number[]) => api.post<DeleteTasksResponse>("/api/tasks/batch-delete", { ids }),
 };
 
 export const logsApi = {

--- a/web/frontend/src/views/TaskList.vue
+++ b/web/frontend/src/views/TaskList.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { type TaskItem, type TaskListResponse, tasksApi } from "@/api";
-import { ElMessage } from "element-plus";
+import { Delete, Refresh, Search } from "@element-plus/icons-vue";
+import { ElMessage, ElMessageBox } from "element-plus";
 import { computed, onMounted, ref } from "vue";
 
 const loading = ref(false);
@@ -16,6 +17,7 @@ const filters = ref({
   pushed: true,
   expired: false,
 });
+const selectedIds = ref<number[]>([]);
 
 // 站点列表（从任务中提取）
 const siteOptions = computed(() => {
@@ -72,6 +74,35 @@ function handleSizeChange(newSize: number) {
   pageSize.value = newSize;
   page.value = 1;
   loadTasks();
+}
+
+function handleSelectionChange(selection: TaskItem[]) {
+  selectedIds.value = selection.map((t) => t.id);
+}
+
+async function handleBatchDelete() {
+  if (selectedIds.value.length === 0) return;
+
+  try {
+    await ElMessageBox.confirm(`确认删除 ${selectedIds.value.length} 条记录吗？`, "警告", {
+      type: "warning",
+      confirmButtonText: "确定",
+      cancelButtonText: "取消",
+    });
+
+    const res = await tasksApi.batchDelete(selectedIds.value);
+    if (res.failed > 0) {
+      ElMessage.warning(`删除完成：成功 ${res.success} 条，失败 ${res.failed} 条`);
+    } else {
+      ElMessage.success(`成功删除 ${res.success} 条记录`);
+    }
+    selectedIds.value = [];
+    loadTasks();
+  } catch (e: unknown) {
+    if ((e as string) !== "cancel") {
+      ElMessage.error((e as Error).message || "批量删除失败");
+    }
+  }
 }
 
 function formatTime(timeStr: string): string {
@@ -227,19 +258,36 @@ function getDiscountTag(task: TaskItem): {
           </el-tag>
         </div>
         <div class="table-card-header-actions">
+          <el-button
+            type="danger"
+            size="small"
+            plain
+            class="batch-delete-btn"
+            :disabled="selectedIds.length === 0"
+            @click="handleBatchDelete">
+            <el-icon class="mr-1"><Delete /></el-icon>
+            批量删除
+          </el-button>
           <el-button type="primary" size="small" plain class="refresh-btn" @click="loadTasks">
             <el-icon class="mr-1"><Refresh /></el-icon>
             刷新
           </el-button>
         </div>
+        <!-- Close table-card-header-actions -->
       </div>
+      <!-- Close table-card-header -->
 
       <div class="table-wrapper">
         <el-table
           :data="tasks"
           style="width: 100%"
           class="pt-table"
-          :header-cell-style="{ background: 'var(--pt-bg-secondary)', fontWeight: 600 }">
+          :header-cell-style="{ background: 'var(--pt-bg-secondary)', fontWeight: 600 }"
+          @selection-change="handleSelectionChange">
+          <el-table-column
+            type="selection"
+            width="55"
+            :selectable="(row: Record<string, any>) => !row.isPushed" />
           <el-table-column label="站点" prop="siteName" width="120" align="center">
             <template #default="{ row }">
               <el-tag size="small" type="primary" effect="light" class="site-tag">{{

--- a/web/server.go
+++ b/web/server.go
@@ -74,6 +74,7 @@ func (s *Server) Serve(addr string) error {
 	mux.HandleFunc("/api/sites/", s.auth(s.apiSiteDetail))
 	mux.HandleFunc("/api/password", s.auth(s.apiPassword))
 	mux.HandleFunc("/api/tasks", s.auth(s.apiTasks))
+	mux.HandleFunc("/api/tasks/batch-delete", s.auth(s.apiDeleteTasks))
 	mux.HandleFunc("/api/logs", s.auth(s.apiLogs))
 	mux.HandleFunc("/api/control/stop", s.auth(s.apiStopAll))
 	mux.HandleFunc("/api/control/start", s.auth(s.apiStartAll))


### PR DESCRIPTION
## Summary
- 跳过的非免费种子在 6 小时后允许重新检测免费状态，仅对当前 RSS 中仍存在的种子生效
- 新增 `POST /api/tasks/batch-delete` 接口，用于批量删除未推送的种子记录
- 任务列表页面增加多选框和批量删除按钮，已推送记录不可选中

## Changes
- `internal/common.go`: 增加定时重检逻辑，6 小时后允许已跳过的非免费种子重新进入检测流程
- `internal/common_test.go`: 补充重检逻辑的单元测试
- `web/api_torrent_management.go`: 新增批量删除 API 接口实现
- `web/api_torrent_management_test.go`: 批量删除接口的完整单元测试（261 行）
- `web/server.go`: 注册新路由
- `web/frontend/src/api/index.ts`: 前端新增批量删除 API 调用
- `web/frontend/src/views/TaskList.vue`: 任务列表页面增加多选和批量删除交互
- `.gitignore`: 更新忽略规则

Closes #161