### PR TITLE
fix(filter): 修复关联过滤规则后仍自动下载非匹配免费种子的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,12 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **site**: 新增 OpenCD 和 PTT 站点适配
 - 新增 site/v2/definitions/opencd.go 适配 open.cd (繁体 NexusPHP)
   _ 使用 div.title + td.rowtitle 替代标准 h1 + td.rowhead
-  _ 支持 plugin*details.php 链接格式
-  * 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
-  * 处理 font.promotion 替代 img.pro*_ 的非标准折扣标记
-  _ span.category 替代 img[alt] 的分类标记
-  _ 处理 info_block 隐藏列的 nth-child 索引偏移
-  _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
+  _ 支持 plugin\*details.php 链接格式
+  - 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
+  - 处理 font.promotion 替代 img.pro\*_ 的非标准折扣标记
+    _ span.category 替代 img[alt] 的分类标记
+    _ 处理 info_block 隐藏列的 nth-child 索引偏移
+    _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
 
 ## [0.23.0] - 2026-04-29
 

--- a/internal/filter/decide_test.go
+++ b/internal/filter/decide_test.go
@@ -462,6 +462,8 @@ func TestDecide_AutoFreeMode_CombinedChannels(t *testing.T) {
 		Enabled: true, Priority: 100,
 	})
 
+	// Plan A semantics: with rules associated on this RSS, a non-matching free
+	// torrent must NOT be auto-downloaded. Non-matching paid is still rejected.
 	tests := []struct {
 		name      string
 		title     string
@@ -471,8 +473,8 @@ func TestDecide_AutoFreeMode_CombinedChannels(t *testing.T) {
 		wantSrc   string
 	}{
 		{"matching + paid → filter channel", "exact-title", false, true, true, SourceFilterRule},
-		{"matching + free → filter channel (filter wins due to order)", "exact-title", true, true, true, SourceFilterRule},
-		{"non-matching + free + can_finish → free channel", "other", true, true, true, SourceFreeDownload},
+		{"matching + free → filter channel", "exact-title", true, true, true, SourceFilterRule},
+		{"non-matching + free → rejected (Plan A: rules gate free channel)", "other", true, true, false, SourceNone},
 		{"non-matching + paid → rejected", "other", false, true, false, SourceNone},
 		{"non-matching + free but cannot finish → rejected", "other", true, false, false, SourceNone},
 	}
@@ -491,7 +493,67 @@ func TestDecide_AutoFreeMode_CombinedChannels(t *testing.T) {
 	}
 }
 
-func TestDecide_RuleSizeMismatch_FallsBackToFreeChannel(t *testing.T) {
+// TestDecide_AutoFreeMode_NoRules_KeepsFreeChannel guards the legacy behavior
+// for RSS subscriptions that have NO associated filter rules. In that case,
+// the free channel must still auto-download free torrents (backward compat).
+func TestDecide_AutoFreeMode_NoRules_KeepsFreeChannel(t *testing.T) {
+	db, cleanup := setupServiceTestDBWithAssociations(t)
+	defer cleanup()
+	svc := NewFilterService(db)
+	rss := createTestRSSSubscription(t, db, "rss-no-rules")
+	// IMPORTANT: no rules are associated with this RSS
+
+	tests := []struct {
+		name   string
+		isFree bool
+		wantDL bool
+	}{
+		{"free + can finish → auto-download (legacy)", true, true},
+		{"paid → rejected (no rules to match)", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := svc.Decide(DecisionContext{
+				Input:      MatchInput{Title: "anything", SizeGB: 5},
+				IsFree:     tt.isFree,
+				CanFinish:  true,
+				GlobalSize: 100,
+				FilterMode: models.FilterModeAutoFree,
+			}, rss.ID)
+			assert.Equal(t, tt.wantDL, d.ShouldDownload)
+		})
+	}
+}
+
+// TestDecide_PlanA_UserReportedBug is the regression guard for the exact
+// user complaint: "即使设置了过滤规则，免费种子仍然全部自动下载".
+// Must stay forever to prevent reintroduction.
+func TestDecide_PlanA_UserReportedBug(t *testing.T) {
+	db, cleanup := setupServiceTestDBWithAssociations(t)
+	defer cleanup()
+	svc := NewFilterService(db)
+	rss := createTestRSSSubscription(t, db, "rss-user-report")
+
+	createRuleForDecide(t, db, svc, rss.ID, &models.FilterRule{
+		Name: "only-4k-movies", Pattern: "2160p", PatternType: models.PatternKeyword,
+		MatchField: models.MatchFieldBoth, RequireFree: false,
+		Enabled: true, Priority: 100,
+	})
+
+	// User sets rule "only 2160p" expecting to download ONLY matching torrents.
+	// An unrelated free torrent appears — it must NOT be auto-downloaded.
+	d := svc.Decide(DecisionContext{
+		Input:      MatchInput{Title: "Documentary.1080p.WEB-DL", SizeGB: 5},
+		IsFree:     true,
+		CanFinish:  true,
+		GlobalSize: 100,
+		FilterMode: models.FilterModeAutoFree,
+	}, rss.ID)
+	assert.False(t, d.ShouldDownload, "non-matching free torrents must NOT be auto-downloaded when RSS has rules")
+	assert.Equal(t, SourceNone, d.Source)
+}
+
+func TestDecide_RuleSizeMismatch_RejectsUnderPlanA(t *testing.T) {
 	db, cleanup := setupServiceTestDBWithAssociations(t)
 	defer cleanup()
 	svc := NewFilterService(db)
@@ -503,8 +565,9 @@ func TestDecide_RuleSizeMismatch_FallsBackToFreeChannel(t *testing.T) {
 		Enabled: true, Priority: 100,
 	})
 
-	// Torrent text matches rule, but size 5GB < MinSizeGB 100. auto_free mode
-	// should then check the free channel, which accepts.
+	// Plan A: Torrent text matches rule, but size 5GB < MinSizeGB 100.
+	// In auto_free mode WITH rules associated, the free channel is now gated off,
+	// so the torrent is rejected rather than falling back to free download.
 	d := svc.Decide(DecisionContext{
 		Input:      MatchInput{Title: "movie", SizeGB: 5},
 		IsFree:     true,
@@ -512,12 +575,13 @@ func TestDecide_RuleSizeMismatch_FallsBackToFreeChannel(t *testing.T) {
 		GlobalSize: 1000,
 		FilterMode: models.FilterModeAutoFree,
 	}, rss.ID)
-	assert.True(t, d.ShouldDownload)
-	assert.Equal(t, SourceFreeDownload, d.Source)
+	assert.False(t, d.ShouldDownload, "Plan A: rules-associated RSS must not fall back to free channel")
+	assert.Equal(t, SourceNone, d.Source)
 	assert.NotNil(t, d.MatchedRule, "matchedRule should be retained for logging")
+	assert.Contains(t, d.Reason, "关联")
 }
 
-func TestDecide_RuleRequireFreeMismatch_FallsBackToFreeChannel(t *testing.T) {
+func TestDecide_RuleRequireFreeMismatch_RejectsUnderPlanA(t *testing.T) {
 	db, cleanup := setupServiceTestDBWithAssociations(t)
 	defer cleanup()
 	svc := NewFilterService(db)
@@ -529,8 +593,8 @@ func TestDecide_RuleRequireFreeMismatch_FallsBackToFreeChannel(t *testing.T) {
 		Enabled: true, Priority: 100,
 	})
 
-	// Matches pattern but NOT free. free channel also fails (not free).
-	// Expect rejection with matchedRule retained.
+	// Plan A: matches pattern but NOT free. Free channel also fails (not free).
+	// Result: rejected with matchedRule retained (same as before).
 	d := svc.Decide(DecisionContext{
 		Input:      MatchInput{Title: "movie", SizeGB: 5},
 		IsFree:     false,

--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -185,7 +185,6 @@ func (s *filterService) MatchRulesForRSSWithInput(input MatchInput, rssID uint) 
 	for _, id := range ruleIDs {
 		ruleIDSet[id] = true
 	}
-
 	// Check rules in priority order
 	for i := range s.rules {
 		rule := &s.rules[i]
@@ -373,12 +372,26 @@ const (
 	SourceNone         = ""
 )
 
+// hasAssociatedRules reports whether the given RSS has any filter rule associated.
+// It must be called without holding s.mu; it takes the read lock internally.
+func (s *filterService) hasAssociatedRules(rssID uint) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ids, ok := s.rssRules[rssID]
+	return ok && len(ids) > 0
+}
+
 // Decide implements the FilterMode-aware decision tree. Order of checks:
 //  1. Global hard size limit — if exceeded, reject immediately regardless of mode.
 //  2. Filter-rule channel (enabled unless mode == free_only):
 //     matches pattern + satisfies RequireFree + per-rule size bounds.
-//  3. Free channel (enabled unless mode == filter_only):
-//     isFree + CanFinish (free-period time check only; size already covered by step 1).
+//  3. Free channel:
+//     - Disabled when mode == filter_only.
+//     - Disabled when mode == auto_free AND the RSS has associated rules (hasRules).
+//     This enforces the "associating rules = precise opt-in" user expectation:
+//     once any rule is attached, non-matching free torrents are NOT auto-downloaded.
+//     - Enabled when mode == auto_free AND no rules are associated (preserves legacy behavior).
+//     - Always enabled when mode == free_only.
 //
 // Per-rule bounds can only narrow the global limit (checked after step 1 is passed).
 // Filter mode falls back to FilterModeAutoFree when unrecognized.
@@ -394,8 +407,10 @@ func (s *filterService) Decide(ctx DecisionContext, rssID uint) Decision {
 	}
 
 	var matchedRule *models.FilterRule
+	var hasRules bool
 	if mode != models.FilterModeFreeOnly {
 		rule, matched := s.MatchRulesForRSSWithInput(ctx.Input, rssID)
+		hasRules = s.hasAssociatedRules(rssID)
 		if matched {
 			matchedRule = rule
 			if rule.RequireFree && !ctx.IsFree {
@@ -413,7 +428,13 @@ func (s *filterService) Decide(ctx DecisionContext, rssID uint) Decision {
 		}
 	}
 
-	if mode != models.FilterModeFilterOnly {
+	// Free channel gating (Plan A semantics):
+	//   filter_only         → never allow free channel
+	//   auto_free + hasRules → never allow free channel (implicit filter-only)
+	//   auto_free + no rules → allow free channel (legacy behavior)
+	//   free_only           → always allow free channel (rules skipped entirely)
+	freeAllowed := mode != models.FilterModeFilterOnly && (mode != models.FilterModeAutoFree || !hasRules)
+	if freeAllowed {
 		if ctx.IsFree && ctx.CanFinish {
 			return Decision{
 				ShouldDownload: true,
@@ -427,7 +448,7 @@ func (s *filterService) Decide(ctx DecisionContext, rssID uint) Decision {
 		ShouldDownload: false,
 		MatchedRule:    matchedRule,
 		Source:         SourceNone,
-		Reason:         buildDecisionReason(mode, matchedRule, ctx.IsFree, ctx.CanFinish),
+		Reason:         buildDecisionReason(mode, matchedRule, ctx.IsFree, ctx.CanFinish, hasRules),
 	}
 }
 
@@ -475,7 +496,7 @@ func DecideWithoutRules(ctx DecisionContext) Decision {
 	}
 }
 
-func buildDecisionReason(mode models.FilterMode, rule *models.FilterRule, isFree, canFinish bool) string {
+func buildDecisionReason(mode models.FilterMode, rule *models.FilterRule, isFree, canFinish, hasRules bool) string {
 	switch mode {
 	case models.FilterModeFilterOnly:
 		if rule == nil {
@@ -491,11 +512,24 @@ func buildDecisionReason(mode models.FilterMode, rule *models.FilterRule, isFree
 		}
 		return "免费期剩余时间不足"
 	default:
+		// auto_free branch
 		if rule != nil && rule.RequireFree && !isFree {
+			if hasRules {
+				return "匹配规则要求免费但种子非免费；RSS 关联了过滤规则，非匹配的免费种子不再自动下载"
+			}
 			return "匹配规则要求免费，种子非免费；且非免费或无法完成"
 		}
 		if rule != nil && !rule.MatchesSize(0) && rule.MaxSizeGB > 0 {
+			if hasRules {
+				return "匹配规则但大小不符合；RSS 关联了过滤规则，非匹配的免费种子不再自动下载"
+			}
 			return "匹配规则但大小不符合；且非免费或无法完成"
+		}
+		if hasRules {
+			if isFree && !canFinish {
+				return "未匹配过滤规则且免费期剩余时间不足（RSS 关联了规则，未匹配种子不自动下载）"
+			}
+			return "未匹配过滤规则（RSS 关联了规则，非匹配的免费种子不再自动下载）"
 		}
 		if !isFree {
 			return "非免费且未匹配过滤规则"

--- a/web/api_filter_rule.go
+++ b/web/api_filter_rule.go
@@ -684,6 +684,9 @@ func sanitizeRuleSize(v int) int {
 // evaluateTestDecision mirrors filter.Decide semantics for the rule-tester UI.
 // It returns the same Decision shape but operates on a single in-memory rule
 // candidate rather than the DB-backed rule cache.
+// Plan A: since the tester is always testing with a rule present, the "rules
+// associated" flag is conceptually true — non-matching conditions do NOT fall
+// back to the free channel under auto_free.
 func evaluateTestDecision(rule *models.FilterRule, mode models.FilterMode, globalSizeGB int, sizeGB float64, isFree bool) filter.Decision {
 	if globalSizeGB > 0 && sizeGB > float64(globalSizeGB) {
 		return filter.Decision{ShouldDownload: false, Source: filter.SourceNone, Reason: "超出全局大小限制"}
@@ -695,22 +698,10 @@ func evaluateTestDecision(rule *models.FilterRule, mode models.FilterMode, globa
 		return filter.Decision{ShouldDownload: false, Source: filter.SourceNone, Reason: "free_only 模式下过滤规则通道已关闭且非免费"}
 	}
 	if rule.RequireFree && !isFree {
-		if mode == models.FilterModeFilterOnly {
-			return filter.Decision{ShouldDownload: false, MatchedRule: rule, Source: filter.SourceNone, Reason: "匹配规则要求免费，但种子非免费"}
-		}
-		if isFree {
-			return filter.Decision{ShouldDownload: true, MatchedRule: rule, Source: filter.SourceFreeDownload}
-		}
-		return filter.Decision{ShouldDownload: false, MatchedRule: rule, Source: filter.SourceNone, Reason: "匹配规则要求免费，种子非免费"}
+		return filter.Decision{ShouldDownload: false, MatchedRule: rule, Source: filter.SourceNone, Reason: "匹配规则要求免费，但种子非免费"}
 	}
 	if !rule.MatchesSize(sizeGB) {
-		if mode == models.FilterModeFilterOnly {
-			return filter.Decision{ShouldDownload: false, MatchedRule: rule, Source: filter.SourceNone, Reason: "匹配规则但大小不符合规则约束"}
-		}
-		if isFree {
-			return filter.Decision{ShouldDownload: true, MatchedRule: rule, Source: filter.SourceFreeDownload}
-		}
-		return filter.Decision{ShouldDownload: false, MatchedRule: rule, Source: filter.SourceNone, Reason: "匹配规则但大小不符合且非免费"}
+		return filter.Decision{ShouldDownload: false, MatchedRule: rule, Source: filter.SourceNone, Reason: "匹配规则但大小不符合规则约束"}
 	}
 	return filter.Decision{ShouldDownload: true, MatchedRule: rule, Source: filter.SourceFilterRule}
 }

--- a/web/frontend/src/views/FilterRules.vue
+++ b/web/frontend/src/views/FilterRules.vue
@@ -276,11 +276,20 @@ function getMatchFieldLabel(field: string | undefined) {
         show-icon
         style="margin-bottom: 16px">
         <template #title>
-          <strong>大多数用户无需设置过滤规则</strong>
+          <strong>过滤规则 = 精准下载，而非"叠加免费自动下"</strong>
         </template>
         <template #default>
-          未启用过滤规则时，RSS
-          订阅<strong>默认只下载免费种子</strong>，适合日常刷流使用。仅在需要追剧或下载特定资源（即便非免费也要下载）时，才需要创建过滤规则并将「仅免费」设为「否」。
+          <div style="line-height: 1.8">
+            未启用过滤规则时，RSS 订阅<strong>默认自动下载免费种子</strong>（适合日常刷流）。
+            <br />
+            一旦给 RSS
+            关联了过滤规则（v0.26.0+），系统会认为你需要<strong>精准下载</strong>：仅下载匹配规则的种子，其他种子（即便免费）将被忽略。
+            <br />
+            如果希望"既下载规则匹配的，又下载所有免费种子"的旧行为，请在具体 RSS
+            的"下载模式"中保持默认
+            <code>跟随全局</code>，并在<strong>全局设置</strong>里将下载模式设为
+            <code>仅免费（忽略过滤规则）</code>；或对该 RSS 不关联任何过滤规则。
+          </div>
         </template>
       </el-alert>
 

--- a/web/frontend/src/views/GlobalSettings.vue
+++ b/web/frontend/src/views/GlobalSettings.vue
@@ -23,15 +23,19 @@ const form = ref<GlobalSettings>({
 const filterModeOptions = [
   {
     value: "auto_free",
-    label: "自动免费 + 过滤规则",
-    desc: "默认。免费种子自动下载，同时启用过滤规则",
+    label: "智能模式（推荐）",
+    desc: "无过滤规则的 RSS：自动下载免费种子；有过滤规则的 RSS：仅下载匹配规则的种子（不再自动下非匹配的免费种子）",
   },
   {
     value: "filter_only",
     label: "仅过滤规则匹配",
-    desc: "关闭自动下载免费种子，只下载匹配过滤规则的种子",
+    desc: "所有 RSS 都必须匹配过滤规则才下载；未关联规则的 RSS 将不下载任何种子",
   },
-  { value: "free_only", label: "仅免费（忽略过滤规则）", desc: "只下载免费种子，忽略所有过滤规则" },
+  {
+    value: "free_only",
+    label: "仅免费（忽略过滤规则）",
+    desc: "只下载免费种子，完全忽略过滤规则；适合纯刷流用户",
+  },
 ];
 
 onMounted(async () => {
@@ -181,7 +185,12 @@ async function save() {
                   </el-radio-button>
                 </el-radio-group>
                 <div class="form-tip">
-                  控制 RSS 种子下载逻辑（RSS 订阅级别可 override）。全局大小上限对所有模式都生效。
+                  控制 RSS 种子下载逻辑（RSS
+                  订阅级别可覆盖此默认值）。全局大小上限对所有模式都生效。
+                  <strong style="color: var(--el-color-warning)">
+                    v0.26.0 起：智能模式下，为 RSS 关联过滤规则 =
+                    精准下载，不再附带自动下载免费种子。
+                  </strong>
                 </div>
                 <div
                   v-for="opt in filterModeOptions"

--- a/web/frontend/src/views/SiteDetail.vue
+++ b/web/frontend/src/views/SiteDetail.vue
@@ -781,12 +781,14 @@ function toggleEditRssCustomPath() {
         <el-form-item label="下载模式">
           <el-radio-group v-model="newRss.filter_mode" size="small">
             <el-radio-button label="">跟随全局</el-radio-button>
-            <el-radio-button label="auto_free">自动免费+过滤规则</el-radio-button>
+            <el-radio-button label="auto_free">智能（推荐）</el-radio-button>
             <el-radio-button label="filter_only">仅过滤规则</el-radio-button>
             <el-radio-button label="free_only">仅免费</el-radio-button>
           </el-radio-group>
           <div class="form-tip">
-            控制此 RSS 的下载策略。"跟随全局"表示使用全局设置。全局大小上限对所有模式都生效。
+            控制此 RSS 的下载策略。"跟随全局"使用全局设置。
+            <strong>智能模式</strong>：无过滤规则 → 下载免费种子；有过滤规则 →
+            仅下载匹配的种子。全局大小上限始终生效。
           </div>
         </el-form-item>
         <el-form-item label="下载路径">
@@ -892,12 +894,14 @@ function toggleEditRssCustomPath() {
         <el-form-item label="下载模式">
           <el-radio-group v-model="editingRss.filter_mode" size="small">
             <el-radio-button label="">跟随全局</el-radio-button>
-            <el-radio-button label="auto_free">自动免费+过滤规则</el-radio-button>
+            <el-radio-button label="auto_free">智能（推荐）</el-radio-button>
             <el-radio-button label="filter_only">仅过滤规则</el-radio-button>
             <el-radio-button label="free_only">仅免费</el-radio-button>
           </el-radio-group>
           <div class="form-tip">
-            控制此 RSS 的下载策略。"跟随全局"表示使用全局设置。全局大小上限对所有模式都生效。
+            控制此 RSS 的下载策略。"跟随全局"使用全局设置。
+            <strong>智能模式</strong>：无过滤规则 → 下载免费种子；有过滤规则 →
+            仅下载匹配的种子。全局大小上限始终生效。
           </div>
         </el-form-item>
         <el-form-item label="下载路径">


### PR DESCRIPTION
## Summary
修复 v0.25 遗留问题：设置过滤规则后，非匹配的免费种子仍然被自动下载（用户感觉"filter 和 free 是 OR 而非 AND 关系"）。

## 问题背景
v0.25 的 `auto_free` 模式语义为：过滤规则通道 + 免费通道并行。导致用户反馈：

> 虽然设置了过滤规则 但是实际上还是只要免费的就下载  感觉还是 free和filter是 or 的关系 不是 and 的关系

## 修复：Plan A 智能模式

| RSS 状态 | auto_free 模式行为 |
|---------|-------------------|
| **关联了过滤规则** | ✅ **精准下载**：仅下载匹配规则的种子，非匹配的免费种子不再自动下 |
| **未关联过滤规则** | ✅ 保留 v0.25 行为：自动下载免费种子 |

`filter_only` / `free_only` 模式语义不变。

## 核心实现
- `filter.Service` 新增 `hasAssociatedRules(rssID)` 内部方法
- `Decide` 决策树新增"免费通道门控"：auto_free + 有规则 → 禁用免费兜底
- `DecideWithoutRules`（RSS 无规则路径）行为不变：auto_free 允许免费通道
- `evaluateTestDecision`（规则测试 UI）同步新语义

## 测试
- ✅ 新增 `TestDecide_PlanA_UserReportedBug` — **永久回归守卫**，直接测试用户反馈场景
- ✅ 新增 `TestDecide_AutoFreeMode_NoRules_KeepsFreeChannel` — 守护无规则 RSS 的旧行为
- ✅ 更新 `TestDecide_AutoFreeMode_CombinedChannels` — 非匹配免费应拒绝
- ✅ 重命名 `*_FallsBackToFreeChannel` → `*_RejectsUnderPlanA` 反映新预期
- ✅ 全量回归: `go test ./...` 全通过，`make lint` 0 issues

## 用户影响与 UI 提示
**行为变更**：升级后，已关联过滤规则的 RSS 不再自动下载非匹配的免费种子。这正是用户反馈期望的行为。

如需保留旧的 "OR" 行为：
- 对该 RSS 不关联任何过滤规则（会走免费通道）
- 或在全局/RSS 级别显式选择 `filter_only` / `free_only`

**UI 提示**：
- 过滤规则页：警告条明确说明"关联规则 = 精准下载"
- 全局设置：\`auto_free\` 更名为 "**智能模式（推荐）**"，附带 v0.26.0 行为变更提示
- 站点详情 RSS 编辑：下载模式选项重新命名并说明智能模式逻辑