### PR TITLE
feat(scheduler): 新增做种竞争度监控功能

### DIFF
--- a/core/config_store.go
+++ b/core/config_store.go
@@ -201,6 +201,10 @@ func (s *ConfigStore) SaveGlobalSettings(gs models.SettingsGlobal) error {
 		cur.CleanupMinRetainH = gs.CleanupMinRetainH
 		cur.CleanupProtectTags = gs.CleanupProtectTags
 		cur.AutoDeleteOnFreeEnd = gs.AutoDeleteOnFreeEnd
+		cur.PeerRatioEnabled = gs.PeerRatioEnabled
+		cur.PeerRatioMaxSL = gs.PeerRatioMaxSL
+		cur.PeerRatioIntervalMin = gs.PeerRatioIntervalMin
+		cur.PeerRatioRemoveData = gs.PeerRatioRemoveData
 		if err := db.Save(&cur).Error; err != nil {
 			return err
 		}

--- a/docs/sites.md
+++ b/docs/sites.md
@@ -1,16 +1,44 @@
 ## 支持站点
 
-| 站点             | 站点类型                | 认证方式 | 支持功能                      | 适配情况 | 原因说明                                     |
-| ---------------- | ----------------------- | -------- | ----------------------------- | -------- | -------------------------------------------- |
-| **HDSky**        | NexusPHP                | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 完全适配                                     |
-| **SpringSunday** | NexusPHP                | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 完全适配                                     |
-| **M-Team**       | mTorrent                | API Key  | RSS、搜索、用户信息、等级要求 | ✅       | 完全适配                                     |
-| **HDDolby**      | HDDolby (NexusPHP 衍生) | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，两步验证有问题请提交 issue           |
-| **NovaHD**       | NexusPHP                | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配但本人无账号未验证，有问题请提交 issue |
-| **Rousi Pro**    | Rousi                   | Passkey  | RSS、搜索、用户信息           | ✅       | 已适配，有问题请提交 issue                   |
-| **AGSVPT**       | NexusPHP                | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                   |
-| **XingYunGe**    | NexusPHP                | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                   |
-| **MooKo**        | Gazelle                 | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配，有问题请提交 issue                   |
+当前已适配 **28** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
+
+### NexusPHP 系列（24）
+
+| 站点             | 认证方式 | 支持功能                      | 适配情况 | 备注                       |
+| ---------------- | -------- | ----------------------------- | -------- | -------------------------- |
+| **HDSky**        | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 完全适配                   |
+| **SpringSunday** | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 完全适配                   |
+| **NovaHD**       | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **AGSVPT**       | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **XingYunGe**    | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **HDHome**       | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **HDTime**       | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **HDFans**       | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **LemonHD**      | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **BTSCHOOL**     | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **BYRPT**        | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **Audiences**    | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **CarPT**        | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **52PT**         | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **HXPT**         | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **MyPTCC**       | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **PTLover**      | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **PTSKIT**       | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **RainGFH**      | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **SoulVoice**    | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **TMPT**         | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **UBits**        | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **1PTBar**       | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+| **lajidui**      | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue |
+
+### 其他架构（4）
+
+| 站点          | 站点类型                | 认证方式 | 支持功能                      | 适配情况 | 备注                               |
+| ------------- | ----------------------- | -------- | ----------------------------- | -------- | ---------------------------------- |
+| **M-Team**    | mTorrent                | API Key  | RSS、搜索、用户信息、等级要求 | ✅       | 完全适配                           |
+| **HDDolby**   | HDDolby (NexusPHP 衍生) | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，两步验证有问题请提交 issue |
+| **Rousi Pro** | Rousi                   | Passkey  | RSS、搜索、用户信息           | ✅       | 已适配，有问题请提交 issue         |
+| **MooKo**     | Gazelle                 | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配，有问题请提交 issue         |
 
 > **扩展站点支持**：如需支持其他站点，欢迎提交 [Issue](https://github.com/sunerpy/pt-tools/issues) 或 [Pull Request](https://github.com/sunerpy/pt-tools/pulls)。
 >

--- a/models/config_models.go
+++ b/models/config_models.go
@@ -65,6 +65,12 @@ type SettingsGlobal struct {
 	// 免费结束自动删除
 	AutoDeleteOnFreeEnd bool `json:"auto_delete_on_free_end" gorm:"default:false"` // 免费期结束时自动删除未完成的种子及数据
 
+	// 做种竞争度监控（Peer Ratio Monitor）
+	PeerRatioEnabled     bool    `json:"peer_ratio_enabled" gorm:"default:false"`     // 是否启用做种竞争度监控
+	PeerRatioMaxSL       float64 `json:"peer_ratio_max_sl" gorm:"default:30.0"`       // Seeder/Leecher 比值上限
+	PeerRatioIntervalMin int     `json:"peer_ratio_interval_min" gorm:"default:10"`   // 检查间隔（分钟）
+	PeerRatioRemoveData  bool    `json:"peer_ratio_remove_data" gorm:"default:false"` // 超标时删除种子及数据（否则仅暂停）
+
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
@@ -95,6 +101,27 @@ func (s *SettingsGlobal) GetEffectiveConcurrency() int32 {
 		return MaxConcurrency
 	}
 	return s.DefaultConcurrency
+}
+
+const (
+	DefaultPeerRatioMaxSL       = 30.0
+	MinPeerRatioMaxSL           = 1.0
+	DefaultPeerRatioIntervalMin = 10
+	MinPeerRatioIntervalMin     = 5
+)
+
+func (s *SettingsGlobal) GetEffectivePeerRatioMaxSL() float64 {
+	if s.PeerRatioMaxSL < MinPeerRatioMaxSL {
+		return DefaultPeerRatioMaxSL
+	}
+	return s.PeerRatioMaxSL
+}
+
+func (s *SettingsGlobal) GetEffectivePeerRatioIntervalMin() int {
+	if s.PeerRatioIntervalMin < MinPeerRatioIntervalMin {
+		return DefaultPeerRatioIntervalMin
+	}
+	return s.PeerRatioIntervalMin
 }
 
 // qBittorrent 设置

--- a/models/init.go
+++ b/models/init.go
@@ -57,6 +57,8 @@ type TorrentInfo struct {
 	HasHR            bool       `gorm:"default:false" json:"hasHR"`
 	HRSeedTimeH      int        `gorm:"default:0" json:"hrSeedTimeH"` // 下载器中的任务 ID（用于暂停/删除操作）
 	CheckCount       int        `gorm:"default:0" json:"checkCount"`  // 进度检查次数
+	Seeders          int        `gorm:"default:0" json:"seeders"`
+	Leechers         int        `gorm:"default:0" json:"leechers"`
 }
 
 // TorrentInfoArchive 种子信息归档表（存储超过保留期的记录）

--- a/scheduler/cleanup_monitor.go
+++ b/scheduler/cleanup_monitor.go
@@ -177,6 +177,9 @@ func (c *CleanupMonitor) processDownloader(cfg *models.SettingsGlobal, dl downlo
 
 	var toDelete []downloader.Torrent
 	for _, t := range candidates {
+		if c.isPausedForPeerRatio(t.InfoHash) {
+			continue
+		}
 		if c.shouldDelete(cfg, t) {
 			toDelete = append(toDelete, t)
 		}
@@ -423,6 +426,15 @@ func (c *CleanupMonitor) shouldDelete(cfg *models.SettingsGlobal, t downloader.T
 	}
 
 	return seedTimeMatch || ratioMatch || inactiveMatch || slowSeedMatch
+}
+
+func (c *CleanupMonitor) isPausedForPeerRatio(infoHash string) bool {
+	var count int64
+	c.db.Model(&models.TorrentInfo{}).
+		Where("torrent_hash = ? AND is_paused_by_system = ? AND pause_reason = ?",
+			strings.ToLower(infoHash), true, PauseReasonPeerRatio).
+		Count(&count)
+	return count > 0
 }
 
 func (c *CleanupMonitor) isFreeExpiredIncomplete(t downloader.Torrent) bool {

--- a/scheduler/manager.go
+++ b/scheduler/manager.go
@@ -27,6 +27,7 @@ type Manager struct {
 	downloaderManager *downloader.DownloaderManager
 	freeEndMonitor    *FreeEndMonitor
 	cleanupMonitor    *CleanupMonitor
+	peerRatioMonitor  *PeerRatioMonitor
 	eventCancel       func()
 	stopped           bool
 }
@@ -94,6 +95,7 @@ func (m *Manager) InitFreeEndMonitor() {
 	m.initDownloaderManager()
 	m.initFreeEndMonitor()
 	m.initCleanupMonitor()
+	m.initPeerRatioMonitor()
 }
 
 // GetDownloaderManager 获取下载器管理器
@@ -169,8 +171,8 @@ func (m *Manager) Reload(cfg *models.Config) {
 
 	m.initFreeEndMonitor()
 	m.initCleanupMonitor()
+	m.initPeerRatioMonitor()
 
-	// 检查是否有可用的默认下载器
 	defaultDl, err := m.downloaderManager.GetDefaultDownloader()
 	if err != nil {
 		global.GetSlogger().Warnf("未配置默认下载器，任务不启动: %v", err)
@@ -334,6 +336,21 @@ func (m *Manager) initCleanupMonitor() {
 	}
 }
 
+func (m *Manager) initPeerRatioMonitor() {
+	if global.GlobalDB == nil {
+		return
+	}
+
+	if m.peerRatioMonitor != nil {
+		m.peerRatioMonitor.Stop()
+	}
+
+	m.peerRatioMonitor = NewPeerRatioMonitor(global.GlobalDB.DB, m.downloaderManager)
+	if err := m.peerRatioMonitor.Start(); err != nil {
+		global.GetSlogger().Errorf("启动竞争度监控器失败: %v", err)
+	}
+}
+
 // createQBitFactory 创建 qBittorrent 工厂
 func createQBitFactory() downloader.DownloaderFactory {
 	return func(config downloader.DownloaderConfig, name string) (downloader.Downloader, error) {
@@ -394,6 +411,10 @@ func (m *Manager) StopAll() {
 	if m.cleanupMonitor != nil {
 		m.cleanupMonitor.Stop()
 		m.cleanupMonitor = nil
+	}
+	if m.peerRatioMonitor != nil {
+		m.peerRatioMonitor.Stop()
+		m.peerRatioMonitor = nil
 	}
 	if m.eventCancel != nil {
 		m.eventCancel()

--- a/scheduler/peer_ratio_monitor.go
+++ b/scheduler/peer_ratio_monitor.go
@@ -1,0 +1,301 @@
+package scheduler
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"github.com/sunerpy/pt-tools/global"
+	"github.com/sunerpy/pt-tools/internal/events"
+	"github.com/sunerpy/pt-tools/models"
+	"github.com/sunerpy/pt-tools/thirdpart/downloader"
+)
+
+const (
+	peerRatioDefaultInterval = 10 * time.Minute
+	peerRatioMinInterval     = 5 * time.Minute
+	PauseReasonPeerRatio     = "做种竞争度过高"
+)
+
+type PeerRatioMonitor struct {
+	mu            sync.Mutex
+	ctx           context.Context
+	cancel        context.CancelFunc
+	db            *gorm.DB
+	downloaderMgr *downloader.DownloaderManager
+	logger        *zap.SugaredLogger
+	running       bool
+}
+
+func NewPeerRatioMonitor(db *gorm.DB, downloaderMgr *downloader.DownloaderManager) *PeerRatioMonitor {
+	ctx, cancel := context.WithCancel(context.Background())
+	logger := global.GetSlogger()
+	return &PeerRatioMonitor{
+		ctx:           ctx,
+		cancel:        cancel,
+		db:            db,
+		downloaderMgr: downloaderMgr,
+		logger:        logger,
+	}
+}
+
+func (p *PeerRatioMonitor) Start() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.running {
+		return nil
+	}
+	p.running = true
+
+	go p.runLoop()
+	p.logger.Info("[竞争度监控] 服务已启动")
+	return nil
+}
+
+func (p *PeerRatioMonitor) Stop() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.running {
+		return
+	}
+	p.cancel()
+	p.running = false
+	p.logger.Info("[竞争度监控] 服务已停止")
+}
+
+func (p *PeerRatioMonitor) runLoop() {
+	time.Sleep(15 * time.Second)
+
+	_, eventCh, cancelSub := events.Subscribe(8)
+	defer cancelSub()
+
+	for {
+		cfg := p.loadConfig()
+		if cfg == nil || !cfg.PeerRatioEnabled {
+			p.logger.Debug("[竞争度监控] 功能未启用，等待下次检查")
+			select {
+			case <-p.ctx.Done():
+				return
+			case <-time.After(5 * time.Minute):
+				continue
+			case <-eventCh:
+				continue
+			}
+		}
+
+		maxSL := cfg.GetEffectivePeerRatioMaxSL()
+		p.logger.Infof("[竞争度监控] 开始检查 (间隔=%d分钟, 阈值=%.1f)",
+			cfg.GetEffectivePeerRatioIntervalMin(), maxSL)
+		p.runOnce(cfg, maxSL)
+
+		interval := time.Duration(cfg.GetEffectivePeerRatioIntervalMin()) * time.Minute
+		if interval < peerRatioMinInterval {
+			interval = peerRatioDefaultInterval
+		}
+
+		select {
+		case <-p.ctx.Done():
+			return
+		case <-time.After(interval):
+		case <-eventCh:
+		}
+	}
+}
+
+func (p *PeerRatioMonitor) loadConfig() *models.SettingsGlobal {
+	var cfg models.SettingsGlobal
+	if err := p.db.First(&cfg).Error; err != nil {
+		return nil
+	}
+	return &cfg
+}
+
+func (p *PeerRatioMonitor) runOnce(cfg *models.SettingsGlobal, maxSL float64) {
+	dlNames := p.downloaderMgr.ListDownloaders()
+	if len(dlNames) == 0 {
+		return
+	}
+
+	for _, name := range dlNames {
+		dl, err := p.downloaderMgr.GetDownloader(name)
+		if err != nil || !dl.IsHealthy() {
+			continue
+		}
+		p.processDownloader(dl, name, maxSL, cfg.PeerRatioRemoveData)
+	}
+}
+
+func (p *PeerRatioMonitor) processDownloader(dl downloader.Downloader, dlName string, maxSL float64, removeData bool) {
+	allTorrents, err := dl.GetAllTorrents()
+	if err != nil {
+		p.logger.Errorf("[竞争度监控] %s: 获取种子列表失败: %v", dlName, err)
+		return
+	}
+
+	managed := p.filterManagedSeedingTorrents(allTorrents, dlName)
+	if len(managed) == 0 {
+		p.logger.Debugf("[竞争度监控] %s: 无做种中的管理种子", dlName)
+		return
+	}
+
+	var acted int
+	for _, t := range managed {
+		if p.ctx.Err() != nil {
+			return
+		}
+
+		seeds, leeches, err := p.getTrackerPeerCounts(dl, t)
+		if err != nil {
+			p.logger.Debugf("[竞争度监控] %s: 获取 tracker 信息失败: %s: %v", dlName, t.Name, err)
+			continue
+		}
+
+		p.updateDBPeerCounts(t.InfoHash, seeds, leeches)
+
+		if seeds == 0 {
+			continue
+		}
+
+		var ratio float64
+		if leeches == 0 {
+			ratio = float64(seeds)
+		} else {
+			ratio = float64(seeds) / float64(leeches)
+		}
+
+		if ratio <= maxSL {
+			continue
+		}
+
+		if p.isAlreadyPausedForPeerRatio(t.InfoHash) {
+			continue
+		}
+
+		if removeData {
+			p.logger.Infof("[竞争度监控] 删除: %s (S/L=%d/%d=%.1f > %.1f)", t.Name, seeds, leeches, ratio, maxSL)
+			if err := dl.RemoveTorrent(t.ID, true); err != nil {
+				p.logger.Errorf("[竞争度监控] 删除失败: %s: %v", t.Name, err)
+				continue
+			}
+			p.markDeletedForPeerRatio(t.InfoHash, seeds, leeches)
+		} else {
+			p.logger.Infof("[竞争度监控] 暂停: %s (S/L=%d/%d=%.1f > %.1f)", t.Name, seeds, leeches, ratio, maxSL)
+			if err := dl.PauseTorrent(t.ID); err != nil {
+				p.logger.Errorf("[竞争度监控] 暂停失败: %s: %v", t.Name, err)
+				continue
+			}
+			p.markPausedForPeerRatio(t.InfoHash, seeds, leeches)
+		}
+		acted++
+	}
+
+	action := "暂停"
+	if removeData {
+		action = "删除"
+	}
+	p.logger.Infof("[竞争度监控] %s: 检查完成 (管理做种=%d, %s=%d)", dlName, len(managed), action, acted)
+}
+
+func (p *PeerRatioMonitor) filterManagedSeedingTorrents(torrents []downloader.Torrent, dlName string) []downloader.Torrent {
+	managedHashes := p.getManagedCompletedHashes(dlName)
+	if len(managedHashes) == 0 {
+		return nil
+	}
+
+	var result []downloader.Torrent
+	for _, t := range torrents {
+		if t.State != downloader.TorrentSeeding {
+			continue
+		}
+		if _, ok := managedHashes[strings.ToLower(t.InfoHash)]; ok {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+func (p *PeerRatioMonitor) getManagedCompletedHashes(dlName string) map[string]struct{} {
+	hashes := make(map[string]struct{})
+	var dbHashes []string
+	p.db.Model(&models.TorrentInfo{}).
+		Where("torrent_hash IS NOT NULL AND torrent_hash != '' AND is_pushed IS NOT NULL AND is_completed = ? AND downloader_name = ?", true, dlName).
+		Pluck("torrent_hash", &dbHashes)
+
+	for _, h := range dbHashes {
+		hashes[strings.ToLower(h)] = struct{}{}
+	}
+	return hashes
+}
+
+func (p *PeerRatioMonitor) getTrackerPeerCounts(dl downloader.Downloader, t downloader.Torrent) (seeds, leeches int, err error) {
+	trackers, err := dl.GetTorrentTrackers(t.ID)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	for _, tr := range trackers {
+		if tr.Status < 2 {
+			continue
+		}
+		if tr.Seeds > seeds {
+			seeds = tr.Seeds
+		}
+		if tr.Leeches > leeches {
+			leeches = tr.Leeches
+		}
+	}
+	return seeds, leeches, nil
+}
+
+func (p *PeerRatioMonitor) isAlreadyPausedForPeerRatio(infoHash string) bool {
+	var count int64
+	p.db.Model(&models.TorrentInfo{}).
+		Where("torrent_hash = ? AND is_paused_by_system = ? AND pause_reason = ?",
+			strings.ToLower(infoHash), true, PauseReasonPeerRatio).
+		Count(&count)
+	return count > 0
+}
+
+func (p *PeerRatioMonitor) updateDBPeerCounts(infoHash string, seeds, leeches int) {
+	now := time.Now()
+	p.db.Model(&models.TorrentInfo{}).
+		Where("torrent_hash = ?", strings.ToLower(infoHash)).
+		Updates(map[string]any{
+			"seeders":         seeds,
+			"leechers":        leeches,
+			"last_check_time": now,
+		})
+}
+
+func (p *PeerRatioMonitor) markPausedForPeerRatio(infoHash string, seeds, leeches int) {
+	now := time.Now()
+	p.db.Model(&models.TorrentInfo{}).
+		Where("torrent_hash = ?", strings.ToLower(infoHash)).
+		Updates(map[string]any{
+			"is_paused_by_system": true,
+			"paused_at":           now,
+			"pause_reason":        PauseReasonPeerRatio,
+			"seeders":             seeds,
+			"leechers":            leeches,
+			"last_check_time":     now,
+		})
+}
+
+func (p *PeerRatioMonitor) markDeletedForPeerRatio(infoHash string, seeds, leeches int) {
+	now := time.Now()
+	p.db.Model(&models.TorrentInfo{}).
+		Where("torrent_hash = ?", strings.ToLower(infoHash)).
+		Updates(map[string]any{
+			"is_expired":      true,
+			"pause_reason":    PauseReasonPeerRatio,
+			"seeders":         seeds,
+			"leechers":        leeches,
+			"last_check_time": now,
+		})
+}

--- a/web/frontend/src/views/AutoCleanup.vue
+++ b/web/frontend/src/views/AutoCleanup.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { globalApi, type GlobalSettings } from "@/api";
-import { Delete, Setting } from "@element-plus/icons-vue";
+import { DataAnalysis, Delete, Setting } from "@element-plus/icons-vue";
 import { ElMessage } from "element-plus";
 import { computed, onMounted, ref, watch } from "vue";
 
@@ -137,6 +137,10 @@ const form = ref({
   cleanup_protect_hr: true,
   cleanup_min_retain_h: 24,
   cleanup_protect_tags: [] as string[],
+  peer_ratio_enabled: false,
+  peer_ratio_max_sl: 30,
+  peer_ratio_interval_min: 10,
+  peer_ratio_remove_data: false,
 });
 
 const presetFields = computed(() => [
@@ -471,6 +475,60 @@ async function save() {
             </el-col>
           </el-row>
         </div>
+      </el-form>
+
+      <div class="form-actions">
+        <el-button type="primary" :loading="saving" @click="save" size="large">保存设置</el-button>
+      </div>
+    </el-card>
+
+    <el-card class="settings-card" shadow="never" style="margin-top: 20px">
+      <template #header>
+        <div class="card-header">
+          <div class="card-title-group">
+            <el-icon :size="20" color="var(--el-color-warning)"><DataAnalysis /></el-icon>
+            <div>
+              <h3 class="card-title">做种竞争度监控</h3>
+              <p class="card-subtitle">
+                监控做种中种子的 Seeder/Leecher 比值，竞争度过高时自动暂停
+              </p>
+            </div>
+          </div>
+          <el-switch v-model="form.peer_ratio_enabled" active-text="启用" inactive-text="关闭" />
+        </div>
+      </template>
+
+      <el-form label-position="top" :disabled="!form.peer_ratio_enabled">
+        <el-row :gutter="40">
+          <el-col :md="12" :sm="24">
+            <el-form-item label="S/L 比值上限">
+              <el-input-number
+                v-model="form.peer_ratio_max_sl"
+                :min="1"
+                :step="5"
+                :precision="1"
+                class="w-full" />
+              <div class="form-tip">Seeder/Leecher 比值超过此值时触发操作（最小值 1）</div>
+            </el-form-item>
+          </el-col>
+          <el-col :md="12" :sm="24">
+            <el-form-item label="检查间隔（分钟）">
+              <el-input-number
+                v-model="form.peer_ratio_interval_min"
+                :min="5"
+                :step="5"
+                class="w-full" />
+              <div class="form-tip">通过 Tracker 获取 Swarm 级别的做种/下载用户数进行判断</div>
+            </el-form-item>
+          </el-col>
+        </el-row>
+
+        <el-form-item>
+          <el-checkbox v-model="form.peer_ratio_remove_data" label="直接删除种子及数据" border />
+          <div class="form-tip">
+            开启后超标种子将被直接删除（含文件），关闭则仅暂停（可在已暂停种子页面手动恢复）
+          </div>
+        </el-form-item>
       </el-form>
 
       <div class="form-actions">

--- a/web/server.go
+++ b/web/server.go
@@ -464,6 +464,10 @@ func (s *Server) apiGlobal(w http.ResponseWriter, r *http.Request) {
 			CleanupMinRetainH      int     `json:"cleanup_min_retain_h"`
 			CleanupProtectTags     string  `json:"cleanup_protect_tags"`
 			AutoDeleteOnFreeEnd    bool    `json:"auto_delete_on_free_end"`
+			PeerRatioEnabled       bool    `json:"peer_ratio_enabled"`
+			PeerRatioMaxSL         float64 `json:"peer_ratio_max_sl"`
+			PeerRatioIntervalMin   int     `json:"peer_ratio_interval_min"`
+			PeerRatioRemoveData    bool    `json:"peer_ratio_remove_data"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -506,6 +510,10 @@ func (s *Server) apiGlobal(w http.ResponseWriter, r *http.Request) {
 			CleanupMinRetainH:      req.CleanupMinRetainH,
 			CleanupProtectTags:     req.CleanupProtectTags,
 			AutoDeleteOnFreeEnd:    req.AutoDeleteOnFreeEnd,
+			PeerRatioEnabled:       req.PeerRatioEnabled,
+			PeerRatioMaxSL:         req.PeerRatioMaxSL,
+			PeerRatioIntervalMin:   req.PeerRatioIntervalMin,
+			PeerRatioRemoveData:    req.PeerRatioRemoveData,
 		}
 		if err := s.store.SaveGlobalSettings(gs); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)


### PR DESCRIPTION
## Summary
- 新增做种竞争度（Seeder/Leecher 比值）监控，自动处理做种竞争过高的种子
- 扩展 docs/sites.md 至完整 28 个适配站点列表

## Features

### 做种竞争度监控（Peer Ratio Monitor）
在 qBittorrent / Transmission 中做种的种子，当 Swarm 级别的 Seeder/Leecher 比值超过阈值时，自动暂停或删除，避免无效做种占用资源。

- **数据来源**：通过下载器的 Tracker API 获取 Swarm 级别的做种用户数（seeds）和下载用户数（leeches），支持多 tracker 取最大值
- **触发条件**：`seeds / max(leeches, 1) > 阈值（默认 30.0）`
- **处置方式**：可配置为仅暂停（保留数据，后续可手动恢复）或直接删除（含数据）
- **Scope 隔离**：仅处理 `TorrentInfo` 表中 `is_completed=true` 且 `downloader_name` 匹配的管理种子，从不触及外部种子
- **配置项**（在"自动删种"页面）：
  - `peer_ratio_enabled` – 启用开关
  - `peer_ratio_max_sl` – S/L 比值上限（最小值 1.0，默认 30.0）
  - `peer_ratio_interval_min` – 检查间隔（最小值 5 分钟，默认 10 分钟）
  - `peer_ratio_remove_data` – 超标时删除种子及数据（默认 false 仅暂停）

### 协同保护
- 已被 Peer Ratio 监控暂停的种子会被 `cleanup_monitor` 主动跳过，避免清理规则二次处理
- `TorrentInfo` 新增 `seeders` / `leechers` 字段持久化最新 Tracker 数据，可用于后续统计与展示

## Documentation
- `docs/sites.md` 更新为当前代码库实际支持的 **28** 个 PT 站点完整列表
  - NexusPHP 系列 24 个（HDSky / SpringSunday / NovaHD / AGSVPT / XingYunGe / HDHome / HDTime / HDFans / LemonHD / BTSCHOOL / BYRPT / Audiences / CarPT / 52PT / HXPT / MyPTCC / PTLover / PTSKIT / RainGFH / SoulVoice / TMPT / UBits / 1PTBar / lajidui）
  - 其他架构 4 个：M-Team (mTorrent) / HDDolby / Rousi Pro / MooKo (Gazelle)

## Changes
- `scheduler/peer_ratio_monitor.go` – 新增监控服务（event bus 订阅 + 周期检查）
- `scheduler/manager.go` – 生命周期集成（Start/Stop/Reload）
- `scheduler/cleanup_monitor.go` – 与 Peer Ratio 互斥检查
- `models/config_models.go` – `SettingsGlobal` 新增 4 个配置字段 + `GetEffectivePeerRatio*` 方法
- `models/init.go` – `TorrentInfo` 新增 `seeders` / `leechers` 字段
- `core/config_store.go` – 保存新配置字段
- `web/server.go` – 全局设置 API 透传新字段
- `web/frontend/src/views/AutoCleanup.vue` – 前端配置 UI
- `docs/sites.md` – 完整站点列表

## Compatibility
- GORM AutoMigrate 自动添加新列，**无需手动迁移**
- 新功能**默认关闭**（`peer_ratio_enabled=false`），升级后不会影响现有行为