### PR TITLE
fix(docker): 同步 Dockerfile Go 版本至 1.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 参数区分构建环境与基础镜像来源
-ARG BUILD_IMAGE=golang:1.26.1
+ARG BUILD_IMAGE=golang:1.26.2
 ARG BASE_IMAGE=alpine:3.20.3
 ARG NODE_IMAGE=node:25.2.0-alpine
 ARG BUILD_ENV=local


### PR DESCRIPTION
## Summary
- Dockerfile BUILD_IMAGE 从 golang:1.26.1 升级至 golang:1.26.2
- 与 go.mod 版本保持一致，修复 v0.22.1 release Docker 构建失败