### PR TITLE
fix(ci): 修复站点请求 Issue 附件检查遗漏 comment 场景

### DIFF
--- a/.github/workflows/issue-attachment-check.yml
+++ b/.github/workflows/issue-attachment-check.yml
@@ -3,24 +3,49 @@ name: Check Site Request Attachment
 on:
   issues:
     types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
 
 jobs:
   check-attachment:
-    if: contains(github.event.issue.title, '新站点请求')
+    # Filter: only run for site-request issues. `issue_comment` event puts the
+    # issue payload under `github.event.issue`, same key as `issues` event.
+    if: contains(github.event.issue.title, '新站点请求') && !github.event.issue.pull_request
     runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:
-      - name: Check for ZIP attachment
+      - name: Check for ZIP attachment in body or comments
         uses: actions/github-script@v8
         with:
           script: |
-            const body = context.payload.issue.body || '';
-            const hasAttachment = body.includes('user-attachments/files') || body.includes('user-attachments/assets');
             const issueNumber = context.payload.issue.number;
+            const body = context.payload.issue.body || '';
+            const ATTACHMENT_PATTERNS = ['user-attachments/files', 'user-attachments/assets'];
+
+            const bodyHasAttachment = ATTACHMENT_PATTERNS.some((p) => body.includes(p));
+
+            // On `issue_comment` events, also scan ALL comments (not just the triggering one)
+            // so that edits/new comments can correctly flip the state from missing to present.
+            let commentsHaveAttachment = false;
+            if (context.eventName === 'issue_comment' || !bodyHasAttachment) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+              commentsHaveAttachment = comments.some((c) => {
+                const text = c.body || '';
+                // Skip our own reminder comment to avoid self-detection
+                if (text.includes('<!-- attachment-check -->')) return false;
+                return ATTACHMENT_PATTERNS.some((p) => text.includes(p));
+              });
+            }
+
+            const hasAttachment = bodyHasAttachment || commentsHaveAttachment;
 
             if (hasAttachment) {
-              // Remove the missing-attachment label if it exists (e.g., user edited to add ZIP)
               try {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
@@ -29,12 +54,13 @@ jobs:
                   name: 'missing-attachment',
                 });
               } catch (e) {
-                // Label doesn't exist, ignore
+                // Label doesn't exist — nothing to remove.
               }
               return;
             }
 
-            // Add label
+            // No attachment anywhere — add label (no-op if already present)
+            // AND post the reminder comment (once).
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -42,18 +68,18 @@ jobs:
               labels: ['missing-attachment'],
             });
 
-            // Check if we already commented (avoid duplicate comments on edit)
-            const comments = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
+              per_page: 100,
             });
-            const botComment = comments.data.find(
-              (c) => c.user.type === 'Bot' && c.body.includes('<!-- attachment-check -->')
+            const alreadyReminded = comments.some(
+              (c) => c.user.type === 'Bot' && (c.body || '').includes('<!-- attachment-check -->')
             );
-            if (botComment) return;
+            if (alreadyReminded) return;
 
-            // Post reminder comment
+            const opener = context.payload.issue.user.login;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -62,27 +88,27 @@ jobs:
                 '<!-- attachment-check -->',
                 '⚠️ **缺少采集数据 ZIP 文件 / Missing collected data ZIP file**',
                 '',
-                '你好 @' + context.payload.issue.user.login + '，',
+                '你好 @' + opener + '，',
                 '',
                 '感谢你提交新站点请求！但我们没有在 Issue 中找到采集数据的 ZIP 附件，**没有 ZIP 文件将无法适配站点**。',
                 '',
                 '请按以下步骤补充：',
                 '1. 使用 [PT Tools Helper 浏览器扩展](https://github.com/sunerpy/pt-tools/releases) 采集站点数据',
                 '2. 点击「📦 导出 ZIP」下载采集文件',
-                '3. **编辑此 Issue**，将 ZIP 文件拖拽上传到正文中',
+                '3. **编辑此 Issue** 正文或**发表一条新评论**，将 ZIP 文件拖拽上传',
                 '',
                 '上传后系统会自动移除此提醒。',
                 '',
                 '---',
                 '',
-                'Hi @' + context.payload.issue.user.login + ',',
+                'Hi @' + opener + ',',
                 '',
                 'Thanks for submitting a new site request! However, we could not find a collected data ZIP attachment in this issue. **The ZIP file is required for site adaptation.**',
                 '',
                 'Please:',
                 '1. Use the [PT Tools Helper browser extension](https://github.com/sunerpy/pt-tools/releases) to collect site data',
                 '2. Click "📦 Export ZIP" to download the collected file',
-                '3. **Edit this issue** and drag-and-drop the ZIP file into the body',
+                '3. **Edit this issue body** or **post a new comment** with the ZIP file attached',
                 '',
                 'The reminder will be automatically removed once the attachment is detected.',
               ].join('\n'),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,12 +128,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **site**: 新增 OpenCD 和 PTT 站点适配
 - 新增 site/v2/definitions/opencd.go 适配 open.cd (繁体 NexusPHP)
   _ 使用 div.title + td.rowtitle 替代标准 h1 + td.rowhead
-  _ 支持 plugin*details.php 链接格式
-  * 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
-  * 处理 font.promotion 替代 img.pro*_ 的非标准折扣标记
-  _ span.category 替代 img[alt] 的分类标记
-  _ 处理 info_block 隐藏列的 nth-child 索引偏移
-  _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
+  _ 支持 plugin\*details.php 链接格式
+  - 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
+  - 处理 font.promotion 替代 img.pro\*_ 的非标准折扣标记
+    _ span.category 替代 img[alt] 的分类标记
+    _ 处理 info_block 隐藏列的 nth-child 索引偏移
+    _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
 
 ## [0.23.0] - 2026-04-29
 


### PR DESCRIPTION
## Summary
修复 [Issue #279](https://github.com/sunerpy/pt-tools/issues/279) 反映的 bug：用户在评论中上传 ZIP 附件后，\`missing-attachment\` 标签未被自动移除。

**Closes #279**

## Root Cause
现有 \`issue-attachment-check.yml\` 只监听 \`issues.opened/edited\`，只检查 \`issue.body\` 是否含附件链接。当用户以**评论形式**上传 ZIP 时：
- 事件未触发（没有 issue_comment 触发器）
- 即使触发也不会扫描评论内容

## Fix

1. **新增 \`issue_comment.created/edited\` 触发器** —— 评论编辑也会重新检查
2. **扫描范围扩展** —— Issue body + 所有评论（排除 bot 自己的提醒评论，避免自匹配）
3. **提醒文案更新** —— 明确告知用户"编辑 Issue 正文 **或** 发表新评论"都可以上传
4. **PR 评论守卫** —— \`!github.event.issue.pull_request\` 防止 \`issue_comment\` 事件意外处理 PR 评论

## Test Plan

- [x] YAML 语法通过（node js-yaml 校验）
- [ ] 手动测试：编辑一个测试 issue 的 body → 标签被移除
- [ ] 手动测试：添加评论（含 ZIP 链接）→ 标签被移除
- [ ] 手动测试：修改评论（删除附件）→ 标签重新添加

## Post-Merge Action
手动清理 Issue #279 的 \`missing-attachment\` 标签（合并后下次评论会自动触发，但为了即时响应用户，我会手动清除一次）。