### PR TITLE
feat(site): 新增 Farmm (pt.0ff.cc) 站点适配

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,12 +134,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **site**: 新增 OpenCD 和 PTT 站点适配
 - 新增 site/v2/definitions/opencd.go 适配 open.cd (繁体 NexusPHP)
   _ 使用 div.title + td.rowtitle 替代标准 h1 + td.rowhead
-  _ 支持 plugin*details.php 链接格式
-  * 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
-  * 处理 font.promotion 替代 img.pro*_ 的非标准折扣标记
-  _ span.category 替代 img[alt] 的分类标记
-  _ 处理 info_block 隐藏列的 nth-child 索引偏移
-  _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
+  _ 支持 plugin\*details.php 链接格式
+  - 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
+  - 处理 font.promotion 替代 img.pro\*_ 的非标准折扣标记
+    _ span.category 替代 img[alt] 的分类标记
+    _ 处理 info_block 隐藏列的 nth-child 索引偏移
+    _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
 
 ## [0.23.0] - 2026-04-29
 

--- a/docs/sites.md
+++ b/docs/sites.md
@@ -1,37 +1,38 @@
 ## 支持站点
 
-当前已适配 **30** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
+当前已适配 **31** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
 
-### NexusPHP 系列（26）
+### NexusPHP 系列（27）
 
-| 站点             | 认证方式 | 支持功能                      | 适配情况 | 备注                          |
-| ---------------- | -------- | ----------------------------- | -------- | ----------------------------- |
-| **HDSky**        | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 完全适配                      |
-| **SpringSunday** | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 完全适配                      |
-| **NovaHD**       | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **OpenCD**       | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（繁体界面/自定义模板） |
-| **PTT (pttime)** | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（PTT-NP 分支）         |
-| **AGSVPT**       | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **XingYunGe**    | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **HDHome**       | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **HDTime**       | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **HDFans**       | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **LemonHD**      | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **BTSCHOOL**     | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **BYRPT**        | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **Audiences**    | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **CarPT**        | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **52PT**         | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **HXPT**         | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **MyPTCC**       | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **PTLover**      | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **PTSKIT**       | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **RainGFH**      | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **SoulVoice**    | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **TMPT**         | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **UBits**        | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **1PTBar**       | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
-| **lajidui**      | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| 站点                  | 认证方式 | 支持功能                      | 适配情况 | 备注                          |
+| --------------------- | -------- | ----------------------------- | -------- | ----------------------------- |
+| **HDSky**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 完全适配                      |
+| **SpringSunday**      | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 完全适配                      |
+| **NovaHD**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **OpenCD**            | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（繁体界面/自定义模板） |
+| **PTT (pttime)**      | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（PTT-NP 分支）         |
+| **Farmm (pt.0ff.cc)** | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（基本信息行内嵌大小）  |
+| **AGSVPT**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **XingYunGe**         | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **HDHome**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **HDTime**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **HDFans**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **LemonHD**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **BTSCHOOL**          | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **BYRPT**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **Audiences**         | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **CarPT**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **52PT**              | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **HXPT**              | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **MyPTCC**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **PTLover**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **PTSKIT**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **RainGFH**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **SoulVoice**         | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **TMPT**              | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **UBits**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **1PTBar**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
+| **lajidui**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
 
 ### 其他架构（4）
 

--- a/site/v2/definitions/pt0ffcc.go
+++ b/site/v2/definitions/pt0ffcc.go
@@ -1,0 +1,186 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+// PT0FFCCDefinition is the site definition for Farmm (pt.0ff.cc).
+// The site is a standard NexusPHP template derived from CHD/scenetorrents with
+// two significant deviations:
+//   - Detail page: size is inline inside the `基本信息` row (not its own rowhead row).
+//     The SizeRegex pattern extracts from the value cell's HTML.
+//   - Userinfo page: HDSky-style combined `传输` row packs ratio + uploaded + downloaded
+//     in a single cell; selectors use regex to parse the combined HTML.
+var PT0FFCCDefinition = &v2.SiteDefinition{
+	ID:             "pt0ffcc",
+	Name:           "Farmm",
+	Aka:            []string{"0ff", "pt.0ff.cc", "种子农场"},
+	Description:    "Farmm 种子农场（pt.0ff.cc）",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://pt.0ff.cc/"},
+	FaviconURL:     "https://pt.0ff.cc/favicon.ico",
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "seeding", "leeching", "bonus"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields: []string{
+					"name", "uploaded", "downloaded", "ratio", "levelName", "joinTime",
+				},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			"id": {
+				Selector: []string{
+					"a[href*='userdetails.php'][class*='Name']",
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php']",
+				},
+				Attr:    "href",
+				Filters: []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{
+					"h1 > span.nowrap > b",
+					"h1 span.nowrap b",
+					"a[href*='userdetails.php'][class*='Name'] b",
+					"a[href*='userdetails.php'][class*='Name']",
+				},
+			},
+			// 传输 row (HDSky-style combined cell) — regex extracts uploaded/downloaded/ratio.
+			// Anchored via \b to distinguish 上传量 from 实际上传量 / 下载量 from 实际下载量.
+			"uploaded": {
+				Selector: []string{
+					"td.rowhead:contains('传输') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('上传量') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:^|[^实])上传量</strong>[：:\s]*\s*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"downloaded": {
+				Selector: []string{
+					"td.rowhead:contains('传输') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('下载量') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:^|[^实])下载量</strong>[：:\s]*\s*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"ratio": {
+				Selector: []string{
+					"td.rowhead:contains('传输') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('分享率') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`分享率</strong>[：:\s]*\s*(?:<font[^>]*>)?([\d.,]+|∞|无限|Inf)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"levelName": {
+				Selector: []string{
+					"table.main td.rowhead:contains('等级') + td img",
+					"td.rowhead:contains('等级') + td > img",
+					"td.rowhead:contains('Class') + td > img",
+				},
+				Attr: "title",
+			},
+			"joinTime": {
+				Selector: []string{
+					"td.rowhead:contains('加入日期') + td span[title]",
+					"td.rowhead:contains('加入日期') + td",
+				},
+				Attr: "title",
+				Filters: []v2.Filter{
+					{Name: "split", Args: []any{" (", 0}},
+					{Name: "parseTime"},
+				},
+			},
+			// 魔力值 lives in logged-in user's #info_block, or (on own profile) a separate row
+			"bonus": {
+				Selector: []string{
+					"td.rowhead:contains('魔力值') + td",
+					"#info_block",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`魔力值[^:：]*[:：]\s*(?:</?[^>]+>)*\s*([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowup"[^>]*/?>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowdown"[^>]*/?>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		// Standard NexusPHP row structure with nested torrentname
+		TableRows: "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:     "table.torrentname a[href*='details.php']",
+		TitleLink: "table.torrentname a[href*='details.php']",
+		Subtitle:  "table.torrentname td.embedded",
+		// 9-column table: 1=category 2=title 3=comments 4=time 5=size 6=seeders 7=leechers 8=snatched 9=uploader
+		Category:           "td:nth-child(1) a[href*='?cat=']",
+		UploadTime:         "td:nth-child(4) span[title]",
+		Size:               "td:nth-child(5)",
+		Seeders:            "td:nth-child(6)",
+		Leechers:           "td:nth-child(7)",
+		Snatched:           "td:nth-child(8)",
+		DiscountIcon:       "table.torrentname img.pro_free, table.torrentname img.pro_free2up, table.torrentname img.pro_2up, table.torrentname img.pro_50pctdown, table.torrentname img.pro_50pctdown2up, table.torrentname img.pro_30pctdown, table.torrentname img.pro_twoupfree, table.torrentname img.pro_twouphalfdown",
+		DetailDownloadLink: "td.rowhead:contains('下载') + td a[href*='download.php'], a.index[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords:       []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		TitleSelector:    "h1#top, h1",
+		DiscountSelector: "h1#top b font[class], h1 b font[class], h1#top font[class], h1 font[class]",
+		EndTimeSelector:  "h1#top span[title], h1 span[title]",
+		// Size is inline in 基本信息 cell; SizeRegex pulls it from that cell's text.
+		// Parser gets .Next() of SizeSelector match, so select the label cell.
+		SizeSelector: "td.rowhead:contains('基本信息')",
+		SizeRegex:    `大小[：:]\s*(?:</?b>)*\s*([\d.]+)\s*(GB|MB|KB|TB)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(PT0FFCCDefinition)
+}

--- a/site/v2/definitions/pt0ffcc_fixture_test.go
+++ b/site/v2/definitions/pt0ffcc_fixture_test.go
@@ -1,0 +1,238 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "pt0ffcc",
+		Search:   testPT0FFCCSearch,
+		Detail:   testPT0FFCCDetail,
+		UserInfo: testPT0FFCCUserInfo,
+	})
+}
+
+const pt0ffccSearchFixture = `<html><body>
+<table class="torrents">
+<tbody>
+<tr>
+  <td><a href="?cat=401" title="Movies|电影"><img alt="Movies|电影" /></a></td>
+  <td>
+    <table class="torrentname"><tr>
+      <td class="embedded"><img class="nexus-lazy-load" data-src="pic/cover.jpg" /></td>
+      <td class="embedded">
+        <a href="details.php?id=38742"><b>Tampopo.1985.CC.BluRay.1080p.x264.FLAC.1.0-CMCT</b></a>
+        <img class="pro_free" src="pic/trans.gif" alt="Free" />
+        <span title="通过"><svg></svg></span>
+        <br/>蒲公英 / Dandelion / Tampopo [CC收藏版] [日语] [简繁中字]
+      </td>
+      <td class="embedded">
+        <a href="download.php?id=38742"><img src="pic/dl.gif" alt="dl"/></a>
+      </td>
+    </tr></table>
+  </td>
+  <td class="rowfollow">0</td>
+  <td class="rowfollow"><span title="2025-07-02 14:27:28">10月3天前</span></td>
+  <td class="rowfollow">9.07<br/>GB</td>
+  <td class="rowfollow"><a href="#seeders"><b>50</b></a></td>
+  <td class="rowfollow"><a href="#leechers"><b>0</b></a></td>
+  <td class="rowfollow"><a href="viewsnatches.php?id=38742"><b>269</b></a></td>
+  <td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr>
+  <td><a href="?cat=401" title="Movies|电影"><img alt="Movies|电影" /></a></td>
+  <td>
+    <table class="torrentname"><tr>
+      <td class="embedded"><img class="nexus-lazy-load" data-src="pic/cover2.jpg" /></td>
+      <td class="embedded">
+        <a href="details.php?id=38743"><b>Normal.Movie.2025.1080p</b></a>
+        <br/>普通电影
+      </td>
+      <td class="embedded">
+        <a href="download.php?id=38743"><img src="pic/dl.gif" alt="dl"/></a>
+      </td>
+    </tr></table>
+  </td>
+  <td class="rowfollow">1</td>
+  <td class="rowfollow"><span title="2025-10-01 08:00:00">3天前</span></td>
+  <td class="rowfollow">4.20<br/>GB</td>
+  <td class="rowfollow"><a href="#seeders"><b>12</b></a></td>
+  <td class="rowfollow"><a href="#leechers"><b>3</b></a></td>
+  <td class="rowfollow"><a href="viewsnatches.php?id=38743"><b>45</b></a></td>
+  <td class="rowfollow"><a href="userdetails.php?id=100">testuploader</a></td>
+</tr>
+</tbody>
+</table>
+</body></html>`
+
+const pt0ffccDetailFixture = `<html><body>
+<h1 align='center' id='top'>Tampopo.1985.CC.BluRay.1080p.x264.FLAC.1.0-CMCT&nbsp;
+  <b>[<font class='free'>免费</font>]</b>
+  <span title="通过"><svg></svg></span>
+</h1>
+<table>
+  <tr>
+    <td class="rowhead">下载</td>
+    <td class="rowfollow">
+      <a class="index" href="download.php?id=38742">Tampopo.1985.torrent</a>
+      <span title="2025-07-02 14:27:28">10月3天前</span>
+    </td>
+  </tr>
+  <tr>
+    <td class="rowhead">副标题</td>
+    <td class="rowfollow">蒲公英 / Dandelion / Tampopo [CC收藏版] [日语] [简繁中字]</td>
+  </tr>
+  <tr>
+    <td class="rowhead">基本信息</td>
+    <td class="rowfollow">
+      <b><b>大小：</b></b>9.07 GB&nbsp;&nbsp;&nbsp;
+      <b>类型:</b>&nbsp;Movies|电影&nbsp;&nbsp;&nbsp;
+      <b>地区: </b>日本 (JPN)&nbsp;&nbsp;&nbsp;
+      <b>分辨率: </b>1080P&nbsp;&nbsp;&nbsp;
+      <b>媒介: </b>Encode
+    </td>
+  </tr>
+</table>
+</body></html>`
+
+const pt0ffccIndexFixture = `<html><body>
+<div id="info_block">
+  欢迎回来, <a href="userdetails.php?id=12189" class="User_Name"><b>TestViewer</b></a>
+  <img class="arrowup" src="pic/arrowup.gif" alt="Torrents seeding" />1
+  <img class="arrowdown" src="pic/arrowdown.gif" alt="Torrents leeching" />0
+  <font class="color_bonus">魔力值</font>[<a href="mybonus.php">使用</a>]: 4,526.9
+</div>
+</body></html>`
+
+const pt0ffccUserdetailsFixture = `<html><body>
+<h1 style='margin:0px'><span class="nowrap"><b>testuser</b></span><img src="pic/flag/CN.gif" alt="CN" /></h1>
+<p>(加入好友列表) - (加入黑名单)</p>
+<table class="main" width="1200">
+<table border="1">
+<tr>
+  <td class="rowhead">加入日期</td>
+  <td class="rowfollow">2025-08-16 13:36:23 (<span title="2025-08-16 13:36:23">2月前</span>)</td>
+</tr>
+<tr>
+  <td class="rowhead">传输</td>
+  <td class="rowfollow">
+    <strong>分享率</strong>: <font color="">24.360</font>（<strong>实际分享率</strong>：10.637）<br/>
+    <strong>上传量</strong>: 55.343 TB&nbsp;&nbsp;&nbsp;<strong>下载量</strong>: 2.272 TB<br/>
+    <strong>实际上传量</strong>: 29.358 TB&nbsp;&nbsp;&nbsp;<strong>实际下载量</strong>: 2.760 TB&nbsp;&nbsp;&nbsp;
+    实际上传/下载量 (仅用于记录, 不参与分享率计算)
+  </td>
+</tr>
+<tr>
+  <td class="rowhead">等级</td>
+  <td class="rowfollow"><img alt="Insane User" title="Insane User" src="pic/insane.gif" /></td>
+</tr>
+</table>
+</table>
+</body></html>`
+
+func getPT0FFCCDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("pt0ffcc")
+	require.True(t, ok, "pt0ffcc definition not found")
+	return def
+}
+
+func testPT0FFCCSearch(t *testing.T) {
+	def := getPT0FFCCDef(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(pt0ffccSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{
+		BaseURL:   server.URL,
+		Cookie:    "test_cookie=1",
+		Selectors: def.Selectors,
+	})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: "GET"})
+	require.NoError(t, err)
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 2, "should parse 2 torrent rows")
+
+	free := items[0]
+	assert.Equal(t, "38742", free.ID)
+	assert.Equal(t, "Tampopo.1985.CC.BluRay.1080p.x264.FLAC.1.0-CMCT", free.Title)
+	assert.Equal(t, v2.DiscountFree, free.DiscountLevel)
+	assert.Equal(t, 50, free.Seeders)
+	assert.Equal(t, 0, free.Leechers)
+	assert.Equal(t, 269, free.Snatched)
+	assert.True(t, free.SizeBytes > 0, "size must be parsed")
+
+	normal := items[1]
+	assert.Equal(t, "38743", normal.ID)
+	assert.Equal(t, v2.DiscountNone, normal.DiscountLevel)
+}
+
+func testPT0FFCCDetail(t *testing.T) {
+	def := getPT0FFCCDef(t)
+	parser := v2.NewNexusPHPParserFromDefinition(def)
+
+	doc := FixtureDoc(t, "pt0ffcc_detail", pt0ffccDetailFixture)
+	info := parser.ParseAll(doc.Selection)
+
+	assert.Equal(t, v2.DiscountFree, info.DiscountLevel, "should parse FREE from h1 font.free")
+	assert.InDelta(t, 9.07*1024, info.SizeMB, 1.0, "SizeRegex must extract 9.07 GB from 基本信息 cell")
+	assert.False(t, info.HasHR, "detail page has no H&R marker")
+}
+
+func testPT0FFCCUserInfo(t *testing.T) {
+	def := getPT0FFCCDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	t.Run("IndexPage_LoggedInUser", func(t *testing.T) {
+		doc := FixtureDoc(t, "pt0ffcc_index", pt0ffccIndexFixture)
+		assert.Equal(t, "12189", driver.ExtractFieldValuePublic(doc, def.UserInfo.Selectors["id"]))
+		assert.Equal(t, "TestViewer", driver.ExtractFieldValuePublic(doc, def.UserInfo.Selectors["name"]))
+		assert.Equal(t, "1", driver.ExtractFieldValuePublic(doc, def.UserInfo.Selectors["seeding"]))
+		assert.Equal(t, "0", driver.ExtractFieldValuePublic(doc, def.UserInfo.Selectors["leeching"]))
+	})
+
+	t.Run("UserdetailsPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "pt0ffcc_userdetails", pt0ffccUserdetailsFixture)
+		assert.Equal(t, "testuser", driver.ExtractFieldValuePublic(doc, def.UserInfo.Selectors["name"]))
+		assert.Equal(t, "Insane User", driver.ExtractFieldValuePublic(doc, def.UserInfo.Selectors["levelName"]))
+
+		// Each regex-driven field must produce a non-empty, well-formed value.
+		// Specifically guards against the 上传量 vs 实际上传量 ambiguity.
+		for _, field := range []string{"uploaded", "downloaded", "ratio", "joinTime"} {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q missing", field)
+				got := driver.ExtractFieldValuePublic(doc, sel)
+				assert.NotEmpty(t, got, "field %q must be parsed", field)
+			})
+		}
+	})
+}
+
+func TestPT0FFCC_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":      pt0ffccSearchFixture,
+		"detail":      pt0ffccDetailFixture,
+		"index":       pt0ffccIndexFixture,
+		"userdetails": pt0ffccUserdetailsFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			RequireNoSecrets(t, name, data)
+		})
+	}
+}

--- a/tools/browser-extension/src/core/constants.ts
+++ b/tools/browser-extension/src/core/constants.ts
@@ -237,6 +237,15 @@ export const KNOWN_SITES: KnownSite[] = [
     syncField: "cookie",
   },
   {
+    id: "pt0ffcc",
+    name: "Farmm",
+    domains: ["pt.0ff.cc"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
+  {
     id: "ptlover",
     name: "PTLover",
     domains: ["www.ptlover.cc"],


### PR DESCRIPTION
## Summary
实现 [Issue #279](https://github.com/sunerpy/pt-tools/issues/279) 站点请求。新增 Farmm (pt.0ff.cc) NexusPHP 站点适配。

**Closes #279**

## Non-Standard Patterns Handled

Farmm 基于 CHD/scenetorrents 模板衍生，有两处关键偏离：

### 1. 详情页 size 内联于「基本信息」行
标准 NexusPHP 为 size 配独立 \`td.rowhead:contains('大小')\` 行，此站点将 size + 类型 + 地区 + 分辨率等字段**全部塞进「基本信息」cell** 内，用 \`<b>\` 分隔：
\`\`\`html
<td class="rowhead">基本信息</td>
<td class="rowfollow">
  <b><b>大小：</b></b>9.07 GB&nbsp;&nbsp;&nbsp;
  <b>类型:</b> Movies|电影 ...
</td>
\`\`\`
**解法**：\`SizeSelector\` 指向 \`基本信息\` label cell，\`SizeRegex\` 从该 cell 文本抽取数值+单位。

### 2. 用户详情页「传输」行 HDSky 风格
\`分享率\`、\`上传量\`、\`下载量\` 三个字段打包在同一 \`td.rowfollow\`：
\`\`\`html
<td class="rowhead">传输</td>
<td class="rowfollow">
  <strong>分享率</strong>: 24.360<br/>
  <strong>上传量</strong>: 55.343 TB&nbsp;<strong>下载量</strong>: 2.272 TB<br/>
  <strong>实际上传量</strong>: 29.358 TB&nbsp;<strong>实际下载量</strong>: 2.760 TB
</td>
\`\`\`
**解法**：正则表达式 \`(?:^|[^实])上传量</strong>[:：\\s]*...\` 前缀锚定避免误匹配 \`实际上传量\`。此坑在 hdsky.go 中有相同处理。

## Changes

| 文件 | 改动 |
|------|------|
| \`site/v2/definitions/pt0ffcc.go\` | **新增** 完整 SiteDefinition (UserInfo + Selectors + DetailParser) |
| \`site/v2/definitions/pt0ffcc_fixture_test.go\` | **新增** Search/Detail/UserInfo + NoSecrets 测试 |
| \`tools/browser-extension/src/core/constants.ts\` | 注册 \`pt0ffcc\` 至 \`KNOWN_SITES\`（域名已在 \`pt-sites.ts\`，无需修改） |
| \`docs/sites.md\` | 已适配站点计数 **30 → 31**（NexusPHP 系列 **26 → 27**） |

## Test Coverage (全部通过 + 0 回归)

- **Search**: 2 行 fixture 验证 id/title/discount=FREE/seeders/leechers/snatched
- **Detail**: FREE discount（从 h1 font.free 解析）+ 9.07 GB size（正则从 \`基本信息\` cell 抽取）+ noHR
- **UserInfo**: 
  - IndexPage: seeding/leeching 从登录用户 \`#info_block\` 正确解析
  - UserdetailsPage: name + level="Insane User" + 4 个 regex 驱动字段（uploaded/downloaded/ratio/joinTime）保证非空 —— 专门守护 \`上传量\` vs \`实际上传量\` 的歧义
- **NoSecrets**: 4 个 fixture 全部通过
- **全量回归**: \`go test ./...\` 21 个包全通过，\`make lint\` 0 issues，\`vue-tsc\` 0 errors
- **Extension 一致性检查**: 31 个站点 Go 定义与 \`KNOWN_SITES\` 同步