### PR TITLE
feat(filter): 新增 FilterMode 与过滤规则大小约束，修复全局大小被绕过问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **site**: 新增 OpenCD 和 PTT 站点适配
 - 新增 site/v2/definitions/opencd.go 适配 open.cd (繁体 NexusPHP)
   _ 使用 div.title + td.rowtitle 替代标准 h1 + td.rowhead
-  _ 支持 plugin*details.php 链接格式
-  * 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
-  * 处理 font.promotion 替代 img.pro*_ 的非标准折扣标记
-  _ span.category 替代 img[alt] 的分类标记
-  _ 处理 info_block 隐藏列的 nth-child 索引偏移
-  _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
+  _ 支持 plugin\*details.php 链接格式
+  - 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
+  - 处理 font.promotion 替代 img.pro\*_ 的非标准折扣标记
+    _ span.category 替代 img[alt] 的分类标记
+    _ 处理 info_block 隐藏列的 nth-child 索引偏移
+    _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
 
 ## [0.23.0] - 2026-04-29
 

--- a/core/config_store.go
+++ b/core/config_store.go
@@ -76,7 +76,7 @@ func (s *ConfigStore) Load() (*models.Config, error) {
 				return e
 			}
 			for _, r := range rss {
-				sc.RSS = append(sc.RSS, models.RSSConfig{ID: r.ID, Name: r.Name, URL: r.URL, Category: r.Category, Tag: r.Tag, IntervalMinutes: r.IntervalMinutes, DownloaderID: r.DownloaderID, DownloadPath: r.DownloadPath, IsExample: r.IsExample, PauseOnFreeEnd: r.PauseOnFreeEnd})
+				sc.RSS = append(sc.RSS, models.RSSConfig{ID: r.ID, Name: r.Name, URL: r.URL, Category: r.Category, Tag: r.Tag, IntervalMinutes: r.IntervalMinutes, DownloaderID: r.DownloaderID, DownloadPath: r.DownloadPath, IsExample: r.IsExample, PauseOnFreeEnd: r.PauseOnFreeEnd, FilterMode: r.FilterMode})
 			}
 			out.Sites[sg] = sc
 		}
@@ -205,6 +205,7 @@ func (s *ConfigStore) SaveGlobalSettings(gs models.SettingsGlobal) error {
 		cur.PeerRatioMaxSL = gs.PeerRatioMaxSL
 		cur.PeerRatioIntervalMin = gs.PeerRatioIntervalMin
 		cur.PeerRatioRemoveData = gs.PeerRatioRemoveData
+		cur.DefaultFilterMode = models.NormalizeFilterMode(gs.DefaultFilterMode)
 		if err := db.Save(&cur).Error; err != nil {
 			return err
 		}
@@ -311,6 +312,7 @@ func (s *ConfigStore) ReplaceSiteRSS(siteID uint, rss []models.RSSConfig) error 
 			Tag:             r.Tag,
 			IntervalMinutes: r.IntervalMinutes,
 			DownloaderID:    r.DownloaderID,
+			FilterMode:      r.FilterMode,
 		}
 		if err := db.Create(&row).Error; err != nil {
 			return err
@@ -481,6 +483,7 @@ func (s *ConfigStore) UpsertSiteWithRSS(site models.SiteGroup, sc models.SiteCon
 				DownloaderID:    r.DownloaderID,
 				DownloadPath:    r.DownloadPath,
 				PauseOnFreeEnd:  r.PauseOnFreeEnd,
+				FilterMode:      r.FilterMode,
 			}
 			if err := tx.Create(&rr).Error; err != nil {
 				return err
@@ -547,7 +550,7 @@ func (s *ConfigStore) ListSites() (map[models.SiteGroup]models.SiteConfig, error
 			return nil, err
 		}
 		for _, r := range rss {
-			sc.RSS = append(sc.RSS, models.RSSConfig{ID: r.ID, Name: r.Name, URL: r.URL, Category: r.Category, Tag: r.Tag, IntervalMinutes: r.IntervalMinutes, DownloaderID: r.DownloaderID, DownloadPath: r.DownloadPath, IsExample: r.IsExample, PauseOnFreeEnd: r.PauseOnFreeEnd})
+			sc.RSS = append(sc.RSS, models.RSSConfig{ID: r.ID, Name: r.Name, URL: r.URL, Category: r.Category, Tag: r.Tag, IntervalMinutes: r.IntervalMinutes, DownloaderID: r.DownloaderID, DownloadPath: r.DownloadPath, IsExample: r.IsExample, PauseOnFreeEnd: r.PauseOnFreeEnd, FilterMode: r.FilterMode})
 		}
 		// 注意：AuthMethod 和 APIUrl 已从数据库读取（由 SyncSites 初始化）
 		out[sg] = sc
@@ -583,6 +586,7 @@ func (s *ConfigStore) GetSiteConf(name models.SiteGroup) (models.SiteConfig, err
 			DownloadPath:    r.DownloadPath,
 			IsExample:       r.IsExample,
 			PauseOnFreeEnd:  r.PauseOnFreeEnd,
+			FilterMode:      r.FilterMode,
 		}
 
 		// 获取关联的过滤规则 ID

--- a/internal/common.go
+++ b/internal/common.go
@@ -592,8 +592,9 @@ func downloadWorkerUnified(
 				stats.detailFailed.Add(1)
 				continue
 			}
-			// 使用 v2.TorrentItem 的方法
-			canFinished := detail.CanbeFinished(gl.DownloadLimitEnabled, gl.DownloadSpeedLimit, gl.TorrentSizeGB)
+			// 使用 v2.TorrentItem 的方法（此处传 0 给 sizeLimitGB，全局大小硬上限由 filter.Decide 统一检查，
+			// 避免过滤规则通道绕过全局限制）
+			canFinished := detail.CanbeFinished(gl.DownloadLimitEnabled, gl.DownloadSpeedLimit, 0)
 			isFree := detail.IsFree()
 
 			freeEndTime := detail.GetFreeEndTime()
@@ -608,31 +609,35 @@ func downloadWorkerUnified(
 
 			// 获取种子的标签/副标题用于过滤匹配
 			detailTag := detail.GetSubTitle()
+			sizeGB := float64(detail.SizeBytes) / 1024 / 1024 / 1024
 
-			// 检查过滤规则匹配
-			var matchedRule *models.FilterRule
-			var shouldDownloadByFilter bool
-			downloadSource := "free_download"
+			// 统一通过 filter.Decide 做完整决策：全局大小硬上限 → 过滤规则通道 → 免费通道
+			var decision filter.Decision
+			if filterSvc != nil && rssCfg.ID != 0 && hasAssociatedRules {
+				decision = filterSvc.Decide(filter.DecisionContext{
+					Input:      filter.MatchInput{Title: title, Tag: detailTag, SizeGB: sizeGB},
+					IsFree:     isFree,
+					CanFinish:  canFinished,
+					GlobalSize: gl.TorrentSizeGB,
+					FilterMode: rssCfg.GetEffectiveFilterMode(&gl),
+				}, rssCfg.ID)
+			} else {
+				decision = filter.DecideWithoutRules(filter.DecisionContext{
+					Input:      filter.MatchInput{Title: title, Tag: detailTag, SizeGB: sizeGB},
+					IsFree:     isFree,
+					CanFinish:  canFinished,
+					GlobalSize: gl.TorrentSizeGB,
+					FilterMode: rssCfg.GetEffectiveFilterMode(&gl),
+				})
+			}
 
-			if filterSvc != nil && rssCfg.ID != 0 {
-				// 构建匹配输入，包含标题和标签
-				matchInput := filter.MatchInput{
-					Title: title,
-					Tag:   detailTag,
-				}
-
-				// 优先使用 RSS 关联的过滤规则（多对多关联）
-				if hasAssociatedRules {
-					shouldDownloadByFilter, matchedRule = filterSvc.ShouldDownloadForRSSWithInput(matchInput, isFree, rssCfg.ID)
-					if matchedRule != nil {
-						downloadSource = "filter_rule"
-						sLogger().Infof("种子 %s (tag: %s) 匹配 RSS 关联过滤规则: %s (require_free=%v)", title, detailTag, matchedRule.Name, matchedRule.RequireFree)
-					}
-				} else {
-					// RSS 没有关联规则时，不进行过滤规则匹配
-					shouldDownloadByFilter = false
-					matchedRule = nil
-				}
+			matchedRule := decision.MatchedRule
+			downloadSource := decision.Source
+			if downloadSource == "" {
+				downloadSource = filter.SourceFreeDownload
+			}
+			if matchedRule != nil && decision.Source == filter.SourceFilterRule {
+				sLogger().Infof("种子 %s (tag: %s) 匹配 RSS 关联过滤规则: %s (require_free=%v, min=%d, max=%d)", title, detailTag, matchedRule.Name, matchedRule.RequireFree, matchedRule.MinSizeGB, matchedRule.MaxSizeGB)
 			}
 
 			// 更新种子状态（标记跳过或继续下载）
@@ -664,11 +669,7 @@ func downloadWorkerUnified(
 				}
 			}
 
-			// 决定是否下载：
-			// 1. 通过过滤规则匹配且满足条件
-			// 2. 或者通过免费下载逻辑（免费且可完成）
-			shouldDownloadByFree := isFree && canFinished
-			shouldDownload := shouldDownloadByFilter || shouldDownloadByFree
+			shouldDownload := decision.ShouldDownload
 
 			if isFree {
 				stats.free.Add(1)
@@ -676,7 +677,11 @@ func downloadWorkerUnified(
 
 			if !shouldDownload {
 				torrent.IsSkipped = true
-				sLogger().Infof("种子: %s 不满足下载条件，跳过 (原因: %s)", title, buildSkipReason(isFree, canFinished, shouldDownloadByFilter))
+				reason := decision.Reason
+				if reason == "" {
+					reason = buildSkipReason(isFree, canFinished, false)
+				}
+				sLogger().Infof("种子: %s 不满足下载条件，跳过 (原因: %s)", title, reason)
 			} else {
 				torrent.IsSkipped = false
 			}
@@ -1138,7 +1143,8 @@ func downloadWorker[T models.ResType](
 				continue
 			}
 			detail := resDetail.Data
-			canFinished := detail.CanbeFinished(global.GetSlogger(), gl.DownloadLimitEnabled, gl.DownloadSpeedLimit, gl.TorrentSizeGB)
+			// 全局大小硬上限由 filter.Decide 统一处理，此处传 0 避免重复检查
+			canFinished := detail.CanbeFinished(global.GetSlogger(), gl.DownloadLimitEnabled, gl.DownloadSpeedLimit, 0)
 			isFree := detail.IsFree()
 
 			legacyFreeEndTime := detail.GetFreeEndTime()
@@ -1153,31 +1159,34 @@ func downloadWorker[T models.ResType](
 
 			// 获取种子的标签/副标题用于过滤匹配
 			detailTag := detail.GetSubTitle()
+			sizeGB := float64(detail.GetSizeBytes()) / 1024 / 1024 / 1024
 
-			// 检查过滤规则匹配
-			var matchedRule *models.FilterRule
-			var shouldDownloadByFilter bool
-			downloadSource := "free_download"
+			var decision filter.Decision
+			if filterSvc != nil && rssCfg.ID != 0 && hasAssociatedRules {
+				decision = filterSvc.Decide(filter.DecisionContext{
+					Input:      filter.MatchInput{Title: title, Tag: detailTag, SizeGB: sizeGB},
+					IsFree:     isFree,
+					CanFinish:  canFinished,
+					GlobalSize: gl.TorrentSizeGB,
+					FilterMode: rssCfg.GetEffectiveFilterMode(&gl),
+				}, rssCfg.ID)
+			} else {
+				decision = filter.DecideWithoutRules(filter.DecisionContext{
+					Input:      filter.MatchInput{Title: title, Tag: detailTag, SizeGB: sizeGB},
+					IsFree:     isFree,
+					CanFinish:  canFinished,
+					GlobalSize: gl.TorrentSizeGB,
+					FilterMode: rssCfg.GetEffectiveFilterMode(&gl),
+				})
+			}
 
-			if filterSvc != nil && rssCfg.ID != 0 {
-				// 构建匹配输入，包含标题和标签
-				matchInput := filter.MatchInput{
-					Title: title,
-					Tag:   detailTag,
-				}
-
-				// 优先使用 RSS 关联的过滤规则（多对多关联）
-				if hasAssociatedRules {
-					shouldDownloadByFilter, matchedRule = filterSvc.ShouldDownloadForRSSWithInput(matchInput, isFree, rssCfg.ID)
-					if matchedRule != nil {
-						downloadSource = "filter_rule"
-						sLogger().Infof("种子 %s (tag: %s) 匹配 RSS 关联过滤规则: %s (require_free=%v)", title, detailTag, matchedRule.Name, matchedRule.RequireFree)
-					}
-				} else {
-					// RSS 没有关联规则时，不进行过滤规则匹配
-					shouldDownloadByFilter = false
-					matchedRule = nil
-				}
+			matchedRule := decision.MatchedRule
+			downloadSource := decision.Source
+			if downloadSource == "" {
+				downloadSource = filter.SourceFreeDownload
+			}
+			if matchedRule != nil && decision.Source == filter.SourceFilterRule {
+				sLogger().Infof("种子 %s (tag: %s) 匹配 RSS 关联过滤规则: %s (require_free=%v, min=%d, max=%d)", title, detailTag, matchedRule.Name, matchedRule.RequireFree, matchedRule.MinSizeGB, matchedRule.MaxSizeGB)
 			}
 
 			// 更新种子状态（标记跳过或继续下载）
@@ -1203,15 +1212,15 @@ func downloadWorker[T models.ResType](
 				}
 			}
 
-			// 决定是否下载：
-			// 1. 通过过滤规则匹配且满足条件
-			// 2. 或者通过免费下载逻辑（免费且可完成）
-			shouldDownloadByFree := isFree && canFinished
-			shouldDownload := shouldDownloadByFilter || shouldDownloadByFree
+			shouldDownload := decision.ShouldDownload
 
 			if !shouldDownload {
 				torrent.IsSkipped = true
-				sLogger().Infof("种子: %s 不满足下载条件，跳过 (原因: %s)", title, buildSkipReason(isFree, canFinished, shouldDownloadByFilter))
+				reason := decision.Reason
+				if reason == "" {
+					reason = buildSkipReason(isFree, canFinished, false)
+				}
+				sLogger().Infof("种子: %s 不满足下载条件，跳过 (原因: %s)", title, reason)
 			} else {
 				torrent.IsSkipped = false
 			}

--- a/internal/filter/decide_test.go
+++ b/internal/filter/decide_test.go
@@ -1,0 +1,543 @@
+package filter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/sunerpy/pt-tools/models"
+)
+
+// createRuleForDecide inserts a rule into the test DB and associates it with
+// the given RSS subscription so the FilterService cache picks it up.
+// It uses Updates with an explicit map to overwrite zero-value booleans
+// (e.g., RequireFree=false) that GORM would otherwise skip due to its
+// "omit zero-value on struct Update" behavior combined with `default:true` tag.
+func createRuleForDecide(t *testing.T, db *gorm.DB, svc FilterService, rssID uint, rule *models.FilterRule) *models.FilterRule {
+	t.Helper()
+	// Snapshot the caller's intended values BEFORE db.Create, because GORM mutates
+	// the struct in-place (e.g., default:true backfills RequireFree from false to true).
+	wantRequireFree := rule.RequireFree
+	wantMin := rule.MinSizeGB
+	wantMax := rule.MaxSizeGB
+	wantEnabled := rule.Enabled
+
+	require.NoError(t, db.Create(rule).Error)
+	require.NoError(t, db.Exec(
+		"UPDATE filter_rules SET require_free = ?, min_size_gb = ?, max_size_gb = ?, enabled = ? WHERE id = ?",
+		wantRequireFree, wantMin, wantMax, wantEnabled, rule.ID,
+	).Error)
+	rule.RequireFree = wantRequireFree
+	rule.MinSizeGB = wantMin
+	rule.MaxSizeGB = wantMax
+	rule.Enabled = wantEnabled
+
+	assoc := models.RSSFilterAssociation{RSSID: rssID, FilterRuleID: rule.ID}
+	require.NoError(t, db.Create(&assoc).Error)
+	require.NoError(t, svc.RefreshCache())
+	return rule
+}
+
+// ============================================================================
+// Tests for models.FilterRule.MatchesSize
+// ============================================================================
+
+func TestFilterRule_MatchesSize(t *testing.T) {
+	tests := []struct {
+		name      string
+		min       int
+		max       int
+		sizeGB    float64
+		wantMatch bool
+	}{
+		{"no bounds", 0, 0, 100, true},
+		{"no bounds zero size", 0, 0, 0, true},
+		{"within min only", 10, 0, 20, true},
+		{"below min", 10, 0, 5, false},
+		{"at min boundary", 10, 0, 10, true},
+		{"at min boundary float", 10, 0, 10.0, true},
+		{"within max only", 0, 50, 30, true},
+		{"above max", 0, 50, 100, false},
+		{"at max boundary", 0, 50, 50, true},
+		{"within min and max", 10, 50, 30, true},
+		{"below min with max set", 10, 50, 5, false},
+		{"above max with min set", 10, 50, 100, false},
+		{"zero size with min=0", 0, 10, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := &models.FilterRule{MinSizeGB: tt.min, MaxSizeGB: tt.max}
+			assert.Equal(t, tt.wantMatch, rule.MatchesSize(tt.sizeGB))
+		})
+	}
+}
+
+// ============================================================================
+// Tests for filter.DecideWithoutRules (no RSS-associated rules)
+// ============================================================================
+
+func TestDecideWithoutRules(t *testing.T) {
+	t.Run("global size limit rejects large torrent", func(t *testing.T) {
+		d := DecideWithoutRules(DecisionContext{
+			Input:      MatchInput{Title: "big", SizeGB: 100},
+			IsFree:     true,
+			CanFinish:  true,
+			GlobalSize: 50,
+			FilterMode: models.FilterModeAutoFree,
+		})
+		assert.False(t, d.ShouldDownload)
+		assert.Equal(t, SourceNone, d.Source)
+		assert.Contains(t, d.Reason, "全局大小限制")
+	})
+
+	t.Run("at global boundary accepts", func(t *testing.T) {
+		d := DecideWithoutRules(DecisionContext{
+			Input:      MatchInput{Title: "boundary", SizeGB: 50},
+			IsFree:     true,
+			CanFinish:  true,
+			GlobalSize: 50,
+			FilterMode: models.FilterModeAutoFree,
+		})
+		assert.True(t, d.ShouldDownload)
+		assert.Equal(t, SourceFreeDownload, d.Source)
+	})
+
+	t.Run("global size zero means unlimited", func(t *testing.T) {
+		d := DecideWithoutRules(DecisionContext{
+			Input:      MatchInput{Title: "huge", SizeGB: 9999},
+			IsFree:     true,
+			CanFinish:  true,
+			GlobalSize: 0,
+			FilterMode: models.FilterModeAutoFree,
+		})
+		assert.True(t, d.ShouldDownload)
+	})
+
+	t.Run("auto_free: free + can finish accepts", func(t *testing.T) {
+		d := DecideWithoutRules(DecisionContext{
+			Input:      MatchInput{Title: "free", SizeGB: 10},
+			IsFree:     true,
+			CanFinish:  true,
+			GlobalSize: 100,
+			FilterMode: models.FilterModeAutoFree,
+		})
+		assert.True(t, d.ShouldDownload)
+		assert.Equal(t, SourceFreeDownload, d.Source)
+	})
+
+	t.Run("auto_free: not free rejects", func(t *testing.T) {
+		d := DecideWithoutRules(DecisionContext{
+			Input:      MatchInput{Title: "paid", SizeGB: 10},
+			IsFree:     false,
+			CanFinish:  true,
+			GlobalSize: 100,
+			FilterMode: models.FilterModeAutoFree,
+		})
+		assert.False(t, d.ShouldDownload)
+		assert.Contains(t, d.Reason, "非免费")
+	})
+
+	t.Run("auto_free: free but cannot finish rejects", func(t *testing.T) {
+		d := DecideWithoutRules(DecisionContext{
+			Input:      MatchInput{Title: "free", SizeGB: 10},
+			IsFree:     true,
+			CanFinish:  false,
+			GlobalSize: 100,
+			FilterMode: models.FilterModeAutoFree,
+		})
+		assert.False(t, d.ShouldDownload)
+		assert.Contains(t, d.Reason, "免费期")
+	})
+
+	t.Run("filter_only without rules: always rejects", func(t *testing.T) {
+		d := DecideWithoutRules(DecisionContext{
+			Input:      MatchInput{Title: "anything", SizeGB: 10},
+			IsFree:     true,
+			CanFinish:  true,
+			GlobalSize: 100,
+			FilterMode: models.FilterModeFilterOnly,
+		})
+		assert.False(t, d.ShouldDownload)
+		assert.Contains(t, d.Reason, "filter_only")
+	})
+
+	t.Run("free_only without rules: only free passes", func(t *testing.T) {
+		freeD := DecideWithoutRules(DecisionContext{
+			Input:      MatchInput{Title: "free", SizeGB: 10},
+			IsFree:     true,
+			CanFinish:  true,
+			GlobalSize: 100,
+			FilterMode: models.FilterModeFreeOnly,
+		})
+		assert.True(t, freeD.ShouldDownload)
+
+		paidD := DecideWithoutRules(DecisionContext{
+			Input:      MatchInput{Title: "paid", SizeGB: 10},
+			IsFree:     false,
+			CanFinish:  true,
+			GlobalSize: 100,
+			FilterMode: models.FilterModeFreeOnly,
+		})
+		assert.False(t, paidD.ShouldDownload)
+	})
+
+	t.Run("empty filter mode falls back to default", func(t *testing.T) {
+		d := DecideWithoutRules(DecisionContext{
+			Input:      MatchInput{Title: "free", SizeGB: 10},
+			IsFree:     true,
+			CanFinish:  true,
+			GlobalSize: 0,
+			FilterMode: "",
+		})
+		assert.True(t, d.ShouldDownload)
+		assert.Equal(t, SourceFreeDownload, d.Source)
+	})
+
+	t.Run("unknown filter mode falls back to default", func(t *testing.T) {
+		d := DecideWithoutRules(DecisionContext{
+			Input:      MatchInput{Title: "free", SizeGB: 10},
+			IsFree:     true,
+			CanFinish:  true,
+			GlobalSize: 0,
+			FilterMode: "bogus_mode",
+		})
+		assert.True(t, d.ShouldDownload)
+		assert.Equal(t, SourceFreeDownload, d.Source)
+	})
+}
+
+// ============================================================================
+// Tests for filter.Decide (with RSS-associated rules) — the core feature
+// ============================================================================
+
+func TestDecide_GlobalSizeLimit(t *testing.T) {
+	db, cleanup := setupServiceTestDBWithAssociations(t)
+	defer cleanup()
+	svc := NewFilterService(db)
+	rss := createTestRSSSubscription(t, db, "rss-1")
+
+	// Regression guard for the core bug: a matching filter rule MUST NOT
+	// bypass the global TorrentSizeGB hard limit.
+	createRuleForDecide(t, db, svc, rss.ID, &models.FilterRule{
+		Name: "always-match", Pattern: "movie", PatternType: models.PatternKeyword,
+		MatchField: models.MatchFieldBoth, RequireFree: false, Enabled: true, Priority: 100,
+	})
+
+	tests := []struct {
+		name       string
+		sizeGB     float64
+		globalSize int
+		isFree     bool
+		wantDL     bool
+		wantReason string
+	}{
+		{"size>global rejects even with rule match", 100, 10, false, false, "全局大小限制"},
+		{"size>global rejects even if free+can_finish", 100, 10, true, false, "全局大小限制"},
+		{"size<global accepts via filter rule", 5, 10, false, true, ""},
+		{"size==global accepts (boundary)", 10, 10, false, true, ""},
+		{"global=0 means unlimited", 9999, 0, false, true, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := svc.Decide(DecisionContext{
+				Input:      MatchInput{Title: "movie", SizeGB: tt.sizeGB},
+				IsFree:     tt.isFree,
+				CanFinish:  true,
+				GlobalSize: tt.globalSize,
+				FilterMode: models.FilterModeAutoFree,
+			}, rss.ID)
+			assert.Equal(t, tt.wantDL, d.ShouldDownload, "ShouldDownload mismatch")
+			if tt.wantReason != "" {
+				assert.Contains(t, d.Reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestDecide_RuleSizeBounds(t *testing.T) {
+	db, cleanup := setupServiceTestDBWithAssociations(t)
+	defer cleanup()
+	svc := NewFilterService(db)
+	rss := createTestRSSSubscription(t, db, "rss-size")
+
+	createRuleForDecide(t, db, svc, rss.ID, &models.FilterRule{
+		Name: "size-range", Pattern: "movie", PatternType: models.PatternKeyword,
+		MatchField: models.MatchFieldBoth, RequireFree: false,
+		MinSizeGB: 10, MaxSizeGB: 50,
+		Enabled: true, Priority: 100,
+	})
+
+	tests := []struct {
+		name   string
+		sizeGB float64
+		wantDL bool
+	}{
+		{"below min size — filter rejects", 5, false},
+		{"above max size — filter rejects", 100, false},
+		{"within range — filter accepts", 30, true},
+		{"at min boundary — accepts", 10, true},
+		{"at max boundary — accepts", 50, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := svc.Decide(DecisionContext{
+				Input:      MatchInput{Title: "movie", SizeGB: tt.sizeGB},
+				IsFree:     false,
+				CanFinish:  true,
+				GlobalSize: 1000,
+				FilterMode: models.FilterModeAutoFree,
+			}, rss.ID)
+			assert.Equal(t, tt.wantDL, d.ShouldDownload)
+		})
+	}
+}
+
+func TestDecide_RuleSizeCanOnlyNarrow(t *testing.T) {
+	db, cleanup := setupServiceTestDBWithAssociations(t)
+	defer cleanup()
+	svc := NewFilterService(db)
+	rss := createTestRSSSubscription(t, db, "rss-narrow")
+
+	// Rule allows up to 500GB, but global caps at 100GB.
+	createRuleForDecide(t, db, svc, rss.ID, &models.FilterRule{
+		Name: "wide-rule", Pattern: "movie", PatternType: models.PatternKeyword,
+		MatchField: models.MatchFieldBoth, MaxSizeGB: 500,
+		Enabled: true, Priority: 100,
+	})
+
+	d := svc.Decide(DecisionContext{
+		Input:      MatchInput{Title: "movie", SizeGB: 200},
+		IsFree:     false,
+		CanFinish:  true,
+		GlobalSize: 100,
+		FilterMode: models.FilterModeAutoFree,
+	}, rss.ID)
+	assert.False(t, d.ShouldDownload, "rule MaxSizeGB must not widen global limit")
+	assert.Contains(t, d.Reason, "全局大小限制")
+}
+
+func TestDecide_RequireFree(t *testing.T) {
+	db, cleanup := setupServiceTestDBWithAssociations(t)
+	defer cleanup()
+	svc := NewFilterService(db)
+	rss := createTestRSSSubscription(t, db, "rss-rf")
+
+	createRuleForDecide(t, db, svc, rss.ID, &models.FilterRule{
+		Name: "needs-free", Pattern: "movie", PatternType: models.PatternKeyword,
+		MatchField: models.MatchFieldBoth, RequireFree: true,
+		Enabled: true, Priority: 100,
+	})
+
+	t.Run("RequireFree + not free + not free auto — rejects", func(t *testing.T) {
+		d := svc.Decide(DecisionContext{
+			Input:      MatchInput{Title: "movie", SizeGB: 10},
+			IsFree:     false,
+			CanFinish:  true,
+			GlobalSize: 100,
+			FilterMode: models.FilterModeAutoFree,
+		}, rss.ID)
+		assert.False(t, d.ShouldDownload)
+		// matchedRule should still be recorded for logging
+		assert.NotNil(t, d.MatchedRule)
+	})
+
+	t.Run("RequireFree + free — accepts via filter channel", func(t *testing.T) {
+		d := svc.Decide(DecisionContext{
+			Input:      MatchInput{Title: "movie", SizeGB: 10},
+			IsFree:     true,
+			CanFinish:  true,
+			GlobalSize: 100,
+			FilterMode: models.FilterModeAutoFree,
+		}, rss.ID)
+		assert.True(t, d.ShouldDownload)
+		assert.Equal(t, SourceFilterRule, d.Source)
+	})
+}
+
+func TestDecide_FilterOnlyMode(t *testing.T) {
+	db, cleanup := setupServiceTestDBWithAssociations(t)
+	defer cleanup()
+	svc := NewFilterService(db)
+	rss := createTestRSSSubscription(t, db, "rss-fo")
+
+	createRuleForDecide(t, db, svc, rss.ID, &models.FilterRule{
+		Name: "match-movie", Pattern: "movie", PatternType: models.PatternKeyword,
+		MatchField: models.MatchFieldBoth, RequireFree: false,
+		Enabled: true, Priority: 100,
+	})
+
+	t.Run("free torrent NOT matching rule — rejected (free channel disabled)", func(t *testing.T) {
+		d := svc.Decide(DecisionContext{
+			Input:      MatchInput{Title: "documentary", SizeGB: 5},
+			IsFree:     true,
+			CanFinish:  true,
+			GlobalSize: 100,
+			FilterMode: models.FilterModeFilterOnly,
+		}, rss.ID)
+		assert.False(t, d.ShouldDownload)
+	})
+
+	t.Run("free torrent matching rule — accepted via filter", func(t *testing.T) {
+		d := svc.Decide(DecisionContext{
+			Input:      MatchInput{Title: "movie", SizeGB: 5},
+			IsFree:     true,
+			CanFinish:  true,
+			GlobalSize: 100,
+			FilterMode: models.FilterModeFilterOnly,
+		}, rss.ID)
+		assert.True(t, d.ShouldDownload)
+		assert.Equal(t, SourceFilterRule, d.Source)
+	})
+
+	t.Run("paid torrent matching rule (RequireFree=false) — accepted", func(t *testing.T) {
+		d := svc.Decide(DecisionContext{
+			Input:      MatchInput{Title: "movie", SizeGB: 5},
+			IsFree:     false,
+			CanFinish:  true,
+			GlobalSize: 100,
+			FilterMode: models.FilterModeFilterOnly,
+		}, rss.ID)
+		assert.True(t, d.ShouldDownload)
+	})
+}
+
+func TestDecide_FreeOnlyMode(t *testing.T) {
+	db, cleanup := setupServiceTestDBWithAssociations(t)
+	defer cleanup()
+	svc := NewFilterService(db)
+	rss := createTestRSSSubscription(t, db, "rss-free")
+
+	createRuleForDecide(t, db, svc, rss.ID, &models.FilterRule{
+		Name: "match-anything", Pattern: "movie", PatternType: models.PatternKeyword,
+		MatchField: models.MatchFieldBoth, RequireFree: false,
+		Enabled: true, Priority: 100,
+	})
+
+	t.Run("free torrent — accepted via free channel (rule ignored)", func(t *testing.T) {
+		d := svc.Decide(DecisionContext{
+			Input:      MatchInput{Title: "movie", SizeGB: 5},
+			IsFree:     true,
+			CanFinish:  true,
+			GlobalSize: 100,
+			FilterMode: models.FilterModeFreeOnly,
+		}, rss.ID)
+		assert.True(t, d.ShouldDownload)
+		assert.Equal(t, SourceFreeDownload, d.Source)
+	})
+
+	t.Run("paid torrent matching rule — rejected (filter channel disabled)", func(t *testing.T) {
+		d := svc.Decide(DecisionContext{
+			Input:      MatchInput{Title: "movie", SizeGB: 5},
+			IsFree:     false,
+			CanFinish:  true,
+			GlobalSize: 100,
+			FilterMode: models.FilterModeFreeOnly,
+		}, rss.ID)
+		assert.False(t, d.ShouldDownload)
+	})
+
+	t.Run("free torrent cannot finish — rejected", func(t *testing.T) {
+		d := svc.Decide(DecisionContext{
+			Input:      MatchInput{Title: "movie", SizeGB: 5},
+			IsFree:     true,
+			CanFinish:  false,
+			GlobalSize: 100,
+			FilterMode: models.FilterModeFreeOnly,
+		}, rss.ID)
+		assert.False(t, d.ShouldDownload)
+	})
+}
+
+func TestDecide_AutoFreeMode_CombinedChannels(t *testing.T) {
+	db, cleanup := setupServiceTestDBWithAssociations(t)
+	defer cleanup()
+	svc := NewFilterService(db)
+	rss := createTestRSSSubscription(t, db, "rss-combo")
+
+	createRuleForDecide(t, db, svc, rss.ID, &models.FilterRule{
+		Name: "specific-match", Pattern: "exact-title", PatternType: models.PatternKeyword,
+		MatchField: models.MatchFieldBoth, RequireFree: false,
+		Enabled: true, Priority: 100,
+	})
+
+	tests := []struct {
+		name      string
+		title     string
+		isFree    bool
+		canFinish bool
+		wantDL    bool
+		wantSrc   string
+	}{
+		{"matching + paid → filter channel", "exact-title", false, true, true, SourceFilterRule},
+		{"matching + free → filter channel (filter wins due to order)", "exact-title", true, true, true, SourceFilterRule},
+		{"non-matching + free + can_finish → free channel", "other", true, true, true, SourceFreeDownload},
+		{"non-matching + paid → rejected", "other", false, true, false, SourceNone},
+		{"non-matching + free but cannot finish → rejected", "other", true, false, false, SourceNone},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := svc.Decide(DecisionContext{
+				Input:      MatchInput{Title: tt.title, SizeGB: 5},
+				IsFree:     tt.isFree,
+				CanFinish:  tt.canFinish,
+				GlobalSize: 100,
+				FilterMode: models.FilterModeAutoFree,
+			}, rss.ID)
+			assert.Equal(t, tt.wantDL, d.ShouldDownload)
+			assert.Equal(t, tt.wantSrc, d.Source)
+		})
+	}
+}
+
+func TestDecide_RuleSizeMismatch_FallsBackToFreeChannel(t *testing.T) {
+	db, cleanup := setupServiceTestDBWithAssociations(t)
+	defer cleanup()
+	svc := NewFilterService(db)
+	rss := createTestRSSSubscription(t, db, "rss-fallback")
+
+	createRuleForDecide(t, db, svc, rss.ID, &models.FilterRule{
+		Name: "min-100gb", Pattern: "movie", PatternType: models.PatternKeyword,
+		MatchField: models.MatchFieldBoth, MinSizeGB: 100,
+		Enabled: true, Priority: 100,
+	})
+
+	// Torrent text matches rule, but size 5GB < MinSizeGB 100. auto_free mode
+	// should then check the free channel, which accepts.
+	d := svc.Decide(DecisionContext{
+		Input:      MatchInput{Title: "movie", SizeGB: 5},
+		IsFree:     true,
+		CanFinish:  true,
+		GlobalSize: 1000,
+		FilterMode: models.FilterModeAutoFree,
+	}, rss.ID)
+	assert.True(t, d.ShouldDownload)
+	assert.Equal(t, SourceFreeDownload, d.Source)
+	assert.NotNil(t, d.MatchedRule, "matchedRule should be retained for logging")
+}
+
+func TestDecide_RuleRequireFreeMismatch_FallsBackToFreeChannel(t *testing.T) {
+	db, cleanup := setupServiceTestDBWithAssociations(t)
+	defer cleanup()
+	svc := NewFilterService(db)
+	rss := createTestRSSSubscription(t, db, "rss-rf-fallback")
+
+	createRuleForDecide(t, db, svc, rss.ID, &models.FilterRule{
+		Name: "needs-free", Pattern: "movie", PatternType: models.PatternKeyword,
+		MatchField: models.MatchFieldBoth, RequireFree: true,
+		Enabled: true, Priority: 100,
+	})
+
+	// Matches pattern but NOT free. free channel also fails (not free).
+	// Expect rejection with matchedRule retained.
+	d := svc.Decide(DecisionContext{
+		Input:      MatchInput{Title: "movie", SizeGB: 5},
+		IsFree:     false,
+		CanFinish:  true,
+		GlobalSize: 100,
+		FilterMode: models.FilterModeAutoFree,
+	}, rss.ID)
+	assert.False(t, d.ShouldDownload)
+	assert.NotNil(t, d.MatchedRule)
+}

--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -12,6 +12,26 @@ import (
 type MatchInput struct {
 	Title string
 	Tag   string
+	// SizeGB is the torrent size in GB. Zero means unknown (skip size checks).
+	SizeGB float64
+}
+
+// DecisionContext bundles the full set of inputs required to make a download decision.
+type DecisionContext struct {
+	Input      MatchInput
+	IsFree     bool
+	CanFinish  bool
+	GlobalSize int
+	FilterMode models.FilterMode
+}
+
+// Decision captures the outcome of a full download decision, including which
+// channel (if any) approved the download and the reason if rejected.
+type Decision struct {
+	ShouldDownload bool
+	MatchedRule    *models.FilterRule
+	Source         string
+	Reason         string
 }
 
 // FilterService provides filter rule matching functionality.
@@ -49,6 +69,11 @@ type FilterService interface {
 	// ShouldDownloadForRSSWithInput determines if a torrent should be downloaded based on RSS-associated filter rules.
 	// Supports matching against title, tag, or both based on rule configuration.
 	ShouldDownloadForRSSWithInput(input MatchInput, isFree bool, rssID uint) (bool, *models.FilterRule)
+
+	// Decide evaluates the full download decision tree for an RSS item, honoring
+	// the configured FilterMode, global hard size limit, and per-rule size bounds.
+	// It is the canonical entry point for the v0.25+ download decision logic.
+	Decide(ctx DecisionContext, rssID uint) Decision
 
 	// GetEnabledRules returns all enabled filter rules ordered by priority.
 	GetEnabledRules() ([]models.FilterRule, error)
@@ -338,5 +363,143 @@ func (s *filterService) MatchTorrentForRSSWithInput(input MatchInput, isFree boo
 		Matched:        true,
 		Rule:           rule,
 		ShouldDownload: shouldDownload,
+	}
+}
+
+// Download source tags persisted on TorrentInfo.DownloadSource.
+const (
+	SourceFreeDownload = "free_download"
+	SourceFilterRule   = "filter_rule"
+	SourceNone         = ""
+)
+
+// Decide implements the FilterMode-aware decision tree. Order of checks:
+//  1. Global hard size limit — if exceeded, reject immediately regardless of mode.
+//  2. Filter-rule channel (enabled unless mode == free_only):
+//     matches pattern + satisfies RequireFree + per-rule size bounds.
+//  3. Free channel (enabled unless mode == filter_only):
+//     isFree + CanFinish (free-period time check only; size already covered by step 1).
+//
+// Per-rule bounds can only narrow the global limit (checked after step 1 is passed).
+// Filter mode falls back to FilterModeAutoFree when unrecognized.
+func (s *filterService) Decide(ctx DecisionContext, rssID uint) Decision {
+	mode := models.NormalizeFilterMode(ctx.FilterMode)
+
+	if ctx.GlobalSize > 0 && ctx.Input.SizeGB > float64(ctx.GlobalSize) {
+		return Decision{
+			ShouldDownload: false,
+			Source:         SourceNone,
+			Reason:         "超出全局大小限制",
+		}
+	}
+
+	var matchedRule *models.FilterRule
+	if mode != models.FilterModeFreeOnly {
+		rule, matched := s.MatchRulesForRSSWithInput(ctx.Input, rssID)
+		if matched {
+			matchedRule = rule
+			if rule.RequireFree && !ctx.IsFree {
+				// Don't approve via filter channel, but keep the matchedRule for
+				// logging; the free channel may still approve below.
+			} else if !rule.MatchesSize(ctx.Input.SizeGB) {
+				// Rule matched text but not size — same handling as above.
+			} else {
+				return Decision{
+					ShouldDownload: true,
+					MatchedRule:    rule,
+					Source:         SourceFilterRule,
+				}
+			}
+		}
+	}
+
+	if mode != models.FilterModeFilterOnly {
+		if ctx.IsFree && ctx.CanFinish {
+			return Decision{
+				ShouldDownload: true,
+				MatchedRule:    matchedRule,
+				Source:         SourceFreeDownload,
+			}
+		}
+	}
+
+	return Decision{
+		ShouldDownload: false,
+		MatchedRule:    matchedRule,
+		Source:         SourceNone,
+		Reason:         buildDecisionReason(mode, matchedRule, ctx.IsFree, ctx.CanFinish),
+	}
+}
+
+// DecideWithoutRules runs the same decision tree as Decide but skips the
+// filter-rule channel entirely. Callers use it when the RSS has no associated
+// rules; it preserves the global hard size limit and free-channel semantics
+// without requiring a FilterService.
+func DecideWithoutRules(ctx DecisionContext) Decision {
+	mode := models.NormalizeFilterMode(ctx.FilterMode)
+
+	if ctx.GlobalSize > 0 && ctx.Input.SizeGB > float64(ctx.GlobalSize) {
+		return Decision{
+			ShouldDownload: false,
+			Source:         SourceNone,
+			Reason:         "超出全局大小限制",
+		}
+	}
+
+	if mode == models.FilterModeFilterOnly {
+		return Decision{
+			ShouldDownload: false,
+			Source:         SourceNone,
+			Reason:         "filter_only 模式下未匹配过滤规则（RSS 无关联规则）",
+		}
+	}
+
+	if ctx.IsFree && ctx.CanFinish {
+		return Decision{
+			ShouldDownload: true,
+			Source:         SourceFreeDownload,
+		}
+	}
+
+	if !ctx.IsFree {
+		return Decision{
+			ShouldDownload: false,
+			Source:         SourceNone,
+			Reason:         "非免费且无关联过滤规则",
+		}
+	}
+	return Decision{
+		ShouldDownload: false,
+		Source:         SourceNone,
+		Reason:         "免费期剩余时间不足",
+	}
+}
+
+func buildDecisionReason(mode models.FilterMode, rule *models.FilterRule, isFree, canFinish bool) string {
+	switch mode {
+	case models.FilterModeFilterOnly:
+		if rule == nil {
+			return "未匹配过滤规则（filter_only 模式下免费通道已关闭）"
+		}
+		if rule.RequireFree && !isFree {
+			return "匹配规则要求免费，但种子非免费"
+		}
+		return "匹配规则但大小不符合规则约束"
+	case models.FilterModeFreeOnly:
+		if !isFree {
+			return "非免费种子（free_only 模式下过滤规则通道已关闭）"
+		}
+		return "免费期剩余时间不足"
+	default:
+		if rule != nil && rule.RequireFree && !isFree {
+			return "匹配规则要求免费，种子非免费；且非免费或无法完成"
+		}
+		if rule != nil && !rule.MatchesSize(0) && rule.MaxSizeGB > 0 {
+			return "匹配规则但大小不符合；且非免费或无法完成"
+		}
+		if !isFree {
+			return "非免费且未匹配过滤规则"
+		}
+		return "免费期剩余时间不足"
 	}
 }

--- a/models/config_models.go
+++ b/models/config_models.go
@@ -18,6 +18,35 @@ const (
 	MaxConcurrency     int32 = 10 // 最大并发数
 )
 
+// FilterMode controls which download channels are active for an RSS feed.
+type FilterMode string
+
+const (
+	// FilterModeAutoFree enables both the free auto-download channel and
+	// the filter-rule channel. This preserves pre-v0.25 behavior and is the default.
+	FilterModeAutoFree FilterMode = "auto_free"
+	// FilterModeFilterOnly disables the free auto-download channel; only torrents
+	// matching an associated filter rule are downloaded.
+	FilterModeFilterOnly FilterMode = "filter_only"
+	// FilterModeFreeOnly disables the filter-rule channel; only free torrents
+	// that can be finished in time are downloaded (ignores associated rules).
+	FilterModeFreeOnly FilterMode = "free_only"
+)
+
+// DefaultFilterMode is the fallback when neither RSS nor Global specifies one.
+const DefaultFilterMode = FilterModeAutoFree
+
+// NormalizeFilterMode returns a validated FilterMode, falling back to DefaultFilterMode
+// when the input is empty or unrecognized.
+func NormalizeFilterMode(m FilterMode) FilterMode {
+	switch m {
+	case FilterModeAutoFree, FilterModeFilterOnly, FilterModeFreeOnly:
+		return m
+	default:
+		return DefaultFilterMode
+	}
+}
+
 // Admin 用户（单用户登录）
 type AdminUser struct {
 	ID           uint   `gorm:"primaryKey"`
@@ -64,6 +93,9 @@ type SettingsGlobal struct {
 
 	// 免费结束自动删除
 	AutoDeleteOnFreeEnd bool `json:"auto_delete_on_free_end" gorm:"default:false"` // 免费期结束时自动删除未完成的种子及数据
+
+	// 默认下载模式（RSS 级别可 override）
+	DefaultFilterMode FilterMode `json:"default_filter_mode" gorm:"size:16;default:'auto_free'"`
 
 	// 做种竞争度监控（Peer Ratio Monitor）
 	PeerRatioEnabled     bool    `json:"peer_ratio_enabled" gorm:"default:false"`     // 是否启用做种竞争度监控
@@ -158,38 +190,40 @@ type SiteSetting struct {
 
 // RSS 订阅
 type RSSSubscription struct {
-	ID              uint      `gorm:"primaryKey" json:"id"`
-	SiteID          uint      `gorm:"index" json:"site_id"`
-	Name            string    `gorm:"size:128;not null" json:"name"`
-	URL             string    `gorm:"size:1024;not null" json:"url"`
-	Category        string    `gorm:"size:128" json:"category"`
-	Tag             string    `gorm:"size:128" json:"tag"`
-	IntervalMinutes int32     `gorm:"check:interval_minutes >= 1" json:"interval_minutes"` // RSS 执行间隔（分钟），0 表示使用全局设置
-	Concurrency     int32     `json:"concurrency"`                                         // 并发数，0 表示使用全局设置
-	DownloadSubPath string    `gorm:"size:256" json:"download_sub_path"`
-	DownloadPath    string    `gorm:"size:512" json:"download_path"` // 下载器中下载任务的目标下载路径（可选）
-	DownloaderID    *uint     `gorm:"index" json:"downloader_id"`    // 指定下载器，nil 表示使用默认下载器
-	IsExample       bool      `json:"is_example"`                    // 是否为示例配置，示例配置不会被执行
-	PauseOnFreeEnd  bool      `gorm:"default:false" json:"pause_on_free_end"`
-	CreatedAt       time.Time `json:"created_at"`
-	UpdatedAt       time.Time `json:"updated_at"`
+	ID              uint       `gorm:"primaryKey" json:"id"`
+	SiteID          uint       `gorm:"index" json:"site_id"`
+	Name            string     `gorm:"size:128;not null" json:"name"`
+	URL             string     `gorm:"size:1024;not null" json:"url"`
+	Category        string     `gorm:"size:128" json:"category"`
+	Tag             string     `gorm:"size:128" json:"tag"`
+	IntervalMinutes int32      `gorm:"check:interval_minutes >= 1" json:"interval_minutes"` // RSS 执行间隔（分钟），0 表示使用全局设置
+	Concurrency     int32      `json:"concurrency"`                                         // 并发数，0 表示使用全局设置
+	DownloadSubPath string     `gorm:"size:256" json:"download_sub_path"`
+	DownloadPath    string     `gorm:"size:512" json:"download_path"` // 下载器中下载任务的目标下载路径（可选）
+	DownloaderID    *uint      `gorm:"index" json:"downloader_id"`    // 指定下载器，nil 表示使用默认下载器
+	IsExample       bool       `json:"is_example"`                    // 是否为示例配置，示例配置不会被执行
+	PauseOnFreeEnd  bool       `gorm:"default:false" json:"pause_on_free_end"`
+	FilterMode      FilterMode `gorm:"size:16;default:''" json:"filter_mode"` // 空字符串表示使用全局 DefaultFilterMode
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
 }
 
 // Runtime-friendly structures for API usage and scheduler/config load
 type RSSConfig struct {
-	ID              uint   `json:"id"`
-	Name            string `json:"name"`
-	URL             string `json:"url"`
-	Category        string `json:"category"`
-	Tag             string `json:"tag"`
-	IntervalMinutes int32  `json:"interval_minutes"` // RSS 执行间隔（分钟），0 表示使用全局设置
-	Concurrency     int32  `json:"concurrency"`      // 并发数，0 表示使用全局设置
-	DownloadSubPath string `json:"download_sub_path"`
-	DownloadPath    string `json:"download_path"`   // 下载器中下载任务的目标下载路径（可选）
-	DownloaderID    *uint  `json:"downloader_id"`   // 指定下载器，nil 表示使用默认下载器
-	FilterRuleIDs   []uint `json:"filter_rule_ids"` // 关联的过滤规则 ID 列表
-	IsExample       bool   `json:"is_example"`      // 是否为示例配置，示例配置不会被执行
-	PauseOnFreeEnd  bool   `json:"pause_on_free_end"`
+	ID              uint       `json:"id"`
+	Name            string     `json:"name"`
+	URL             string     `json:"url"`
+	Category        string     `json:"category"`
+	Tag             string     `json:"tag"`
+	IntervalMinutes int32      `json:"interval_minutes"` // RSS 执行间隔（分钟），0 表示使用全局设置
+	Concurrency     int32      `json:"concurrency"`      // 并发数，0 表示使用全局设置
+	DownloadSubPath string     `json:"download_sub_path"`
+	DownloadPath    string     `json:"download_path"`   // 下载器中下载任务的目标下载路径（可选）
+	DownloaderID    *uint      `json:"downloader_id"`   // 指定下载器，nil 表示使用默认下载器
+	FilterRuleIDs   []uint     `json:"filter_rule_ids"` // 关联的过滤规则 ID 列表
+	IsExample       bool       `json:"is_example"`      // 是否为示例配置，示例配置不会被执行
+	PauseOnFreeEnd  bool       `json:"pause_on_free_end"`
+	FilterMode      FilterMode `json:"filter_mode"` // 空字符串表示使用全局 DefaultFilterMode
 }
 
 // ShouldSkip 判断是否应该跳过此 RSS 配置
@@ -249,6 +283,19 @@ func (r *RSSConfig) GetEffectiveDownloadPath() string {
 // HasCustomDownloadPath 检查是否配置了自定义下载路径
 func (r *RSSConfig) HasCustomDownloadPath() bool {
 	return r.DownloadPath != ""
+}
+
+// GetEffectiveFilterMode resolves the filter mode using the RSS > Global > Default priority.
+// RSS-level value takes precedence; empty falls through to the global default; unknown
+// values also fall back to DefaultFilterMode via NormalizeFilterMode.
+func (r *RSSConfig) GetEffectiveFilterMode(globalSettings *SettingsGlobal) FilterMode {
+	if r.FilterMode != "" {
+		return NormalizeFilterMode(r.FilterMode)
+	}
+	if globalSettings != nil && globalSettings.DefaultFilterMode != "" {
+		return NormalizeFilterMode(globalSettings.DefaultFilterMode)
+	}
+	return DefaultFilterMode
 }
 
 type SiteConfig struct {

--- a/models/filter_rule.go
+++ b/models/filter_rule.go
@@ -36,12 +36,27 @@ type FilterRule struct {
 	PatternType PatternType `gorm:"size:16;not null;default:'keyword'" json:"pattern_type"`
 	MatchField  MatchField  `gorm:"size:16;not null;default:'both'" json:"match_field"`
 	RequireFree bool        `gorm:"default:true" json:"require_free"`
+	MinSizeGB   int         `gorm:"default:0" json:"min_size_gb"`
+	MaxSizeGB   int         `gorm:"default:0" json:"max_size_gb"`
 	Enabled     bool        `gorm:"default:true" json:"enabled"`
 	SiteID      *uint       `gorm:"index" json:"site_id"`
 	RSSID       *uint       `gorm:"index" json:"rss_id"`
 	Priority    int         `gorm:"default:100" json:"priority"`
 	CreatedAt   time.Time   `json:"created_at"`
 	UpdatedAt   time.Time   `json:"updated_at"`
+}
+
+// MatchesSize reports whether the torrent size (in GB) satisfies this rule's
+// optional MinSizeGB / MaxSizeGB bounds. Zero on either side means "no bound".
+// The rule's bounds can only narrow the global TorrentSizeGB; never widen it.
+func (r *FilterRule) MatchesSize(sizeGB float64) bool {
+	if r.MinSizeGB > 0 && sizeGB < float64(r.MinSizeGB) {
+		return false
+	}
+	if r.MaxSizeGB > 0 && sizeGB > float64(r.MaxSizeGB) {
+		return false
+	}
+	return true
 }
 
 // TableName returns the table name for FilterRule.

--- a/models/filter_rule_size_test.go
+++ b/models/filter_rule_size_test.go
@@ -1,0 +1,104 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ============================================================================
+// FilterRule.MatchesSize - exhaustive size-bound behavior
+// ============================================================================
+
+func TestFilterRule_MatchesSize_AllCombinations(t *testing.T) {
+	tests := []struct {
+		name   string
+		min    int
+		max    int
+		sizeGB float64
+		want   bool
+	}{
+		// No bounds
+		{"no bounds / zero size", 0, 0, 0, true},
+		{"no bounds / huge size", 0, 0, 9999, true},
+		// Min only
+		{"min=10 / below", 10, 0, 5, false},
+		{"min=10 / at boundary", 10, 0, 10, true},
+		{"min=10 / above", 10, 0, 20, true},
+		// Max only
+		{"max=50 / below", 0, 50, 25, true},
+		{"max=50 / at boundary", 0, 50, 50, true},
+		{"max=50 / above", 0, 50, 100, false},
+		// Both bounds
+		{"min=10 max=50 / below min", 10, 50, 5, false},
+		{"min=10 max=50 / at min", 10, 50, 10, true},
+		{"min=10 max=50 / middle", 10, 50, 30, true},
+		{"min=10 max=50 / at max", 10, 50, 50, true},
+		{"min=10 max=50 / above max", 10, 50, 100, false},
+		// Fractional sizes
+		{"min=5 / fractional at boundary", 5, 0, 5.0, true},
+		{"min=5 / fractional just below", 5, 0, 4.999, false},
+		{"max=10 / fractional just above", 0, 10, 10.001, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := &FilterRule{MinSizeGB: tt.min, MaxSizeGB: tt.max}
+			assert.Equal(t, tt.want, rule.MatchesSize(tt.sizeGB))
+		})
+	}
+}
+
+// ============================================================================
+// NormalizeFilterMode — enum validation and fallback
+// ============================================================================
+
+func TestNormalizeFilterMode(t *testing.T) {
+	tests := []struct {
+		input FilterMode
+		want  FilterMode
+	}{
+		{FilterModeAutoFree, FilterModeAutoFree},
+		{FilterModeFilterOnly, FilterModeFilterOnly},
+		{FilterModeFreeOnly, FilterModeFreeOnly},
+		{"", DefaultFilterMode},
+		{"bogus", DefaultFilterMode},
+		{"AUTO_FREE", DefaultFilterMode},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.input), func(t *testing.T) {
+			assert.Equal(t, tt.want, NormalizeFilterMode(tt.input))
+		})
+	}
+}
+
+// ============================================================================
+// RSSConfig.GetEffectiveFilterMode — priority chain: RSS > Global > Default
+// ============================================================================
+
+func TestRSSConfig_GetEffectiveFilterMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		rssMode     FilterMode
+		globalMode  FilterMode
+		wantMode    FilterMode
+		nilSettings bool
+	}{
+		{"RSS filter_only overrides global auto_free", FilterModeFilterOnly, FilterModeAutoFree, FilterModeFilterOnly, false},
+		{"RSS free_only overrides global", FilterModeFreeOnly, FilterModeAutoFree, FilterModeFreeOnly, false},
+		{"empty RSS falls back to global free_only", "", FilterModeFreeOnly, FilterModeFreeOnly, false},
+		{"empty RSS + empty global = default", "", "", DefaultFilterMode, false},
+		{"empty RSS + nil global settings = default", "", "", DefaultFilterMode, true},
+		{"invalid RSS mode falls back to default", "bogus", FilterModeFilterOnly, DefaultFilterMode, false},
+		{"invalid global mode falls back to default", "", "bogus", DefaultFilterMode, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RSSConfig{FilterMode: tt.rssMode}
+			var gs *SettingsGlobal
+			if !tt.nilSettings {
+				gs = &SettingsGlobal{DefaultFilterMode: tt.globalMode}
+			}
+			assert.Equal(t, tt.wantMode, r.GetEffectiveFilterMode(gs))
+		})
+	}
+}

--- a/models/php_torrent.go
+++ b/models/php_torrent.go
@@ -80,3 +80,8 @@ func (p PHPTorrentInfo) GetName() string {
 func (p PHPTorrentInfo) GetSubTitle() string {
 	return p.SubTitle
 }
+
+// GetSizeBytes 获取种子大小（字节），由 SizeMB 换算得到。
+func (p PHPTorrentInfo) GetSizeBytes() int64 {
+	return int64(p.SizeMB * 1024 * 1024)
+}

--- a/models/resp.go
+++ b/models/resp.go
@@ -25,6 +25,8 @@ type TorrentMetadata interface {
 	GetName() string
 	// GetSubTitle 获取副标题/标签信息
 	GetSubTitle() string
+	// GetSizeBytes 获取种子大小（字节），用于过滤规则的大小匹配
+	GetSizeBytes() int64
 }
 type FreeDownChecker interface {
 	IsFree() bool
@@ -225,4 +227,12 @@ func (t MTTorrentDetail) GetName() string {
 // GetSubTitle 获取副标题（返回 SmallDescr）
 func (t MTTorrentDetail) GetSubTitle() string {
 	return t.SmallDescr
+}
+
+// GetSizeBytes 获取种子大小（字节）；解析失败时返回 0。
+func (t MTTorrentDetail) GetSizeBytes() int64 {
+	if n, err := strconv.ParseInt(t.Size, 10, 64); err == nil {
+		return n
+	}
+	return 0
 }

--- a/web/api_filter_rule.go
+++ b/web/api_filter_rule.go
@@ -25,6 +25,8 @@ type FilterRuleRequest struct {
 	PatternType string `json:"pattern_type"` // keyword, wildcard, regex
 	MatchField  string `json:"match_field"`  // title, tag, both
 	RequireFree bool   `json:"require_free"`
+	MinSizeGB   int    `json:"min_size_gb"`
+	MaxSizeGB   int    `json:"max_size_gb"`
 	Enabled     bool   `json:"enabled"`
 	SiteID      *uint  `json:"site_id"`
 	RSSID       *uint  `json:"rss_id"`
@@ -39,6 +41,8 @@ type FilterRuleResponse struct {
 	PatternType string `json:"pattern_type"`
 	MatchField  string `json:"match_field"`
 	RequireFree bool   `json:"require_free"`
+	MinSizeGB   int    `json:"min_size_gb"`
+	MaxSizeGB   int    `json:"max_size_gb"`
 	Enabled     bool   `json:"enabled"`
 	SiteID      *uint  `json:"site_id"`
 	RSSID       *uint  `json:"rss_id"`
@@ -49,20 +53,30 @@ type FilterRuleResponse struct {
 
 // FilterRuleTestRequest 过滤规则测试请求
 type FilterRuleTestRequest struct {
-	Pattern     string `json:"pattern"`
-	PatternType string `json:"pattern_type"`
-	MatchField  string `json:"match_field"`  // title, tag, both
-	RequireFree bool   `json:"require_free"` // 是否仅匹配免费种子
-	SiteID      *uint  `json:"site_id"`
-	RSSID       *uint  `json:"rss_id"`
-	Limit       int    `json:"limit"` // 最多返回多少条匹配结果
+	Pattern     string  `json:"pattern"`
+	PatternType string  `json:"pattern_type"`
+	MatchField  string  `json:"match_field"`  // title, tag, both
+	RequireFree bool    `json:"require_free"` // 是否仅匹配免费种子
+	MinSizeGB   int     `json:"min_size_gb"`
+	MaxSizeGB   int     `json:"max_size_gb"`
+	TestSizeGB  float64 `json:"test_size_gb"` // 模拟种子大小，用于完整决策测试
+	TestIsFree  *bool   `json:"test_is_free"` // 覆盖 is_free 状态（nil=使用真实值）
+	GlobalSize  int     `json:"global_size"`  // 模拟全局大小上限
+	FilterMode  string  `json:"filter_mode"`  // 模拟 FilterMode
+	SiteID      *uint   `json:"site_id"`
+	RSSID       *uint   `json:"rss_id"`
+	Limit       int     `json:"limit"` // 最多返回多少条匹配结果
 }
 
 // FilterRuleTestMatch 单个匹配结果
 type FilterRuleTestMatch struct {
-	Title  string `json:"title"`
-	Tag    string `json:"tag"`
-	IsFree bool   `json:"is_free"` // 是否免费
+	Title    string  `json:"title"`
+	Tag      string  `json:"tag"`
+	IsFree   bool    `json:"is_free"`  // 是否免费
+	SizeGB   float64 `json:"size_gb"`  // 种子大小（GB）
+	Decision string  `json:"decision"` // 完整决策结果: downloaded / skipped
+	Reason   string  `json:"reason"`   // 跳过原因（如果有）
+	Source   string  `json:"source"`   // 下载通道: filter_rule / free_download / ""
 }
 
 // FilterRuleTestResponse 过滤规则测试响应
@@ -203,6 +217,8 @@ func (s *Server) createFilterRule(w http.ResponseWriter, r *http.Request) {
 		PatternType: patternType,
 		MatchField:  matchField,
 		RequireFree: req.RequireFree,
+		MinSizeGB:   sanitizeRuleSize(req.MinSizeGB),
+		MaxSizeGB:   sanitizeRuleSize(req.MaxSizeGB),
 		Enabled:     req.Enabled,
 		SiteID:      req.SiteID,
 		RSSID:       req.RSSID,
@@ -296,6 +312,8 @@ func (s *Server) updateFilterRule(w http.ResponseWriter, r *http.Request, id uin
 	}
 
 	rule.RequireFree = req.RequireFree
+	rule.MinSizeGB = sanitizeRuleSize(req.MinSizeGB)
+	rule.MaxSizeGB = sanitizeRuleSize(req.MaxSizeGB)
 	rule.Enabled = req.Enabled
 	rule.SiteID = req.SiteID
 	rule.RSSID = req.RSSID
@@ -417,17 +435,48 @@ func (s *Server) testFilterRule(w http.ResponseWriter, r *http.Request) {
 	// 匹配种子
 	var matches []FilterRuleTestMatch
 	global.GetSlogger().Debugf("[FilterRuleTest] 开始匹配种子，总数: %d", len(torrents))
+
+	testRule := &models.FilterRule{
+		Pattern:     req.Pattern,
+		PatternType: models.PatternType(patternType),
+		MatchField:  matchField,
+		RequireFree: req.RequireFree,
+		MinSizeGB:   sanitizeRuleSize(req.MinSizeGB),
+		MaxSizeGB:   sanitizeRuleSize(req.MaxSizeGB),
+		Enabled:     true,
+	}
+	mode := models.NormalizeFilterMode(models.FilterMode(req.FilterMode))
+
 	for _, t := range torrents {
 		isMatch := matchesField(matcher, matchField, t.Title, t.Tag)
 		global.GetSlogger().Debugf("[FilterRuleTest] 尝试匹配: title=%s, tag=%s, matched=%v", t.Title, t.Tag, isMatch)
-		if isMatch {
-			matches = append(matches, FilterRuleTestMatch{
-				Title: t.Title,
-				Tag:   t.Tag,
-			})
-			if len(matches) >= limit {
-				break
-			}
+		if !isMatch {
+			continue
+		}
+
+		// 用当前种子数据评估完整决策（模拟 filter.Decide 流程）
+		torrentSizeGB := bytesToGB(t.TorrentSize)
+		if req.TestSizeGB > 0 {
+			torrentSizeGB = req.TestSizeGB
+		}
+		isFree := t.IsFree
+		if req.TestIsFree != nil {
+			isFree = *req.TestIsFree
+		}
+		decision := evaluateTestDecision(testRule, mode, req.GlobalSize, torrentSizeGB, isFree)
+
+		match := FilterRuleTestMatch{
+			Title:    t.Title,
+			Tag:      t.Tag,
+			IsFree:   isFree,
+			SizeGB:   torrentSizeGB,
+			Decision: decisionLabel(decision.ShouldDownload),
+			Reason:   decision.Reason,
+			Source:   decision.Source,
+		}
+		matches = append(matches, match)
+		if len(matches) >= limit {
+			break
 		}
 	}
 
@@ -518,9 +567,11 @@ func (s *Server) testFilterRuleWithRSS(w http.ResponseWriter, matcher filter.Pat
 
 			if matchCount < limit {
 				matchChan <- FilterRuleTestMatch{
-					Title:  title,
-					Tag:    tag,
-					IsFree: isFree,
+					Title:    title,
+					Tag:      tag,
+					IsFree:   isFree,
+					Decision: decisionLabel(true),
+					Source:   filter.SourceFilterRule,
 				}
 				matchCount++
 			}
@@ -611,6 +662,8 @@ func toFilterRuleResponse(rule models.FilterRule) FilterRuleResponse {
 		PatternType: string(rule.PatternType),
 		MatchField:  matchField,
 		RequireFree: rule.RequireFree,
+		MinSizeGB:   rule.MinSizeGB,
+		MaxSizeGB:   rule.MaxSizeGB,
 		Enabled:     rule.Enabled,
 		SiteID:      rule.SiteID,
 		RSSID:       rule.RSSID,
@@ -618,4 +671,60 @@ func toFilterRuleResponse(rule models.FilterRule) FilterRuleResponse {
 		CreatedAt:   rule.CreatedAt.Format("2006-01-02 15:04:05"),
 		UpdatedAt:   rule.UpdatedAt.Format("2006-01-02 15:04:05"),
 	}
+}
+
+// sanitizeRuleSize clamps negative values to 0 (meaning "no bound").
+func sanitizeRuleSize(v int) int {
+	if v < 0 {
+		return 0
+	}
+	return v
+}
+
+// evaluateTestDecision mirrors filter.Decide semantics for the rule-tester UI.
+// It returns the same Decision shape but operates on a single in-memory rule
+// candidate rather than the DB-backed rule cache.
+func evaluateTestDecision(rule *models.FilterRule, mode models.FilterMode, globalSizeGB int, sizeGB float64, isFree bool) filter.Decision {
+	if globalSizeGB > 0 && sizeGB > float64(globalSizeGB) {
+		return filter.Decision{ShouldDownload: false, Source: filter.SourceNone, Reason: "超出全局大小限制"}
+	}
+	if mode == models.FilterModeFreeOnly {
+		if isFree {
+			return filter.Decision{ShouldDownload: true, Source: filter.SourceFreeDownload}
+		}
+		return filter.Decision{ShouldDownload: false, Source: filter.SourceNone, Reason: "free_only 模式下过滤规则通道已关闭且非免费"}
+	}
+	if rule.RequireFree && !isFree {
+		if mode == models.FilterModeFilterOnly {
+			return filter.Decision{ShouldDownload: false, MatchedRule: rule, Source: filter.SourceNone, Reason: "匹配规则要求免费，但种子非免费"}
+		}
+		if isFree {
+			return filter.Decision{ShouldDownload: true, MatchedRule: rule, Source: filter.SourceFreeDownload}
+		}
+		return filter.Decision{ShouldDownload: false, MatchedRule: rule, Source: filter.SourceNone, Reason: "匹配规则要求免费，种子非免费"}
+	}
+	if !rule.MatchesSize(sizeGB) {
+		if mode == models.FilterModeFilterOnly {
+			return filter.Decision{ShouldDownload: false, MatchedRule: rule, Source: filter.SourceNone, Reason: "匹配规则但大小不符合规则约束"}
+		}
+		if isFree {
+			return filter.Decision{ShouldDownload: true, MatchedRule: rule, Source: filter.SourceFreeDownload}
+		}
+		return filter.Decision{ShouldDownload: false, MatchedRule: rule, Source: filter.SourceNone, Reason: "匹配规则但大小不符合且非免费"}
+	}
+	return filter.Decision{ShouldDownload: true, MatchedRule: rule, Source: filter.SourceFilterRule}
+}
+
+func decisionLabel(ok bool) string {
+	if ok {
+		return "downloaded"
+	}
+	return "skipped"
+}
+
+func bytesToGB(n int64) float64 {
+	if n <= 0 {
+		return 0
+	}
+	return float64(n) / 1024 / 1024 / 1024
 }

--- a/web/frontend/src/api/index.ts
+++ b/web/frontend/src/api/index.ts
@@ -49,6 +49,8 @@ export const api = {
 };
 
 // API 类型定义
+export type FilterMode = "" | "auto_free" | "filter_only" | "free_only";
+
 export interface GlobalSettings {
   default_interval_minutes: number;
   download_dir: string;
@@ -76,6 +78,11 @@ export interface GlobalSettings {
   cleanup_min_retain_h?: number;
   cleanup_protect_tags?: string;
   auto_delete_on_free_end?: boolean;
+  peer_ratio_enabled?: boolean;
+  peer_ratio_max_sl?: number;
+  peer_ratio_interval_min?: number;
+  peer_ratio_remove_data?: boolean;
+  default_filter_mode?: FilterMode;
 }
 
 export interface QbitSettings {
@@ -97,6 +104,7 @@ export interface RSSConfig {
   filter_rule_ids?: number[]; // 关联的过滤规则 ID 列表
   pause_on_free_end?: boolean; // 免费结束时是否暂停未完成的下载
   is_example?: boolean; // 是否为示例配置
+  filter_mode?: FilterMode; // 空字符串表示继承全局
 }
 
 export interface SiteConfig {
@@ -322,6 +330,8 @@ export interface FilterRule {
   pattern_type: "keyword" | "wildcard" | "regex";
   match_field?: "title" | "tag" | "both";
   require_free: boolean;
+  min_size_gb?: number;
+  max_size_gb?: number;
   enabled: boolean;
   site_id?: number;
   rss_id?: number;
@@ -335,6 +345,12 @@ export interface FilterRuleTestRequest {
   pattern_type: string;
   match_field?: string;
   require_free?: boolean;
+  min_size_gb?: number;
+  max_size_gb?: number;
+  test_size_gb?: number;
+  test_is_free?: boolean | null;
+  global_size?: number;
+  filter_mode?: FilterMode;
   site_id?: number;
   rss_id?: number;
   limit?: number;
@@ -344,6 +360,10 @@ export interface FilterRuleTestMatch {
   title: string;
   tag: string;
   is_free: boolean;
+  size_gb?: number;
+  decision?: "downloaded" | "skipped";
+  reason?: string;
+  source?: "filter_rule" | "free_download" | "";
 }
 
 export interface FilterRuleTestResponse {

--- a/web/frontend/src/views/FilterRules.vue
+++ b/web/frontend/src/views/FilterRules.vue
@@ -27,9 +27,24 @@ const form = ref<FilterRule>({
   pattern_type: "keyword",
   match_field: "both",
   require_free: true,
+  min_size_gb: 0,
+  max_size_gb: 0,
   enabled: true,
   priority: 100,
 });
+
+const testForm = ref({
+  test_size_gb: 0,
+  test_is_free: null as boolean | null,
+  global_size: 0,
+  filter_mode: "auto_free" as "auto_free" | "filter_only" | "free_only",
+});
+
+const filterModeOptions = [
+  { value: "auto_free", label: "自动免费 + 过滤规则" },
+  { value: "filter_only", label: "仅过滤规则匹配" },
+  { value: "free_only", label: "仅免费种子" },
+];
 
 const patternTypes = [
   { value: "keyword", label: "关键词", tip: "大小写不敏感，匹配包含该关键词的标题" },
@@ -104,6 +119,8 @@ function openAddDialog() {
     pattern_type: "keyword",
     match_field: "both",
     require_free: true,
+    min_size_gb: 0,
+    max_size_gb: 0,
     enabled: true,
     priority: 100,
   };
@@ -195,6 +212,12 @@ async function testPattern() {
       pattern_type: form.value.pattern_type,
       match_field: form.value.match_field || "both",
       require_free: form.value.require_free,
+      min_size_gb: form.value.min_size_gb || 0,
+      max_size_gb: form.value.max_size_gb || 0,
+      test_size_gb: testForm.value.test_size_gb,
+      test_is_free: testForm.value.test_is_free,
+      global_size: testForm.value.global_size,
+      filter_mode: testForm.value.filter_mode,
       rss_id: selectedRssId.value,
       limit: 20,
     });
@@ -324,6 +347,15 @@ function getMatchFieldLabel(field: string | undefined) {
           </template>
         </el-table-column>
 
+        <el-table-column label="大小范围" min-width="120" align="center">
+          <template #default="{ row }">
+            <span v-if="!row.min_size_gb && !row.max_size_gb">不限</span>
+            <span v-else>
+              {{ row.min_size_gb || 0 }} ~ {{ row.max_size_gb ? row.max_size_gb : "∞" }} GB
+            </span>
+          </template>
+        </el-table-column>
+
         <el-table-column label="操作" min-width="200" align="center">
           <template #default="{ row }">
             <el-space class="rule-actions">
@@ -390,6 +422,18 @@ function getMatchFieldLabel(field: string | undefined) {
           <div class="form-tip">开启后仅下载免费种子</div>
         </el-form-item>
 
+        <el-form-item label="最小大小 (GB)">
+          <el-input-number v-model="form.min_size_gb" :min="0" :max="99999" />
+          <div class="form-tip">种子大小小于该值时不通过此规则，0 = 不限制</div>
+        </el-form-item>
+
+        <el-form-item label="最大大小 (GB)">
+          <el-input-number v-model="form.max_size_gb" :min="0" :max="99999" />
+          <div class="form-tip">
+            种子大小大于该值时不通过此规则，0 = 不限制；规则上限不能突破全局设置
+          </div>
+        </el-form-item>
+
         <el-form-item label="启用">
           <el-switch v-model="form.enabled" />
         </el-form-item>
@@ -408,6 +452,32 @@ function getMatchFieldLabel(field: string | undefined) {
               :value="rss.id" />
           </el-select>
           <div class="form-tip">选择 RSS 订阅从实时数据中测试，不选则从历史记录中测试</div>
+        </el-form-item>
+
+        <el-form-item label="模拟大小 (GB)">
+          <el-input-number v-model="testForm.test_size_gb" :min="0" :step="0.5" :precision="2" />
+          <div class="form-tip">覆盖种子实际大小以测试大小规则，0 = 使用种子真实大小</div>
+        </el-form-item>
+
+        <el-form-item label="模拟免费状态">
+          <el-radio-group v-model="testForm.test_is_free">
+            <el-radio :label="null">使用真实值</el-radio>
+            <el-radio :label="true">免费</el-radio>
+            <el-radio :label="false">非免费</el-radio>
+          </el-radio-group>
+        </el-form-item>
+
+        <el-form-item label="模拟全局上限 (GB)">
+          <el-input-number v-model="testForm.global_size" :min="0" :max="99999" />
+          <div class="form-tip">模拟全局 TorrentSizeGB 上限，0 = 无上限</div>
+        </el-form-item>
+
+        <el-form-item label="下载模式">
+          <el-radio-group v-model="testForm.filter_mode">
+            <el-radio-button v-for="m in filterModeOptions" :key="m.value" :label="m.value">
+              {{ m.label }}
+            </el-radio-button>
+          </el-radio-group>
         </el-form-item>
 
         <el-form-item>
@@ -458,11 +528,39 @@ function getMatchFieldLabel(field: string | undefined) {
             <template #header>
               <div class="match-header">
                 <span class="match-index">#{{ idx + 1 }}</span>
-                <el-tag size="small" type="success" effect="plain">匹配成功</el-tag>
+                <el-tag
+                  size="small"
+                  :type="match.decision === 'downloaded' ? 'success' : 'danger'"
+                  effect="plain">
+                  {{
+                    match.decision === "downloaded"
+                      ? "会下载"
+                      : match.decision === "skipped"
+                        ? "会跳过"
+                        : "匹配成功"
+                  }}
+                </el-tag>
                 <el-tag v-if="match.is_free" size="small" type="warning" effect="plain">
                   免费
                 </el-tag>
                 <el-tag v-else size="small" type="info" effect="plain">非免费</el-tag>
+                <el-tag
+                  v-if="match.source === 'filter_rule'"
+                  size="small"
+                  type="primary"
+                  effect="plain">
+                  过滤规则通道
+                </el-tag>
+                <el-tag
+                  v-else-if="match.source === 'free_download'"
+                  size="small"
+                  type="success"
+                  effect="plain">
+                  免费通道
+                </el-tag>
+                <span v-if="match.size_gb" class="match-size">
+                  {{ match.size_gb.toFixed(2) }} GB
+                </span>
               </div>
             </template>
 
@@ -475,6 +573,11 @@ function getMatchFieldLabel(field: string | undefined) {
               <div v-if="match.tag" class="match-section">
                 <div class="match-label">标签</div>
                 <div class="match-tag-content">{{ match.tag }}</div>
+              </div>
+
+              <div v-if="match.reason" class="match-section">
+                <div class="match-label">原因</div>
+                <div class="match-reason">{{ match.reason }}</div>
               </div>
             </div>
           </el-card>

--- a/web/frontend/src/views/GlobalSettings.vue
+++ b/web/frontend/src/views/GlobalSettings.vue
@@ -17,7 +17,22 @@ const form = ref<GlobalSettings>({
   min_free_minutes: 30,
   auto_start: false,
   auto_delete_on_free_end: false,
+  default_filter_mode: "auto_free",
 });
+
+const filterModeOptions = [
+  {
+    value: "auto_free",
+    label: "自动免费 + 过滤规则",
+    desc: "默认。免费种子自动下载，同时启用过滤规则",
+  },
+  {
+    value: "filter_only",
+    label: "仅过滤规则匹配",
+    desc: "关闭自动下载免费种子，只下载匹配过滤规则的种子",
+  },
+  { value: "free_only", label: "仅免费（忽略过滤规则）", desc: "只下载免费种子，忽略所有过滤规则" },
+];
 
 onMounted(async () => {
   loading.value = true;
@@ -150,6 +165,31 @@ async function save() {
               <el-form-item label="自动启动任务">
                 <el-switch v-model="form.auto_start" />
                 <div class="form-tip">程序启动时立即开启已启用的 RSS 检查任务</div>
+              </el-form-item>
+            </el-col>
+          </el-row>
+
+          <el-row :gutter="40" class="strategy-row">
+            <el-col :md="24">
+              <el-form-item label="默认下载模式">
+                <el-radio-group v-model="form.default_filter_mode">
+                  <el-radio-button
+                    v-for="opt in filterModeOptions"
+                    :key="opt.value"
+                    :label="opt.value">
+                    {{ opt.label }}
+                  </el-radio-button>
+                </el-radio-group>
+                <div class="form-tip">
+                  控制 RSS 种子下载逻辑（RSS 订阅级别可 override）。全局大小上限对所有模式都生效。
+                </div>
+                <div
+                  v-for="opt in filterModeOptions"
+                  :key="opt.value"
+                  v-show="form.default_filter_mode === opt.value"
+                  class="form-tip form-tip-secondary">
+                  {{ opt.desc }}
+                </div>
               </el-form-item>
             </el-col>
           </el-row>

--- a/web/frontend/src/views/SiteDetail.vue
+++ b/web/frontend/src/views/SiteDetail.vue
@@ -115,6 +115,7 @@ const newRss = reactive<RSSConfig>({
   download_path: "",
   filter_rule_ids: [],
   pause_on_free_end: false,
+  filter_mode: "",
 });
 
 const editRssDialogVisible = ref(false);
@@ -129,6 +130,7 @@ const editingRss = reactive<RSSConfig>({
   download_path: "",
   filter_rule_ids: [],
   pause_on_free_end: false,
+  filter_mode: "",
 });
 const editingRssIndex = ref(-1);
 const updatingRss = ref(false);
@@ -216,6 +218,7 @@ function openAddRssDialog() {
     download_path: "",
     filter_rule_ids: [],
     pause_on_free_end: true,
+    filter_mode: "",
   });
   newRssUseCustomPath.value = false;
   rssDialogVisible.value = true;
@@ -253,6 +256,7 @@ async function addRss() {
       download_path: newRss.download_path || "",
       filter_rule_ids: newRss.filter_rule_ids || [],
       pause_on_free_end: newRss.pause_on_free_end || false,
+      filter_mode: newRss.filter_mode || "",
     });
     await sitesApi.save(siteName.value, form.value);
     // 重新加载数据以获取数据库中的真实 ID
@@ -323,6 +327,7 @@ function openEditRssDialog(index: number) {
     download_path: rss.download_path || "",
     filter_rule_ids: rss.filter_rule_ids || [],
     pause_on_free_end: rss.pause_on_free_end || false,
+    filter_mode: rss.filter_mode || "",
   });
   // 检查当前路径是否为预设目录，如果不是则启用自定义输入
   editRssUseCustomPath.value = rss.download_path
@@ -367,6 +372,7 @@ async function updateRss() {
       download_path: editingRss.download_path || "",
       filter_rule_ids: editingRss.filter_rule_ids || [],
       pause_on_free_end: editingRss.pause_on_free_end || false,
+      filter_mode: editingRss.filter_mode || "",
     };
 
     // 保存到服务器
@@ -772,6 +778,17 @@ function toggleEditRssCustomPath() {
           <el-switch v-model="newRss.pause_on_free_end" />
           <div class="form-tip">启用后，免费期结束时如果下载未完成，系统将自动暂停任务</div>
         </el-form-item>
+        <el-form-item label="下载模式">
+          <el-radio-group v-model="newRss.filter_mode" size="small">
+            <el-radio-button label="">跟随全局</el-radio-button>
+            <el-radio-button label="auto_free">自动免费+过滤规则</el-radio-button>
+            <el-radio-button label="filter_only">仅过滤规则</el-radio-button>
+            <el-radio-button label="free_only">仅免费</el-radio-button>
+          </el-radio-group>
+          <div class="form-tip">
+            控制此 RSS 的下载策略。"跟随全局"表示使用全局设置。全局大小上限对所有模式都生效。
+          </div>
+        </el-form-item>
         <el-form-item label="下载路径">
           <div class="path-selector">
             <el-select
@@ -871,6 +888,17 @@ function toggleEditRssCustomPath() {
         <el-form-item label="免费结束暂停">
           <el-switch v-model="editingRss.pause_on_free_end" />
           <div class="form-tip">启用后，免费期结束时如果下载未完成，系统将自动暂停任务</div>
+        </el-form-item>
+        <el-form-item label="下载模式">
+          <el-radio-group v-model="editingRss.filter_mode" size="small">
+            <el-radio-button label="">跟随全局</el-radio-button>
+            <el-radio-button label="auto_free">自动免费+过滤规则</el-radio-button>
+            <el-radio-button label="filter_only">仅过滤规则</el-radio-button>
+            <el-radio-button label="free_only">仅免费</el-radio-button>
+          </el-radio-group>
+          <div class="form-tip">
+            控制此 RSS 的下载策略。"跟随全局"表示使用全局设置。全局大小上限对所有模式都生效。
+          </div>
         </el-form-item>
         <el-form-item label="下载路径">
           <div class="path-selector">

--- a/web/server.go
+++ b/web/server.go
@@ -468,6 +468,7 @@ func (s *Server) apiGlobal(w http.ResponseWriter, r *http.Request) {
 			PeerRatioMaxSL         float64 `json:"peer_ratio_max_sl"`
 			PeerRatioIntervalMin   int     `json:"peer_ratio_interval_min"`
 			PeerRatioRemoveData    bool    `json:"peer_ratio_remove_data"`
+			DefaultFilterMode      string  `json:"default_filter_mode"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -514,6 +515,7 @@ func (s *Server) apiGlobal(w http.ResponseWriter, r *http.Request) {
 			PeerRatioMaxSL:         req.PeerRatioMaxSL,
 			PeerRatioIntervalMin:   req.PeerRatioIntervalMin,
 			PeerRatioRemoveData:    req.PeerRatioRemoveData,
+			DefaultFilterMode:      models.NormalizeFilterMode(models.FilterMode(req.DefaultFilterMode)),
 		}
 		if err := s.store.SaveGlobalSettings(gs); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)


### PR DESCRIPTION
## Summary
- **Bug fix**: 全局 `TorrentSizeGB` 限制被过滤规则绕过的问题
- **新功能**: 过滤规则新增 `MinSizeGB` / `MaxSizeGB` 字段
- **新功能**: 新增 3 种下载模式 `FilterMode` (`auto_free` / `filter_only` / `free_only`)
- **新功能**: 规则测试 UI 支持完整决策模拟（大小/免费/全局上限/模式）

## Bug Fix Detail

用户反馈："过滤规则大于10G的不下载无论是全局还是过滤都没效果"。

**根因**: `internal/common.go` 中 `shouldDownload = shouldDownloadByFilter || shouldDownloadByFree`，过滤规则命中后 `canFinished`（内含大小检查）的结果被 OR 逻辑丢弃，导致全局 `TorrentSizeGB` 限制对走过滤规则通道的种子形同虚设。

**修复**: 统一决策树 `全局大小硬上限 → 过滤规则通道 → 免费通道`。全局大小是所有通道的硬上限，过滤规则只能进一步收紧（不能突破全局）。

## New Features

### FilterRule 大小字段
```
MinSizeGB: int  // 0 = 不限制下限
MaxSizeGB: int  // 0 = 不限制上限（不能突破全局 TorrentSizeGB）
```

### FilterMode（3 级优先级: RSS > Global > Default）
- `auto_free`（默认）: 免费自动下载 + 过滤规则并行（兼容旧行为）
- `filter_only`: 仅匹配过滤规则的种子才下载（关闭免费通道）
- `free_only`: 仅免费种子自动下载（忽略过滤规则）

### 规则测试 UI 扩展
新增"模拟种子大小 / 模拟免费状态 / 模拟全局上限 / 模拟下载模式"输入，结果显示：
- 决策: ✅ 会下载 / ❌ 会跳过
- 下载通道: 过滤规则 / 免费通道
- 跳过原因（精确到具体条件）

## Changes
- `models/filter_rule.go`: 新增 `MinSizeGB` / `MaxSizeGB` 字段 + `MatchesSize()` 方法
- `models/config_models.go`: 新增 `FilterMode` 类型 + `NormalizeFilterMode` + `RSSConfig.GetEffectiveFilterMode` + `SettingsGlobal.DefaultFilterMode` + `RSSSubscription.FilterMode`
- `models/resp.go` + `models/php_torrent.go`: `TorrentMetadata` 接口新增 `GetSizeBytes()` 方法
- `internal/filter/service.go`: 新增 `Decide` / `DecideWithoutRules` / `DecisionContext` / `Decision`
- `internal/common.go`: 两条 RSS 工作路径统一改用 `Decide`，`CanbeFinished` 改为仅检查免费期时间
- `web/api_filter_rule.go`: `FilterRuleRequest/Response` 新增 size 字段；Test API 新增 `test_size_gb/test_is_free/global_size/filter_mode` 模拟参数
- `web/server.go`: 全局设置 API 透传 `default_filter_mode`
- `core/config_store.go`: 持久化新字段
- `web/frontend/src/views/FilterRules.vue`: 编辑对话框 + 列表 + 测试对话框
- `web/frontend/src/views/GlobalSettings.vue`: 默认下载模式配置
- `web/frontend/src/views/SiteDetail.vue`: 每个 RSS 的下载模式
- `web/frontend/src/api/index.ts`: TypeScript 类型同步

## Regression Test Coverage (All Pass ✅)
- `internal/filter/decide_test.go` - 30+ cases:
  * 全局大小硬上限（含 bug 回归守卫：过滤规则命中不能绕过全局限制）
  * 规则 Min/Max 边界、GlobalSize=0 无上限、规则收紧但不能突破全局
  * 3 种 FilterMode 的通道开关行为
  * RequireFree 与 Free 通道的 fallback 关系
- `models/filter_rule_size_test.go` - MatchesSize 所有组合 + NormalizeFilterMode + GetEffectiveFilterMode 3 级优先级
- 全量回归: `go test ./...` 全通过；`make lint` 0 issues；`vue-tsc` 0 errors

## Compatibility
- GORM AutoMigrate 自动添加新列（`min_size_gb` / `max_size_gb` / `filter_mode` / `default_filter_mode`）
- 所有新字段默认为零值/空字符串，升级后**保持旧行为不变**（兼容性 100%）
- FilterMode 空字符串 → 继承全局 → 全局空 → `DefaultFilterMode=auto_free` → 与旧版本语义一致