### PR TITLE
fix(ci): 修复 stale issue 自动关闭缺少7天宽限期和用户回复检测

### DIFF
--- a/.github/workflows/close-stale-site-requests.yml
+++ b/.github/workflows/close-stale-site-requests.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           script: |
             const STALE_DAYS = 14;
+            const CLOSE_GRACE_DAYS = 7;
             const now = new Date();
 
             // Find open issues that are site requests
@@ -82,7 +83,33 @@ jobs:
               );
 
               if (hasCloseWarning) {
-                // Already warned, close the issue
+                // Find the close warning comment
+                const closeWarningComment = comments.data.find(c =>
+                  c.body.includes('<!-- stale-close -->')
+                );
+                if (!closeWarningComment) continue;
+
+                const warningDate = new Date(closeWarningComment.created_at);
+                const daysSinceWarning = (now - warningDate) / (1000 * 60 * 60 * 24);
+
+                // Check if any non-bot user replied after the warning
+                const hasUserReplyAfterWarning = comments.data.some(c => {
+                  if (c.user.type === 'Bot') return false;
+                  return new Date(c.created_at) > warningDate;
+                });
+
+                if (hasUserReplyAfterWarning) {
+                  console.log(`Skipped #${issue.number}: user replied after close warning`);
+                  continue;
+                }
+
+                // Wait for the full grace period
+                if (daysSinceWarning < CLOSE_GRACE_DAYS) {
+                  console.log(`Skipped #${issue.number}: only ${Math.floor(daysSinceWarning)} days since warning (need ${CLOSE_GRACE_DAYS})`);
+                  continue;
+                }
+
+                // Grace period expired with no user reply, close the issue
                 await github.rest.issues.update({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -98,7 +125,7 @@ jobs:
                   labels: ['stale-closed'],
                 });
 
-                console.log(`Closed #${issue.number}: ${issue.title}`);
+                console.log(`Closed #${issue.number}: ${issue.title} (${Math.floor(daysSinceWarning)} days since warning)`);
                 continue;
               }
 


### PR DESCRIPTION
## Summary
- 修复 `close-stale-site-requests.yml` 中 stale issue 关闭逻辑的两个缺陷

## 问题
1. **缺少 7 天宽限期**：发出 `<!-- stale-close -->` 警告后，下一次 cron（~1天）就直接关闭 issue，实际应等待 7 天
2. **忽略用户回复**：警告发出后用户回复不影响关闭判断，bot 自己的评论也会被当作活动

## 修复
- 新增 `CLOSE_GRACE_DAYS = 7` 常量，关闭前检查警告是否已发出超过 7 天
- 检查 `<!-- stale-close -->` 警告之后是否有非 Bot 用户回复，如有则跳过关闭