### PR TITLE
fix(build): 同步 Makefile Go 镜像版本至 1.26.2 修复 release 构建失败

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ HTTPS_PROXY ?= $(https_proxy)
 NO_PROXY ?= $(no_proxy)
 
 # 默认基础镜像
-BUILD_IMAGE ?= golang:1.26.1
+BUILD_IMAGE ?= golang:1.26.2
 BASE_IMAGE ?= alpine:3.20.3
 NODE_IMAGE ?= node:25.2.0-alpine
 BUILD_ENV ?= remote


### PR DESCRIPTION
## Summary
- Makefile BUILD_IMAGE 从 golang:1.26.1 升级至 golang:1.26.2
- 此为 v0.22.1/v0.22.2 Docker 构建失败的根因
- Makefile 通过 `--build-arg BUILD_IMAGE` 覆盖了 Dockerfile 的默认值