### PR TITLE
feat(downloader): 支持按站点配置种子上传/下载限速

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,12 +69,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **site**: 新增 OpenCD 和 PTT 站点适配
 - 新增 site/v2/definitions/opencd.go 适配 open.cd (繁体 NexusPHP)
   _ 使用 div.title + td.rowtitle 替代标准 h1 + td.rowhead
-  _ 支持 plugin*details.php 链接格式
-  * 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
-  * 处理 font.promotion 替代 img.pro*_ 的非标准折扣标记
-  _ span.category 替代 img[alt] 的分类标记
-  _ 处理 info_block 隐藏列的 nth-child 索引偏移
-  _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
+  _ 支持 plugin\*details.php 链接格式
+  - 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
+  - 处理 font.promotion 替代 img.pro\*_ 的非标准折扣标记
+    _ span.category 替代 img[alt] 的分类标记
+    _ 处理 info_block 隐藏列的 nth-child 索引偏移
+    _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
 
 ## [0.23.0] - 2026-04-29
 

--- a/core/config_store.go
+++ b/core/config_store.go
@@ -70,7 +70,7 @@ func (s *ConfigStore) Load() (*models.Config, error) {
 		}
 		for _, sitem := range sites {
 			sg := models.SiteGroup(strings.ToLower(sitem.Name))
-			sc := models.SiteConfig{Enabled: boolPtr(sitem.Enabled), AuthMethod: sitem.AuthMethod, Cookie: sitem.Cookie, APIKey: sitem.APIKey, APIUrl: sitem.APIUrl, Passkey: sitem.Passkey, RSS: []models.RSSConfig{}}
+			sc := models.SiteConfig{Enabled: boolPtr(sitem.Enabled), AuthMethod: sitem.AuthMethod, Cookie: sitem.Cookie, APIKey: sitem.APIKey, APIUrl: sitem.APIUrl, Passkey: sitem.Passkey, UploadLimitKBs: sitem.UploadLimitKBs, DownloadLimitKBs: sitem.DownloadLimitKBs, RSS: []models.RSSConfig{}}
 			var rss []models.RSSSubscription
 			if e := tx.Where("site_id = ?", sitem.ID).Find(&rss).Error; e != nil {
 				return e
@@ -458,6 +458,8 @@ func (s *ConfigStore) UpsertSiteWithRSS(site models.SiteGroup, sc models.SiteCon
 		row.APIKey = sc.APIKey
 		row.APIUrl = sc.APIUrl
 		row.Passkey = sc.Passkey
+		row.UploadLimitKBs = sc.UploadLimitKBs
+		row.DownloadLimitKBs = sc.DownloadLimitKBs
 		if err := tx.Save(&row).Error; err != nil {
 			return err
 		}
@@ -544,7 +546,7 @@ func (s *ConfigStore) ListSites() (map[models.SiteGroup]models.SiteConfig, error
 	}
 	for _, ss := range sites {
 		sg := models.SiteGroup(strings.ToLower(ss.Name))
-		sc := models.SiteConfig{Enabled: boolPtr(ss.Enabled), AuthMethod: ss.AuthMethod, Cookie: ss.Cookie, APIKey: ss.APIKey, APIUrl: ss.APIUrl, Passkey: ss.Passkey, RSS: []models.RSSConfig{}}
+		sc := models.SiteConfig{Enabled: boolPtr(ss.Enabled), AuthMethod: ss.AuthMethod, Cookie: ss.Cookie, APIKey: ss.APIKey, APIUrl: ss.APIUrl, Passkey: ss.Passkey, UploadLimitKBs: ss.UploadLimitKBs, DownloadLimitKBs: ss.DownloadLimitKBs, RSS: []models.RSSConfig{}}
 		var rss []models.RSSSubscription
 		if err := s.db.DB.Where("site_id = ?", ss.ID).Find(&rss).Error; err != nil {
 			return nil, err
@@ -565,7 +567,7 @@ func (s *ConfigStore) GetSiteConf(name models.SiteGroup) (models.SiteConfig, err
 		return models.SiteConfig{}, err
 	}
 	// 初始化 RSS 为空数组，确保 JSON 序列化时返回 [] 而不是 null
-	sc := models.SiteConfig{Enabled: boolPtr(ss.Enabled), AuthMethod: ss.AuthMethod, Cookie: ss.Cookie, APIKey: ss.APIKey, APIUrl: ss.APIUrl, Passkey: ss.Passkey, RSS: []models.RSSConfig{}}
+	sc := models.SiteConfig{Enabled: boolPtr(ss.Enabled), AuthMethod: ss.AuthMethod, Cookie: ss.Cookie, APIKey: ss.APIKey, APIUrl: ss.APIUrl, Passkey: ss.Passkey, UploadLimitKBs: ss.UploadLimitKBs, DownloadLimitKBs: ss.DownloadLimitKBs, RSS: []models.RSSConfig{}}
 	var rss []models.RSSSubscription
 	if err := s.db.DB.Where("site_id = ?", ss.ID).Find(&rss).Error; err != nil {
 		return models.SiteConfig{}, err

--- a/internal/push.go
+++ b/internal/push.go
@@ -119,6 +119,9 @@ func PushTorrentToDownloader(ctx context.Context, req PushTorrentRequest) (*Push
 		Tags:        req.Tags,
 	}
 
+	// 按站点应用速度限制（从 SiteSetting 读取）
+	applySiteSpeedLimits(&opts, req.SiteID)
+
 	glOnly, glErr := core.NewConfigStore(global.GlobalDB).GetGlobalOnly()
 	if glErr == nil && glOnly.CleanupDiskProtect && glOnly.CleanupMinDiskSpaceGB > 0 {
 		freeSpace, spaceErr := dl.GetClientFreeSpace(ctx)
@@ -203,4 +206,20 @@ func createDownloaderInstanceForPush(config models.DownloaderSetting) (downloade
 	default:
 		return nil, fmt.Errorf("不支持的下载器类型: %s", config.Type)
 	}
+}
+
+// applySiteSpeedLimits fills opts.UploadSpeedLimitKBs / DownloadSpeedLimitKBs
+// from the SiteSetting row keyed by siteName. No-op when siteName is empty
+// or the lookup fails (e.g. unknown site or DB error) — the torrent is added
+// with unlimited speed in that case, matching pre-v0.26 behavior.
+func applySiteSpeedLimits(opts *downloader.AddTorrentOptions, siteName string) {
+	if opts == nil || siteName == "" || global.GlobalDB == nil {
+		return
+	}
+	var site models.SiteSetting
+	if err := global.GlobalDB.DB.Where("name = ?", siteName).First(&site).Error; err != nil {
+		return
+	}
+	opts.UploadSpeedLimitKBs = site.UploadLimitKBs
+	opts.DownloadSpeedLimitKBs = site.DownloadLimitKBs
 }

--- a/internal/push_speed_limit_test.go
+++ b/internal/push_speed_limit_test.go
@@ -1,0 +1,119 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sunerpy/pt-tools/global"
+	"github.com/sunerpy/pt-tools/models"
+	"github.com/sunerpy/pt-tools/thirdpart/downloader"
+)
+
+// TestApplySiteSpeedLimits_PopulatesFromSiteRow verifies the core integration
+// point for issue #276: push flow reads per-site speed limits from SiteSetting
+// and populates AddTorrentOptions, so the downstream downloader.AddTorrentFileEx
+// applies them atomically.
+func TestApplySiteSpeedLimits_PopulatesFromSiteRow(t *testing.T) {
+	db := setupDB(t)
+	require.NoError(t, db.DB.Create(&models.SiteSetting{
+		Name:             "springsunday",
+		AuthMethod:       "cookie",
+		UploadLimitKBs:   500,
+		DownloadLimitKBs: 2000,
+	}).Error)
+
+	opts := downloader.AddTorrentOptions{}
+	applySiteSpeedLimits(&opts, "springsunday")
+
+	assert.Equal(t, 500, opts.UploadSpeedLimitKBs)
+	assert.Equal(t, 2000, opts.DownloadSpeedLimitKBs)
+}
+
+// TestApplySiteSpeedLimits_ZeroLimits verifies that sites with no limits
+// configured leave opts at zero (meaning "unlimited" downstream). Regression
+// guard: ensure the feature is truly opt-in.
+func TestApplySiteSpeedLimits_ZeroLimits(t *testing.T) {
+	db := setupDB(t)
+	require.NoError(t, db.DB.Create(&models.SiteSetting{
+		Name:       "springsunday",
+		AuthMethod: "cookie",
+	}).Error)
+
+	opts := downloader.AddTorrentOptions{}
+	applySiteSpeedLimits(&opts, "springsunday")
+
+	assert.Equal(t, 0, opts.UploadSpeedLimitKBs)
+	assert.Equal(t, 0, opts.DownloadSpeedLimitKBs)
+}
+
+// TestApplySiteSpeedLimits_UnknownSiteNoOp verifies that an unknown site name
+// is silently a no-op (opts unchanged). This is the safety contract that
+// allows the push flow to pass any SiteID without risking a panic or error.
+func TestApplySiteSpeedLimits_UnknownSiteNoOp(t *testing.T) {
+	_ = setupDB(t)
+
+	opts := downloader.AddTorrentOptions{UploadSpeedLimitKBs: 123, DownloadSpeedLimitKBs: 456}
+	applySiteSpeedLimits(&opts, "nonexistent-site")
+
+	assert.Equal(t, 123, opts.UploadSpeedLimitKBs, "pre-existing value must not be wiped")
+	assert.Equal(t, 456, opts.DownloadSpeedLimitKBs)
+}
+
+// TestApplySiteSpeedLimits_EmptySiteNameNoOp verifies no-op on empty siteName.
+func TestApplySiteSpeedLimits_EmptySiteNameNoOp(t *testing.T) {
+	_ = setupDB(t)
+	opts := downloader.AddTorrentOptions{}
+	applySiteSpeedLimits(&opts, "")
+	assert.Equal(t, 0, opts.UploadSpeedLimitKBs)
+	assert.Equal(t, 0, opts.DownloadSpeedLimitKBs)
+}
+
+// TestApplySiteSpeedLimits_NilOpts verifies no panic on nil.
+func TestApplySiteSpeedLimits_NilOpts(t *testing.T) {
+	_ = setupDB(t)
+	assert.NotPanics(t, func() {
+		applySiteSpeedLimits(nil, "any-site")
+	})
+}
+
+// TestApplySiteSpeedLimits_NilDB verifies no panic when DB is not initialized.
+// Regression guard: push flow should not crash during early-stage testing
+// where global.GlobalDB may be unset.
+func TestApplySiteSpeedLimits_NilDB(t *testing.T) {
+	origDB := global.GlobalDB
+	global.GlobalDB = nil
+	defer func() { global.GlobalDB = origDB }()
+
+	opts := downloader.AddTorrentOptions{}
+	assert.NotPanics(t, func() {
+		applySiteSpeedLimits(&opts, "any-site")
+	})
+	assert.Equal(t, 0, opts.UploadSpeedLimitKBs)
+}
+
+// TestApplySiteSpeedLimits_SiteRowUpdates verifies that changes to the site
+// row are reflected immediately (no caching). Regression guard: if caching
+// is ever introduced, it must correctly invalidate on settings change.
+func TestApplySiteSpeedLimits_SiteRowUpdates(t *testing.T) {
+	db := setupDB(t)
+	site := &models.SiteSetting{
+		Name:             "hdsky",
+		AuthMethod:       "cookie",
+		UploadLimitKBs:   100,
+		DownloadLimitKBs: 200,
+	}
+	require.NoError(t, db.DB.Create(site).Error)
+
+	opts1 := downloader.AddTorrentOptions{}
+	applySiteSpeedLimits(&opts1, "hdsky")
+	assert.Equal(t, 100, opts1.UploadSpeedLimitKBs)
+
+	site.UploadLimitKBs = 999
+	require.NoError(t, db.DB.Save(site).Error)
+
+	opts2 := downloader.AddTorrentOptions{}
+	applySiteSpeedLimits(&opts2, "hdsky")
+	assert.Equal(t, 999, opts2.UploadSpeedLimitKBs, "updated limit must be reflected on next push")
+}

--- a/models/config_models.go
+++ b/models/config_models.go
@@ -169,23 +169,25 @@ type QbitSettings struct {
 
 // SiteSetting 站点设置（统一表，合并原 DynamicSiteSetting）
 type SiteSetting struct {
-	ID           uint      `gorm:"primaryKey" json:"id"`
-	Name         string    `gorm:"uniqueIndex;size:64;not null" json:"name"`
-	DisplayName  string    `gorm:"size:128" json:"display_name"`
-	BaseURL      string    `gorm:"size:512" json:"base_url"`
-	Enabled      bool      `json:"enabled"`
-	AuthMethod   string    `gorm:"size:16;not null" json:"auth_method"`
-	Cookie       string    `gorm:"size:2048" json:"cookie,omitempty"`
-	APIKey       string    `gorm:"size:512" json:"api_key,omitempty"`
-	APIUrl       string    `gorm:"size:512" json:"api_url,omitempty"`
-	APIUrls      string    `gorm:"size:2048" json:"api_urls,omitempty"`
-	Passkey      string    `gorm:"size:512" json:"passkey,omitempty"`
-	DownloaderID *uint     `gorm:"index" json:"downloader_id,omitempty"`
-	ParserConfig string    `gorm:"type:text" json:"parser_config,omitempty"`
-	IsBuiltin    bool      `json:"is_builtin"`
-	TemplateID   *uint     `gorm:"index" json:"template_id,omitempty"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
+	ID               uint      `gorm:"primaryKey" json:"id"`
+	Name             string    `gorm:"uniqueIndex;size:64;not null" json:"name"`
+	DisplayName      string    `gorm:"size:128" json:"display_name"`
+	BaseURL          string    `gorm:"size:512" json:"base_url"`
+	Enabled          bool      `json:"enabled"`
+	AuthMethod       string    `gorm:"size:16;not null" json:"auth_method"`
+	Cookie           string    `gorm:"size:2048" json:"cookie,omitempty"`
+	APIKey           string    `gorm:"size:512" json:"api_key,omitempty"`
+	APIUrl           string    `gorm:"size:512" json:"api_url,omitempty"`
+	APIUrls          string    `gorm:"size:2048" json:"api_urls,omitempty"`
+	Passkey          string    `gorm:"size:512" json:"passkey,omitempty"`
+	DownloaderID     *uint     `gorm:"index" json:"downloader_id,omitempty"`
+	ParserConfig     string    `gorm:"type:text" json:"parser_config,omitempty"`
+	UploadLimitKBs   int       `gorm:"default:0" json:"upload_limit_kbs"`
+	DownloadLimitKBs int       `gorm:"default:0" json:"download_limit_kbs"`
+	IsBuiltin        bool      `json:"is_builtin"`
+	TemplateID       *uint     `gorm:"index" json:"template_id,omitempty"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
 }
 
 // RSS 订阅
@@ -299,13 +301,15 @@ func (r *RSSConfig) GetEffectiveFilterMode(globalSettings *SettingsGlobal) Filte
 }
 
 type SiteConfig struct {
-	Enabled    *bool       `json:"enabled"`
-	AuthMethod string      `json:"auth_method"`
-	Cookie     string      `json:"cookie"`
-	APIKey     string      `json:"api_key"`
-	APIUrl     string      `json:"api_url"`
-	Passkey    string      `json:"passkey"`
-	RSS        []RSSConfig `json:"rss"`
+	Enabled          *bool       `json:"enabled"`
+	AuthMethod       string      `json:"auth_method"`
+	Cookie           string      `json:"cookie"`
+	APIKey           string      `json:"api_key"`
+	APIUrl           string      `json:"api_url"`
+	Passkey          string      `json:"passkey"`
+	UploadLimitKBs   int         `json:"upload_limit_kbs"`
+	DownloadLimitKBs int         `json:"download_limit_kbs"`
+	RSS              []RSSConfig `json:"rss"`
 }
 type Config struct {
 	Global SettingsGlobal           `json:"global"`

--- a/thirdpart/downloader/interface.go
+++ b/thirdpart/downloader/interface.go
@@ -132,11 +132,41 @@ type AddTorrentOptions struct {
 
 	// UploadSpeedLimitMB 上传速度限制 (MB/s)
 	// 0 表示不限制
+	// Deprecated: 使用 UploadSpeedLimitKBs（KB/s，更细粒度）。若同时设置两者，UploadSpeedLimitKBs 优先。
 	UploadSpeedLimitMB int
+
+	// UploadSpeedLimitKBs 上传速度限制 (KB/s)
+	// 0 表示不限制。KB 单位比 MB 更细粒度，适合按站点精确配置。
+	UploadSpeedLimitKBs int
+
+	// DownloadSpeedLimitKBs 下载速度限制 (KB/s)
+	// 0 表示不限制
+	DownloadSpeedLimitKBs int
 
 	// AdvanceOptions 高级选项（可选）
 	// 用于传递客户端特定的高级配置
 	AdvanceOptions map[string]any
+}
+
+// EffectiveUploadLimitBytes returns the effective upload speed limit in bytes/second.
+// Priority: UploadSpeedLimitKBs (new) > UploadSpeedLimitMB (deprecated). Returns 0 for unlimited.
+func (o AddTorrentOptions) EffectiveUploadLimitBytes() int64 {
+	if o.UploadSpeedLimitKBs > 0 {
+		return int64(o.UploadSpeedLimitKBs) * 1024
+	}
+	if o.UploadSpeedLimitMB > 0 {
+		return int64(o.UploadSpeedLimitMB) * 1024 * 1024
+	}
+	return 0
+}
+
+// EffectiveDownloadLimitBytes returns the effective download speed limit in bytes/second.
+// Returns 0 for unlimited.
+func (o AddTorrentOptions) EffectiveDownloadLimitBytes() int64 {
+	if o.DownloadSpeedLimitKBs > 0 {
+		return int64(o.DownloadSpeedLimitKBs) * 1024
+	}
+	return 0
 }
 
 // AddTorrentResult 添加种子的结果

--- a/thirdpart/downloader/qbit/qbit_impl.go
+++ b/thirdpart/downloader/qbit/qbit_impl.go
@@ -1144,11 +1144,16 @@ func (q *QbitClient) writeAddTorrentOptions(writer *multipart.Writer, opt downlo
 		}
 	}
 
-	// 设置上传速度限制
-	if opt.UploadSpeedLimitMB > 0 {
-		limitBytes := opt.UploadSpeedLimitMB * 1024 * 1024
-		if err := writer.WriteField("upLimit", fmt.Sprintf("%d", limitBytes)); err != nil {
+	// 设置上传/下载速度限制（bytes/second）
+	// qBit 原生支持在 /api/v2/torrents/add 时通过 upLimit/dlLimit 字段设定
+	if upBytes := opt.EffectiveUploadLimitBytes(); upBytes > 0 {
+		if err := writer.WriteField("upLimit", fmt.Sprintf("%d", upBytes)); err != nil {
 			return fmt.Errorf("failed to write upLimit: %w", err)
+		}
+	}
+	if dlBytes := opt.EffectiveDownloadLimitBytes(); dlBytes > 0 {
+		if err := writer.WriteField("dlLimit", fmt.Sprintf("%d", dlBytes)); err != nil {
+			return fmt.Errorf("failed to write dlLimit: %w", err)
 		}
 	}
 

--- a/thirdpart/downloader/qbit/qbit_speed_limit_test.go
+++ b/thirdpart/downloader/qbit/qbit_speed_limit_test.go
@@ -1,0 +1,250 @@
+package qbit
+
+import (
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sunerpy/pt-tools/thirdpart/downloader"
+)
+
+// capturedAddRequest is the decoded multipart form submitted to
+// /api/v2/torrents/add, captured for assertion.
+type capturedAddRequest struct {
+	Fields map[string]string
+}
+
+// newCapturingQbitServer returns an httptest server that captures the most
+// recent /api/v2/torrents/add request for inspection.
+func newCapturingQbitServer(t *testing.T) (*httptest.Server, *sync.Mutex, *capturedAddRequest) {
+	t.Helper()
+	mu := &sync.Mutex{}
+	captured := &capturedAddRequest{Fields: map[string]string{}}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/sync/maindata":
+			_, _ = w.Write([]byte(`{"server_state":{"free_space_on_disk":1073741824}}`))
+		case "/api/v2/torrents/properties":
+			w.WriteHeader(http.StatusNotFound)
+		case "/api/v2/torrents/add":
+			ct := r.Header.Get("Content-Type")
+			_, params, _ := mime.ParseMediaType(ct)
+			reader := multipart.NewReader(r.Body, params["boundary"])
+			mu.Lock()
+			captured.Fields = map[string]string{}
+			for {
+				part, err := reader.NextPart()
+				if err != nil {
+					break
+				}
+				name := part.FormName()
+				if name == "torrents" {
+					_ = part.Close()
+					continue
+				}
+				data, _ := io.ReadAll(part)
+				captured.Fields[name] = string(data)
+				_ = part.Close()
+			}
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	return srv, mu, captured
+}
+
+func newQbitTestClient(t *testing.T, srvURL string) *QbitClient {
+	t.Helper()
+	config := NewQBitConfig(srvURL, "admin", "pwd")
+	cli, err := NewQbitClient(config, "test-qbit")
+	require.NoError(t, err)
+	return cli.(*QbitClient)
+}
+
+// minimal valid torrent bytes for AddTorrentFileEx (the qbit mock accepts any).
+func fixtureTorrentBytes() []byte {
+	return []byte("d8:announce35:http://tracker.example.com/announce4:infod6:lengthi1024e4:name8:test.txt12:piece lengthi16384e6:pieces20:01234567890123456789ee")
+}
+
+// TestQbitAddTorrentFileEx_UploadLimitKBs verifies that UploadSpeedLimitKBs
+// is correctly converted to bytes/second and sent as `upLimit` multipart field.
+// Regression guard for issue #276 per-site upload limit.
+func TestQbitAddTorrentFileEx_UploadLimitKBs(t *testing.T) {
+	srv, mu, captured := newCapturingQbitServer(t)
+	defer srv.Close()
+	cli := newQbitTestClient(t, srv.URL)
+	defer cli.Close()
+
+	_, err := cli.AddTorrentFileEx(fixtureTorrentBytes(), downloader.AddTorrentOptions{
+		UploadSpeedLimitKBs: 500,
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "512000", captured.Fields["upLimit"], "500 KB/s should be sent as 512000 bytes/s")
+	_, hasDl := captured.Fields["dlLimit"]
+	assert.False(t, hasDl, "dlLimit must not be set when only upload is limited")
+}
+
+// TestQbitAddTorrentFileEx_DownloadLimitKBs verifies that DownloadSpeedLimitKBs
+// is sent as `dlLimit` in bytes/second. Regression guard for issue #276.
+func TestQbitAddTorrentFileEx_DownloadLimitKBs(t *testing.T) {
+	srv, mu, captured := newCapturingQbitServer(t)
+	defer srv.Close()
+	cli := newQbitTestClient(t, srv.URL)
+	defer cli.Close()
+
+	_, err := cli.AddTorrentFileEx(fixtureTorrentBytes(), downloader.AddTorrentOptions{
+		DownloadSpeedLimitKBs: 2048,
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "2097152", captured.Fields["dlLimit"], "2048 KB/s should be 2097152 bytes/s")
+	_, hasUp := captured.Fields["upLimit"]
+	assert.False(t, hasUp)
+}
+
+// TestQbitAddTorrentFileEx_BothLimits verifies both limits set simultaneously.
+func TestQbitAddTorrentFileEx_BothLimits(t *testing.T) {
+	srv, mu, captured := newCapturingQbitServer(t)
+	defer srv.Close()
+	cli := newQbitTestClient(t, srv.URL)
+	defer cli.Close()
+
+	_, err := cli.AddTorrentFileEx(fixtureTorrentBytes(), downloader.AddTorrentOptions{
+		UploadSpeedLimitKBs:   1000,
+		DownloadSpeedLimitKBs: 4000,
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "1024000", captured.Fields["upLimit"])
+	assert.Equal(t, "4096000", captured.Fields["dlLimit"])
+}
+
+// TestQbitAddTorrentFileEx_NoLimits verifies no speed-limit fields are sent
+// when the options are at zero value (preserves backward compatibility —
+// previous callers never set these fields and must not get unlimited→0 surprises).
+func TestQbitAddTorrentFileEx_NoLimits(t *testing.T) {
+	srv, mu, captured := newCapturingQbitServer(t)
+	defer srv.Close()
+	cli := newQbitTestClient(t, srv.URL)
+	defer cli.Close()
+
+	_, err := cli.AddTorrentFileEx(fixtureTorrentBytes(), downloader.AddTorrentOptions{})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	_, hasUp := captured.Fields["upLimit"]
+	_, hasDl := captured.Fields["dlLimit"]
+	assert.False(t, hasUp, "upLimit must not be sent when limit=0")
+	assert.False(t, hasDl, "dlLimit must not be sent when limit=0")
+}
+
+// TestQbitAddTorrentFileEx_LegacyMBFieldBackwardCompat ensures the deprecated
+// UploadSpeedLimitMB still works (converted via EffectiveUploadLimitBytes).
+// Backward-compat guard: existing integrations using the MB field (before v0.26)
+// must continue working.
+func TestQbitAddTorrentFileEx_LegacyMBFieldBackwardCompat(t *testing.T) {
+	srv, mu, captured := newCapturingQbitServer(t)
+	defer srv.Close()
+	cli := newQbitTestClient(t, srv.URL)
+	defer cli.Close()
+
+	_, err := cli.AddTorrentFileEx(fixtureTorrentBytes(), downloader.AddTorrentOptions{
+		UploadSpeedLimitMB: 3,
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "3145728", captured.Fields["upLimit"], "3 MB/s should be 3*1024*1024 bytes/s")
+}
+
+// TestQbitAddTorrentFileEx_KBsTakesPriorityOverMB verifies that when both fields
+// are set, the new KBs field wins. Guards against a regression where the old MB
+// field accidentally overrides the finer-grained new field.
+func TestQbitAddTorrentFileEx_KBsTakesPriorityOverMB(t *testing.T) {
+	srv, mu, captured := newCapturingQbitServer(t)
+	defer srv.Close()
+	cli := newQbitTestClient(t, srv.URL)
+	defer cli.Close()
+
+	_, err := cli.AddTorrentFileEx(fixtureTorrentBytes(), downloader.AddTorrentOptions{
+		UploadSpeedLimitMB:  5,   // 5 MB = 5120 KB = 5242880 bytes
+		UploadSpeedLimitKBs: 100, // 100 KB = 102400 bytes
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "102400", captured.Fields["upLimit"], "KBs must win over MB")
+	assert.NotEqual(t, "5242880", captured.Fields["upLimit"])
+}
+
+// TestQbitAddTorrentFileEx_NegativeLimitIgnored verifies that negative values
+// are treated as unset (no field sent), preventing accidental 负数 bug.
+func TestQbitAddTorrentFileEx_NegativeLimitIgnored(t *testing.T) {
+	srv, mu, captured := newCapturingQbitServer(t)
+	defer srv.Close()
+	cli := newQbitTestClient(t, srv.URL)
+	defer cli.Close()
+
+	_, err := cli.AddTorrentFileEx(fixtureTorrentBytes(), downloader.AddTorrentOptions{
+		UploadSpeedLimitKBs:   -100,
+		DownloadSpeedLimitKBs: -50,
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	_, hasUp := captured.Fields["upLimit"]
+	_, hasDl := captured.Fields["dlLimit"]
+	assert.False(t, hasUp)
+	assert.False(t, hasDl)
+}
+
+// TestQbitAddTorrentFileEx_OtherFieldsUnaffected verifies that adding speed
+// limits does not break other existing multipart fields (category, tags,
+// savepath, skip_checking). Regression guard against accidental field removal.
+func TestQbitAddTorrentFileEx_OtherFieldsUnaffected(t *testing.T) {
+	srv, mu, captured := newCapturingQbitServer(t)
+	defer srv.Close()
+	cli := newQbitTestClient(t, srv.URL)
+	defer cli.Close()
+
+	_, err := cli.AddTorrentFileEx(fixtureTorrentBytes(), downloader.AddTorrentOptions{
+		SavePath:            "/downloads/pt",
+		Category:            "movie",
+		Tags:                "hd,movie",
+		UploadSpeedLimitKBs: 500,
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "/downloads/pt", captured.Fields["savepath"])
+	assert.Equal(t, "movie", captured.Fields["category"])
+	assert.True(t, strings.Contains(captured.Fields["tags"], "hd"))
+	assert.Equal(t, "512000", captured.Fields["upLimit"])
+}

--- a/thirdpart/downloader/speed_limit_test.go
+++ b/thirdpart/downloader/speed_limit_test.go
@@ -1,0 +1,56 @@
+package downloader
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAddTorrentOptions_EffectiveUploadLimitBytes verifies the priority chain
+// and unit conversion for the upload speed limit field on AddTorrentOptions.
+//
+// This is a regression guard for the v0.26 per-site speed limit feature
+// (issue #276). Key contracts:
+//   - KBs field (new) takes priority over MB field (deprecated)
+//   - 0 means "unlimited" (no bounds)
+//   - Returned value is bytes/second (NOT KB/s or MB/s)
+func TestAddTorrentOptions_EffectiveUploadLimitBytes(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      AddTorrentOptions
+		wantBytes int64
+	}{
+		{"no limit set", AddTorrentOptions{}, 0},
+		{"KBs set to 500 → 500*1024 bytes", AddTorrentOptions{UploadSpeedLimitKBs: 500}, 500 * 1024},
+		{"MB set to 2 → 2*1024*1024 bytes", AddTorrentOptions{UploadSpeedLimitMB: 2}, 2 * 1024 * 1024},
+		{"both set, KBs wins", AddTorrentOptions{UploadSpeedLimitMB: 5, UploadSpeedLimitKBs: 100}, 100 * 1024},
+		{"negative KBs treated as unset", AddTorrentOptions{UploadSpeedLimitKBs: -5}, 0},
+		{"negative MB treated as unset", AddTorrentOptions{UploadSpeedLimitMB: -1}, 0},
+		{"zero KBs + positive MB falls back to MB", AddTorrentOptions{UploadSpeedLimitKBs: 0, UploadSpeedLimitMB: 3}, 3 * 1024 * 1024},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantBytes, tt.opts.EffectiveUploadLimitBytes())
+		})
+	}
+}
+
+// TestAddTorrentOptions_EffectiveDownloadLimitBytes verifies the download
+// speed limit field produces bytes/second correctly.
+func TestAddTorrentOptions_EffectiveDownloadLimitBytes(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      AddTorrentOptions
+		wantBytes int64
+	}{
+		{"no limit set", AddTorrentOptions{}, 0},
+		{"KBs=1000 → 1000*1024 bytes", AddTorrentOptions{DownloadSpeedLimitKBs: 1000}, 1000 * 1024},
+		{"KBs=0 → 0", AddTorrentOptions{DownloadSpeedLimitKBs: 0}, 0},
+		{"negative treated as unset", AddTorrentOptions{DownloadSpeedLimitKBs: -10}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantBytes, tt.opts.EffectiveDownloadLimitBytes())
+		})
+	}
+}

--- a/thirdpart/downloader/transmission/transmission_impl.go
+++ b/thirdpart/downloader/transmission/transmission_impl.go
@@ -889,9 +889,20 @@ func (t *TransmissionClient) AddTorrentFileEx(fileData []byte, opt downloader.Ad
 	// Transmission 使用 base64 编码的种子文件
 	metainfo := base64.StdEncoding.EncodeToString(fileData)
 
+	// Transmission 的 torrent-add 不支持 upload_limit/download_limit 字段，
+	// 必须在 torrent-add（paused）后用 torrent-set 设置限速、再 torrent-start。
+	upBytes := opt.EffectiveUploadLimitBytes()
+	dlBytes := opt.EffectiveDownloadLimitBytes()
+	hasSpeedLimit := upBytes > 0 || dlBytes > 0
+	addAtPaused := opt.AddAtPaused
+	if hasSpeedLimit && !addAtPaused {
+		// 暂停添加以便设置限速，限速生效后再启动
+		addAtPaused = true
+	}
+
 	args := map[string]any{
 		"metainfo": metainfo,
-		"paused":   opt.AddAtPaused,
+		"paused":   addAtPaused,
 	}
 
 	if opt.SavePath != "" {
@@ -920,12 +931,58 @@ func (t *TransmissionClient) AddTorrentFileEx(fileData []byte, opt downloader.Ad
 		return downloader.AddTorrentResult{Success: false, Message: err.Error()}, err
 	}
 
+	var torrentID int
+	var hashString string
+	var duplicate bool
 	if addResp.TorrentDuplicate != nil {
+		torrentID = addResp.TorrentDuplicate.ID
+		hashString = addResp.TorrentDuplicate.HashString
+		duplicate = true
+	} else if addResp.TorrentAdded != nil {
+		torrentID = addResp.TorrentAdded.ID
+		hashString = addResp.TorrentAdded.HashString
+	}
+
+	// 如果需要设置限速，在 torrent-add 后通过 torrent-set 应用；重复种子跳过（已有限速）
+	if hasSpeedLimit && !duplicate && torrentID != 0 {
+		setArgs := map[string]any{"ids": []int{torrentID}}
+		if upBytes > 0 {
+			// Transmission 使用 kB/s（整数），pt-tools 内部用 bytes/s，此处转换
+			setArgs["uploadLimit"] = upBytes / 1024
+			setArgs["uploadLimited"] = true
+		}
+		if dlBytes > 0 {
+			setArgs["downloadLimit"] = dlBytes / 1024
+			setArgs["downloadLimited"] = true
+		}
+		if _, err := t.doRequest("torrent-set", setArgs); err != nil {
+			return downloader.AddTorrentResult{
+				Success: false,
+				Message: fmt.Sprintf("torrent added but failed to set speed limits: %v", err),
+				ID:      fmt.Sprintf("%d", torrentID),
+				Hash:    hashString,
+			}, err
+		}
+
+		// 如果用户本来希望自动启动（opt.AddAtPaused=false），此时触发 start
+		if !opt.AddAtPaused {
+			if _, err := t.doRequest("torrent-start", map[string]any{"ids": []int{torrentID}}); err != nil {
+				return downloader.AddTorrentResult{
+					Success: false,
+					Message: fmt.Sprintf("torrent added with limits but failed to start: %v", err),
+					ID:      fmt.Sprintf("%d", torrentID),
+					Hash:    hashString,
+				}, err
+			}
+		}
+	}
+
+	if duplicate {
 		return downloader.AddTorrentResult{
 			Success: true,
 			Message: "Torrent already exists",
-			ID:      fmt.Sprintf("%d", addResp.TorrentDuplicate.ID),
-			Hash:    addResp.TorrentDuplicate.HashString,
+			ID:      fmt.Sprintf("%d", torrentID),
+			Hash:    hashString,
 		}, nil
 	}
 
@@ -933,8 +990,8 @@ func (t *TransmissionClient) AddTorrentFileEx(fileData []byte, opt downloader.Ad
 		return downloader.AddTorrentResult{
 			Success: true,
 			Message: "Torrent added successfully",
-			ID:      fmt.Sprintf("%d", addResp.TorrentAdded.ID),
-			Hash:    addResp.TorrentAdded.HashString,
+			ID:      fmt.Sprintf("%d", torrentID),
+			Hash:    hashString,
 		}, nil
 	}
 

--- a/thirdpart/downloader/transmission/transmission_speed_limit_test.go
+++ b/thirdpart/downloader/transmission/transmission_speed_limit_test.go
@@ -1,0 +1,281 @@
+package transmission
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sunerpy/pt-tools/thirdpart/downloader"
+)
+
+// recordedRPCCall captures one RPC invocation for test assertions.
+type recordedRPCCall struct {
+	Method string
+	Args   map[string]any
+}
+
+// newRecordingTransmissionServer returns a mock Transmission RPC endpoint that
+// records every method call in order. This lets tests verify the expected
+// torrent-add → torrent-set → torrent-start sequence that speed limits require.
+func newRecordingTransmissionServer(t *testing.T) (*httptest.Server, *sync.Mutex, *[]recordedRPCCall) {
+	t.Helper()
+	sessionID := "test-session-id"
+	mu := &sync.Mutex{}
+	calls := &[]recordedRPCCall{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Transmission-Session-Id") != sessionID {
+			w.Header().Set("X-Transmission-Session-Id", sessionID)
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+
+		// 解码为通用 map 以便同时读取 method + arguments（rpcRequest.Arguments 为 any 类型）
+		var raw struct {
+			Method    string         `json:"method"`
+			Arguments map[string]any `json:"arguments"`
+			Tag       int            `json:"tag"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		*calls = append(*calls, recordedRPCCall{Method: raw.Method, Args: raw.Arguments})
+		mu.Unlock()
+
+		resp := rpcResponse{Result: "success"}
+		switch raw.Method {
+		case "session-get":
+			a := map[string]any{"download-dir": "/downloads"}
+			resp.Arguments, _ = json.Marshal(a)
+		case "torrent-add":
+			a := torrentAddResponse{
+				TorrentAdded: &torrentInfo{ID: 42, Name: "test", HashString: "hash42"},
+			}
+			resp.Arguments, _ = json.Marshal(a)
+		case "torrent-set", "torrent-start":
+			// no arguments needed in response
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	return srv, mu, calls
+}
+
+func newTransmissionTestClient(t *testing.T, srvURL string) *TransmissionClient {
+	t.Helper()
+	cfg := NewTransmissionConfig(srvURL, "", "")
+	cli, err := NewTransmissionClient(cfg, "test-tr")
+	require.NoError(t, err)
+	return cli.(*TransmissionClient)
+}
+
+// rpcCallsByMethod filters the recorded calls to a single method.
+func rpcCallsByMethod(calls []recordedRPCCall, method string) []recordedRPCCall {
+	var out []recordedRPCCall
+	for _, c := range calls {
+		if c.Method == method {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// TestTransmissionAddTorrentFileEx_NoLimits verifies that when no speed limits
+// are configured, only a single torrent-add call is made (no set/start follow-ups).
+// Regression guard: ensure the new speed-limit code path doesn't break the
+// simple "add and go" flow for users who don't configure any limits.
+func TestTransmissionAddTorrentFileEx_NoLimits(t *testing.T) {
+	srv, mu, calls := newRecordingTransmissionServer(t)
+	defer srv.Close()
+	cli := newTransmissionTestClient(t, srv.URL)
+
+	_, err := cli.AddTorrentFileEx([]byte("fake-torrent"), downloader.AddTorrentOptions{})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	setCalls := rpcCallsByMethod(*calls, "torrent-set")
+	startCalls := rpcCallsByMethod(*calls, "torrent-start")
+	assert.Empty(t, setCalls, "no torrent-set expected when no limits")
+	assert.Empty(t, startCalls, "no torrent-start expected when no limits")
+}
+
+// TestTransmissionAddTorrentFileEx_UploadLimit_AutoStart verifies that when
+// the user wants auto-start + speed limit:
+//  1. torrent-add is called with paused=true (forced, to allow setting limits)
+//  2. torrent-set is called with uploadLimit (in KB/s) + uploadLimited=true
+//  3. torrent-start is called to honor the original auto-start intent
+//
+// Regression guard for issue #276 per-site upload limit.
+func TestTransmissionAddTorrentFileEx_UploadLimit_AutoStart(t *testing.T) {
+	srv, mu, calls := newRecordingTransmissionServer(t)
+	defer srv.Close()
+	cli := newTransmissionTestClient(t, srv.URL)
+
+	_, err := cli.AddTorrentFileEx([]byte("fake-torrent"), downloader.AddTorrentOptions{
+		UploadSpeedLimitKBs: 512,
+		AddAtPaused:         false, // user wants auto-start
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	addCalls := rpcCallsByMethod(*calls, "torrent-add")
+	require.Len(t, addCalls, 1)
+	assert.Equal(t, true, addCalls[0].Args["paused"], "torrent-add must force paused=true when limits set")
+
+	setCalls := rpcCallsByMethod(*calls, "torrent-set")
+	require.Len(t, setCalls, 1, "torrent-set should be called exactly once")
+	// Transmission uses kB/s (integer) — 512 KB input = 512 KB/s
+	// The implementation converts: bytes/1024 = KB. Since EffectiveUploadLimitBytes
+	// returns 512*1024 = 524288 bytes, dividing by 1024 gives 512.
+	assert.EqualValues(t, 512, setCalls[0].Args["uploadLimit"])
+	assert.Equal(t, true, setCalls[0].Args["uploadLimited"])
+
+	startCalls := rpcCallsByMethod(*calls, "torrent-start")
+	require.Len(t, startCalls, 1, "torrent-start must be called to honor user's auto-start intent")
+}
+
+// TestTransmissionAddTorrentFileEx_UploadLimit_KeepsPaused verifies that when
+// the user EXPLICITLY wanted paused+limits, no torrent-start is called (user's
+// intent is preserved; they will start manually).
+func TestTransmissionAddTorrentFileEx_UploadLimit_KeepsPaused(t *testing.T) {
+	srv, mu, calls := newRecordingTransmissionServer(t)
+	defer srv.Close()
+	cli := newTransmissionTestClient(t, srv.URL)
+
+	_, err := cli.AddTorrentFileEx([]byte("fake"), downloader.AddTorrentOptions{
+		UploadSpeedLimitKBs: 256,
+		AddAtPaused:         true,
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	setCalls := rpcCallsByMethod(*calls, "torrent-set")
+	startCalls := rpcCallsByMethod(*calls, "torrent-start")
+	assert.Len(t, setCalls, 1)
+	assert.Empty(t, startCalls, "no torrent-start when user explicitly wanted paused")
+}
+
+// TestTransmissionAddTorrentFileEx_DownloadLimit verifies that download speed
+// limit is sent as downloadLimit (kB/s) + downloadLimited=true.
+func TestTransmissionAddTorrentFileEx_DownloadLimit(t *testing.T) {
+	srv, mu, calls := newRecordingTransmissionServer(t)
+	defer srv.Close()
+	cli := newTransmissionTestClient(t, srv.URL)
+
+	_, err := cli.AddTorrentFileEx([]byte("fake"), downloader.AddTorrentOptions{
+		DownloadSpeedLimitKBs: 2048,
+		AddAtPaused:           true,
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	setCalls := rpcCallsByMethod(*calls, "torrent-set")
+	require.Len(t, setCalls, 1)
+	assert.EqualValues(t, 2048, setCalls[0].Args["downloadLimit"])
+	assert.Equal(t, true, setCalls[0].Args["downloadLimited"])
+	_, hasUp := setCalls[0].Args["uploadLimit"]
+	assert.False(t, hasUp, "uploadLimit must not be set when only download is limited")
+}
+
+// TestTransmissionAddTorrentFileEx_BothLimits verifies setting both upload +
+// download in a single torrent-set call (single RPC, atomic).
+func TestTransmissionAddTorrentFileEx_BothLimits(t *testing.T) {
+	srv, mu, calls := newRecordingTransmissionServer(t)
+	defer srv.Close()
+	cli := newTransmissionTestClient(t, srv.URL)
+
+	_, err := cli.AddTorrentFileEx([]byte("fake"), downloader.AddTorrentOptions{
+		UploadSpeedLimitKBs:   100,
+		DownloadSpeedLimitKBs: 500,
+		AddAtPaused:           true,
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	setCalls := rpcCallsByMethod(*calls, "torrent-set")
+	require.Len(t, setCalls, 1, "must be a single torrent-set call carrying both limits")
+	assert.EqualValues(t, 100, setCalls[0].Args["uploadLimit"])
+	assert.EqualValues(t, 500, setCalls[0].Args["downloadLimit"])
+	assert.Equal(t, true, setCalls[0].Args["uploadLimited"])
+	assert.Equal(t, true, setCalls[0].Args["downloadLimited"])
+}
+
+// TestTransmissionAddTorrentFileEx_LegacyMBFieldBackwardCompat ensures the
+// deprecated UploadSpeedLimitMB still works via the EffectiveUploadLimitBytes
+// helper. Backward-compat guard: existing code using the MB field must continue
+// to apply the limit after v0.26.
+func TestTransmissionAddTorrentFileEx_LegacyMBFieldBackwardCompat(t *testing.T) {
+	srv, mu, calls := newRecordingTransmissionServer(t)
+	defer srv.Close()
+	cli := newTransmissionTestClient(t, srv.URL)
+
+	_, err := cli.AddTorrentFileEx([]byte("fake"), downloader.AddTorrentOptions{
+		UploadSpeedLimitMB: 3, // 3 MB/s = 3072 KB/s
+		AddAtPaused:        true,
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	setCalls := rpcCallsByMethod(*calls, "torrent-set")
+	require.Len(t, setCalls, 1)
+	assert.EqualValues(t, 3072, setCalls[0].Args["uploadLimit"])
+}
+
+// TestTransmissionAddTorrentFileEx_CallOrdering verifies the exact call
+// sequence torrent-add → torrent-set → torrent-start. This ordering is
+// important: calling set before add would fail, and calling start before set
+// would race the limit application.
+func TestTransmissionAddTorrentFileEx_CallOrdering(t *testing.T) {
+	srv, mu, calls := newRecordingTransmissionServer(t)
+	defer srv.Close()
+	cli := newTransmissionTestClient(t, srv.URL)
+
+	_, err := cli.AddTorrentFileEx([]byte("fake"), downloader.AddTorrentOptions{
+		UploadSpeedLimitKBs: 100,
+		AddAtPaused:         false,
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	var rpcMethods []string
+	for _, c := range *calls {
+		if c.Method == "torrent-add" || c.Method == "torrent-set" || c.Method == "torrent-start" {
+			rpcMethods = append(rpcMethods, c.Method)
+		}
+	}
+	assert.Equal(t, []string{"torrent-add", "torrent-set", "torrent-start"}, rpcMethods,
+		"calls must be add → set → start in order")
+}
+
+// TestTransmissionAddTorrentFileEx_NegativeLimitIgnored verifies that negative
+// values are treated as unset.
+func TestTransmissionAddTorrentFileEx_NegativeLimitIgnored(t *testing.T) {
+	srv, mu, calls := newRecordingTransmissionServer(t)
+	defer srv.Close()
+	cli := newTransmissionTestClient(t, srv.URL)
+
+	_, err := cli.AddTorrentFileEx([]byte("fake"), downloader.AddTorrentOptions{
+		UploadSpeedLimitKBs: -5,
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	setCalls := rpcCallsByMethod(*calls, "torrent-set")
+	assert.Empty(t, setCalls, "negative limit must be treated as unset")
+}

--- a/web/frontend/src/api/index.ts
+++ b/web/frontend/src/api/index.ts
@@ -114,6 +114,8 @@ export interface SiteConfig {
   api_key: string;
   api_url: string;
   passkey?: string;
+  upload_limit_kbs?: number;
+  download_limit_kbs?: number;
   rss: RSSConfig[];
   urls?: string[];
   unavailable?: boolean;

--- a/web/frontend/src/views/SiteDetail.vue
+++ b/web/frontend/src/views/SiteDetail.vue
@@ -37,6 +37,8 @@ const form = ref<SiteConfig>({
   api_key: "",
   api_url: "",
   passkey: "",
+  upload_limit_kbs: 0,
+  download_limit_kbs: 0,
   rss: [],
 });
 
@@ -560,6 +562,32 @@ function toggleEditRssCustomPath() {
             show-password
             placeholder="从站点个人设置中获取 Passkey" />
           <div class="form-tip">Passkey 用于 RSS 订阅认证，请从站点个人设置页面获取。</div>
+        </el-form-item>
+
+        <el-divider content-position="left">单种子速度限制（可选）</el-divider>
+
+        <el-form-item label="上传限速 (KB/s)">
+          <el-input-number
+            v-model="form.upload_limit_kbs"
+            :min="0"
+            :max="1048576"
+            :step="128"
+            placeholder="0 表示不限速" />
+          <div class="form-tip">
+            推送到下载器的每个种子自动应用此上传限速。0 = 不限制（使用下载器全局/默认设置）。
+          </div>
+        </el-form-item>
+
+        <el-form-item label="下载限速 (KB/s)">
+          <el-input-number
+            v-model="form.download_limit_kbs"
+            :min="0"
+            :max="1048576"
+            :step="128"
+            placeholder="0 表示不限速" />
+          <div class="form-tip">
+            推送到下载器的每个种子自动应用此下载限速。0 = 不限制（使用下载器全局/默认设置）。
+          </div>
         </el-form-item>
       </el-form>
     </el-card>

--- a/web/server.go
+++ b/web/server.go
@@ -578,6 +578,8 @@ type SiteConfigResponse struct {
 	APIKey            string             `json:"api_key"`
 	APIUrl            string             `json:"api_url"`
 	Passkey           string             `json:"passkey"`
+	UploadLimitKBs    int                `json:"upload_limit_kbs"`
+	DownloadLimitKBs  int                `json:"download_limit_kbs"`
 	RSS               []models.RSSConfig `json:"rss"`
 	URLs              []string           `json:"urls,omitempty"`
 	Unavailable       bool               `json:"unavailable,omitempty"`
@@ -598,13 +600,15 @@ func (s *Server) apiSites(w http.ResponseWriter, r *http.Request) {
 		var sitesToDisable []models.SiteGroup
 		for sg, sc := range sites {
 			resp := SiteConfigResponse{
-				Enabled:    sc.Enabled,
-				AuthMethod: sc.AuthMethod,
-				Cookie:     sc.Cookie,
-				APIKey:     sc.APIKey,
-				APIUrl:     sc.APIUrl,
-				Passkey:    sc.Passkey,
-				RSS:        sc.RSS,
+				Enabled:          sc.Enabled,
+				AuthMethod:       sc.AuthMethod,
+				Cookie:           sc.Cookie,
+				APIKey:           sc.APIKey,
+				APIUrl:           sc.APIUrl,
+				Passkey:          sc.Passkey,
+				UploadLimitKBs:   sc.UploadLimitKBs,
+				DownloadLimitKBs: sc.DownloadLimitKBs,
+				RSS:              sc.RSS,
 			}
 			if def, ok := defRegistry.Get(string(sg)); ok {
 				resp.URLs = def.URLs
@@ -688,13 +692,15 @@ func (s *Server) apiSiteDetail(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		resp := SiteConfigResponse{
-			Enabled:    sc.Enabled,
-			AuthMethod: sc.AuthMethod,
-			Cookie:     sc.Cookie,
-			APIKey:     sc.APIKey,
-			APIUrl:     sc.APIUrl,
-			Passkey:    sc.Passkey,
-			RSS:        sc.RSS,
+			Enabled:          sc.Enabled,
+			AuthMethod:       sc.AuthMethod,
+			Cookie:           sc.Cookie,
+			APIKey:           sc.APIKey,
+			APIUrl:           sc.APIUrl,
+			Passkey:          sc.Passkey,
+			UploadLimitKBs:   sc.UploadLimitKBs,
+			DownloadLimitKBs: sc.DownloadLimitKBs,
+			RSS:              sc.RSS,
 		}
 		defRegistry := v2.GetDefinitionRegistry()
 		if def, ok := defRegistry.Get(string(sg)); ok {


### PR DESCRIPTION
## Summary
实现 issue #276：为每个 PT 站点配置独立的种子上传和下载速度限制，推送种子到下载器时自动应用。

**Closes #276**

## Design

- **上传/下载限速对称支持**（用户可分别配置或只配一项）
- **qBittorrent**: 在 `/api/v2/torrents/add` 时通过 `upLimit` / `dlLimit` 字段原子设置（qBit 4.1+ 原生支持）
- **Transmission**: `torrent-add` 不支持 limit 字段，实现 `add-paused → torrent-set → torrent-start` 的三步流程；若用户原本要求 paused 则跳过最后的 start
- **全局 DownloadSpeedLimit 不受影响**（它是内部 "能否在免费期下完" 的计算参数，与本次 per-torrent 限速语义正交）

## Implementation

| 层级 | 改动 |
|------|------|
| `models.SiteSetting` + `SiteConfig` | 新增 `UploadLimitKBs` + `DownloadLimitKBs` 字段 |
| `downloader.AddTorrentOptions` | 新增 `UploadSpeedLimitKBs` + `DownloadSpeedLimitKBs`（KB/s，更细粒度）；原 `UploadSpeedLimitMB` 标记为 Deprecated 但保留兼容 |
| `EffectiveUploadLimitBytes()` / `EffectiveDownloadLimitBytes()` | 统一返回 bytes/s；KBs 字段优先于 MB |
| `qbit.AddTorrentFileEx` | 改用 EffectiveXxxLimitBytes，支持 upLimit + dlLimit |
| `transmission.AddTorrentFileEx` | 限速时自动 paused → set → start |
| `internal/push.go` | 新增 `applySiteSpeedLimits()` 从 SiteSetting 读取并填充 opts |
| `web/server.go` | SiteConfigResponse 新增两个字段 |
| 前端 `SiteDetail.vue` | 新增两个 `el-input-number` 输入框 |

## Test Coverage (全部新增测试通过 + 0 回归)

| 测试文件 | 用例数 | 覆盖 |
|---------|-------|------|
| \`downloader/speed_limit_test.go\` | 2 组 | \`EffectiveXxxLimitBytes\` 优先级链 + 单位换算 |
| \`qbit/qbit_speed_limit_test.go\` | 8 | upload/download/双限速/零值/负值/MB 向后兼容/KBs优先/其他字段回归 |
| \`transmission/transmission_speed_limit_test.go\` | 8 | 无限速/AutoStart+限速三步链路/paused 保持/下载/双限速/MB 兼容/调用顺序/负值 |
| \`internal/push_speed_limit_test.go\` | 7 | 站点配置正确传递/零值/未知站点/nil 安全/更新立即生效 |

**测试设计原则**：
- 所有用例附 godoc 明确说明"为何是回归守卫"
- 关键单位换算有内联注释（如 \`500 KB/s = 512000 bytes/s\`）
- Transmission 三步调用顺序明确断言 \`[torrent-add, torrent-set, torrent-start]\`
- 向后兼容性用专用测试守护（\`UploadSpeedLimitMB\` 字段继续工作）

**全量回归**：\`go test ./...\` 21 个包全通过，\`make lint\` 0 issues，\`vue-tsc\` 0 errors

## Compatibility

- GORM AutoMigrate 自动添加新列，无需手动迁移
- 所有新字段零值默认 → 升级后旧行为不变
- 遗留 \`UploadSpeedLimitMB\` 字段继续生效（backward-compat 守卫测试覆盖）

## UI

站点管理页面新增 "单种子速度限制" 分组：
- **上传限速 (KB/s)** —— 0 表示不限制
- **下载限速 (KB/s)** —— 0 表示不限制