### PR TITLE
fix(qbit): 兼容 qBittorrent v5.2.0+ 接口变更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,12 +171,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **site**: 新增 OpenCD 和 PTT 站点适配
 - 新增 site/v2/definitions/opencd.go 适配 open.cd (繁体 NexusPHP)
   _ 使用 div.title + td.rowtitle 替代标准 h1 + td.rowhead
-  _ 支持 plugin*details.php 链接格式
-  * 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
-  * 处理 font.promotion 替代 img.pro*_ 的非标准折扣标记
-  _ span.category 替代 img[alt] 的分类标记
-  _ 处理 info_block 隐藏列的 nth-child 索引偏移
-  _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
+  _ 支持 plugin\*details.php 链接格式
+  - 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
+  - 处理 font.promotion 替代 img.pro\*_ 的非标准折扣标记
+    _ span.category 替代 img[alt] 的分类标记
+    _ 处理 info_block 隐藏列的 nth-child 索引偏移
+    _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
 
 ## [0.23.0] - 2026-04-29
 

--- a/thirdpart/downloader/qbit/qbit_impl.go
+++ b/thirdpart/downloader/qbit/qbit_impl.go
@@ -13,6 +13,8 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +35,9 @@ type QbitClient struct {
 	mu           sync.Mutex
 	healthy      bool
 	lastActivity time.Time
+	appVersion   string
+	isV520Plus   bool
+	versionMu    sync.RWMutex
 }
 
 type requestDoer interface {
@@ -46,6 +51,30 @@ type QbitTorrentProperties struct {
 
 // 确保 QbitClient 实现 Downloader 接口
 var _ downloader.Downloader = (*QbitClient)(nil)
+
+// parseQBitVersion extracts semver major.minor.patch from a qBit version string.
+func parseQBitVersion(raw string) (major, minor, patch int, ok bool) {
+	re := regexp.MustCompile(`v?(\d+)\.(\d+)\.(\d+)`)
+	m := re.FindStringSubmatch(raw)
+	if len(m) != 4 {
+		return 0, 0, 0, false
+	}
+
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	minor, err = strconv.Atoi(m[2])
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	patch, err = strconv.Atoi(m[3])
+	if err != nil {
+		return 0, 0, 0, false
+	}
+
+	return major, minor, patch, true
+}
 
 // NewQbitClient 创建新的 qBittorrent 客户端
 func NewQbitClient(config downloader.DownloaderConfig, name string) (downloader.Downloader, error) {
@@ -124,9 +153,19 @@ func (q *QbitClient) AuthenticateWithContext(ctx context.Context) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		q.healthy = false
 		return q.wrapStatusCodeError(resp.StatusCode)
+	}
+
+	if resp.StatusCode == http.StatusNoContent {
+		q.healthy = true
+		q.lastActivity = time.Now()
+		sLogger().Info("Successfully logged in to qBittorrent (204 No Content)")
+		if detectErr := q.detectVersion(ctx); detectErr != nil {
+			sLogger().Debugf("qBit 版本探测返回错误: %v", detectErr)
+		}
+		return nil
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -135,18 +174,80 @@ func (q *QbitClient) AuthenticateWithContext(ctx context.Context) error {
 		return fmt.Errorf("读取响应失败: %w", err)
 	}
 
-	if string(body) != "Ok." {
+	if string(body) == "Fails." {
 		q.healthy = false
-		if string(body) == "Fails." {
-			return fmt.Errorf("用户名或密码错误")
-		}
-		return fmt.Errorf("登录失败，服务器响应: %s", string(body))
+		return fmt.Errorf("用户名或密码错误")
 	}
 
 	q.healthy = true
 	q.lastActivity = time.Now()
 	sLogger().Info("Successfully logged in to qBittorrent")
+	if detectErr := q.detectVersion(ctx); detectErr != nil {
+		sLogger().Debugf("qBit 版本探测返回错误: %v", detectErr)
+	}
 	return nil
+}
+
+func (q *QbitClient) detectVersion(ctx context.Context) error {
+	versionURL := fmt.Sprintf("%s/api/v2/app/version", q.baseURL)
+	req, err := http.NewRequestWithContext(ctx, "GET", versionURL, nil)
+	if err != nil {
+		sLogger().Warnf("qBit 版本探测失败，使用 legacy 模式（旧版兼容）: %v", err)
+		return nil
+	}
+
+	resp, err := q.client.Do(req)
+	if err != nil {
+		sLogger().Warnf("qBit 版本探测失败，使用 legacy 模式（旧版兼容）: %v", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		sLogger().Warnf("qBit 版本探测失败，使用 legacy 模式（旧版兼容）: HTTP %d", resp.StatusCode)
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		sLogger().Warnf("qBit 版本探测失败，使用 legacy 模式（旧版兼容）: %v", err)
+		return nil
+	}
+
+	version := strings.TrimSpace(string(body))
+	if version == "" {
+		sLogger().Warnf("qBit 版本探测失败，使用 legacy 模式（旧版兼容）: empty version response")
+		return nil
+	}
+
+	major, minor, patch, ok := parseQBitVersion(version)
+	if !ok {
+		sLogger().Warnf("qBit 版本探测失败，使用 legacy 模式（旧版兼容）: invalid version %q", version)
+		return nil
+	}
+
+	isV520Plus := major > 5 || (major == 5 && (minor > 2 || (minor == 2 && patch >= 0)))
+	q.versionMu.Lock()
+	q.appVersion = version
+	q.isV520Plus = isV520Plus
+	q.versionMu.Unlock()
+
+	mode := "legacy"
+	if isV520Plus {
+		mode = "5.2.0+"
+	}
+	sLogger().Infof("qBit 版本探测: %s (%s 模式)", q.appVersion, mode)
+
+	return nil
+}
+
+func (q *QbitClient) isSuccessStatus(code int) bool {
+	q.versionMu.RLock()
+	defer q.versionMu.RUnlock()
+	if q.isV520Plus {
+		return code >= 200 && code < 300
+	}
+	return code == http.StatusOK
 }
 
 func (q *QbitClient) wrapConnectionError(err error) error {
@@ -203,7 +304,7 @@ func (q *QbitClient) doRequestWithRetry(req *http.Request) (*http.Response, erro
 		}
 	}
 
-	if resp.StatusCode == http.StatusOK {
+	if q.isSuccessStatus(resp.StatusCode) {
 		q.mu.Lock()
 		q.lastActivity = time.Now()
 		q.mu.Unlock()
@@ -228,7 +329,7 @@ func (q *QbitClient) GetDiskSpace(ctx context.Context) (int64, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if !q.isSuccessStatus(resp.StatusCode) {
 		return 0, fmt.Errorf("disk space request failed with status code: %d", resp.StatusCode)
 	}
 
@@ -340,7 +441,7 @@ func (q *QbitClient) AddTorrentWithPath(fileData []byte, category, tags, downloa
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if !q.isSuccessStatus(resp.StatusCode) {
 		respBody, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("upload failed with status code: %d, response: %s", resp.StatusCode, string(respBody))
 	}
@@ -372,7 +473,7 @@ func (q *QbitClient) CheckTorrentExistsWithContext(ctx context.Context, torrentH
 		return false, nil
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if !q.isSuccessStatus(resp.StatusCode) {
 		return false, fmt.Errorf("check failed with status code: %d", resp.StatusCode)
 	}
 
@@ -558,7 +659,7 @@ func (q *QbitClient) EnsureTorrentStarted(torrentHash string) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if !q.isSuccessStatus(resp.StatusCode) {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("info request failed with status %d: %s", resp.StatusCode, string(body))
 	}
@@ -598,7 +699,7 @@ func (q *QbitClient) EnsureTorrentStarted(torrentHash string) error {
 		}
 		defer resumeResp.Body.Close()
 
-		if resumeResp.StatusCode != http.StatusOK {
+		if !q.isSuccessStatus(resumeResp.StatusCode) {
 			body, _ := io.ReadAll(resumeResp.Body)
 			return fmt.Errorf("resume request failed with status %d: %s", resumeResp.StatusCode, string(body))
 		}
@@ -631,7 +732,7 @@ func (q *QbitClient) Ping() (bool, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if !q.isSuccessStatus(resp.StatusCode) {
 		q.healthy = false
 		return false, nil
 	}
@@ -658,7 +759,7 @@ func (q *QbitClient) GetClientVersion() (string, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if !q.isSuccessStatus(resp.StatusCode) {
 		return "", fmt.Errorf("version request failed with status code: %d", resp.StatusCode)
 	}
 
@@ -687,7 +788,7 @@ func (q *QbitClient) GetClientStatus() (downloader.ClientStatus, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if !q.isSuccessStatus(resp.StatusCode) {
 		return downloader.ClientStatus{}, fmt.Errorf("status request failed with status code: %d", resp.StatusCode)
 	}
 
@@ -746,7 +847,7 @@ func (q *QbitClient) GetAllTorrents() ([]downloader.Torrent, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if !q.isSuccessStatus(resp.StatusCode) {
 		return nil, fmt.Errorf("torrents request failed with status code: %d", resp.StatusCode)
 	}
 
@@ -856,7 +957,7 @@ func (q *QbitClient) postForm(endpoint string, data url.Values) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if !q.isSuccessStatus(resp.StatusCode) {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("request failed for %s with status %d: %s", endpoint, resp.StatusCode, string(body))
 	}
@@ -876,7 +977,7 @@ func (q *QbitClient) getJSON(endpoint string, dst any) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if !q.isSuccessStatus(resp.StatusCode) {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("request failed for %s with status %d: %s", endpoint, resp.StatusCode, string(body))
 	}
@@ -913,7 +1014,7 @@ func (q *QbitClient) callPauseResumeEndpoints(ids []string, modernEndpoint, lega
 		return q.postForm(legacyEndpoint, data)
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if !q.isSuccessStatus(resp.StatusCode) {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("request failed for %s with status %d: %s", modernEndpoint, resp.StatusCode, string(body))
 	}
@@ -1040,11 +1141,47 @@ func (q *QbitClient) AddTorrentEx(torrentURL string, opt downloader.AddTorrentOp
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return downloader.AddTorrentResult{Success: false, Message: err.Error()}, err
+	}
+
+	q.versionMu.RLock()
+	isNew := q.isV520Plus
+	q.versionMu.RUnlock()
+
+	if isNew {
+		switch resp.StatusCode {
+		case http.StatusOK, http.StatusAccepted, http.StatusNoContent:
+			var result struct {
+				SuccessCount    int      `json:"success_count"`
+				PendingCount    int      `json:"pending_count"`
+				FailureCount    int      `json:"failure_count"`
+				AddedTorrentIDs []string `json:"added_torrent_ids"`
+			}
+			if len(bodyBytes) > 0 && json.Unmarshal(bodyBytes, &result) == nil {
+				message := fmt.Sprintf("成功 %d, 待定 %d, 失败 %d", result.SuccessCount, result.PendingCount, result.FailureCount)
+				hash := ""
+				if len(result.AddedTorrentIDs) > 0 {
+					hash = result.AddedTorrentIDs[0]
+				}
+				return downloader.AddTorrentResult{Success: result.FailureCount == 0, Message: message, Hash: hash}, nil
+			}
+			if string(bodyBytes) == "Fails." {
+				return downloader.AddTorrentResult{Success: false, Message: "添加失败"}, fmt.Errorf("add failed")
+			}
+			return downloader.AddTorrentResult{Success: true, Message: "Torrent added successfully"}, nil
+		case http.StatusConflict:
+			return downloader.AddTorrentResult{Success: false, Message: "种子已存在或添加失败 (409 Conflict)"}, nil
+		default:
+			return downloader.AddTorrentResult{Success: false, Message: fmt.Sprintf("HTTP %d", resp.StatusCode)}, fmt.Errorf("upload failed with status code: %d, response: %s", resp.StatusCode, string(bodyBytes))
+		}
+	}
+
+	if !q.isSuccessStatus(resp.StatusCode) {
 		return downloader.AddTorrentResult{
 			Success: false,
-			Message: fmt.Sprintf("upload failed with status code: %d, response: %s", resp.StatusCode, string(respBody)),
+			Message: fmt.Sprintf("upload failed with status code: %d, response: %s", resp.StatusCode, string(bodyBytes)),
 		}, fmt.Errorf("upload failed with status code: %d", resp.StatusCode)
 	}
 
@@ -1096,11 +1233,47 @@ func (q *QbitClient) AddTorrentFileEx(fileData []byte, opt downloader.AddTorrent
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return downloader.AddTorrentResult{Success: false, Message: err.Error()}, err
+	}
+
+	q.versionMu.RLock()
+	isNew := q.isV520Plus
+	q.versionMu.RUnlock()
+
+	if isNew {
+		switch resp.StatusCode {
+		case http.StatusOK, http.StatusAccepted, http.StatusNoContent:
+			var result struct {
+				SuccessCount    int      `json:"success_count"`
+				PendingCount    int      `json:"pending_count"`
+				FailureCount    int      `json:"failure_count"`
+				AddedTorrentIDs []string `json:"added_torrent_ids"`
+			}
+			if len(bodyBytes) > 0 && json.Unmarshal(bodyBytes, &result) == nil {
+				message := fmt.Sprintf("成功 %d, 待定 %d, 失败 %d", result.SuccessCount, result.PendingCount, result.FailureCount)
+				hash := torrentHash
+				if len(result.AddedTorrentIDs) > 0 {
+					hash = result.AddedTorrentIDs[0]
+				}
+				return downloader.AddTorrentResult{Success: result.FailureCount == 0, Message: message, Hash: hash}, nil
+			}
+			if string(bodyBytes) == "Fails." {
+				return downloader.AddTorrentResult{Success: false, Message: "添加失败"}, fmt.Errorf("add failed")
+			}
+			return downloader.AddTorrentResult{Success: true, Message: "Torrent added successfully", Hash: torrentHash}, nil
+		case http.StatusConflict:
+			return downloader.AddTorrentResult{Success: false, Message: "种子已存在或添加失败 (409 Conflict)"}, nil
+		default:
+			return downloader.AddTorrentResult{Success: false, Message: fmt.Sprintf("HTTP %d", resp.StatusCode)}, fmt.Errorf("upload failed with status code: %d, response: %s", resp.StatusCode, string(bodyBytes))
+		}
+	}
+
+	if !q.isSuccessStatus(resp.StatusCode) {
 		return downloader.AddTorrentResult{
 			Success: false,
-			Message: fmt.Sprintf("upload failed with status code: %d, response: %s", resp.StatusCode, string(respBody)),
+			Message: fmt.Sprintf("upload failed with status code: %d, response: %s", resp.StatusCode, string(bodyBytes)),
 		}, fmt.Errorf("upload failed with status code: %d", resp.StatusCode)
 	}
 
@@ -1369,7 +1542,7 @@ func (q *QbitClient) GetSpeedLimit() (downloader.SpeedLimit, error) {
 		return downloader.SpeedLimit{}, fmt.Errorf("speed mode request failed: %w", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
+	if !q.isSuccessStatus(resp.StatusCode) {
 		body, _ := io.ReadAll(resp.Body)
 		return downloader.SpeedLimit{}, fmt.Errorf("speed mode request failed with status %d: %s", resp.StatusCode, string(body))
 	}
@@ -1389,7 +1562,7 @@ func (q *QbitClient) GetSpeedLimit() (downloader.SpeedLimit, error) {
 		return downloader.SpeedLimit{}, fmt.Errorf("download limit request failed: %w", err)
 	}
 	defer respDl.Body.Close()
-	if respDl.StatusCode != http.StatusOK {
+	if !q.isSuccessStatus(respDl.StatusCode) {
 		dlBody, _ := io.ReadAll(respDl.Body)
 		return downloader.SpeedLimit{}, fmt.Errorf("download limit request failed with status %d: %s", respDl.StatusCode, string(dlBody))
 	}
@@ -1407,7 +1580,7 @@ func (q *QbitClient) GetSpeedLimit() (downloader.SpeedLimit, error) {
 		return downloader.SpeedLimit{}, fmt.Errorf("upload limit request failed: %w", err)
 	}
 	defer respUl.Body.Close()
-	if respUl.StatusCode != http.StatusOK {
+	if !q.isSuccessStatus(respUl.StatusCode) {
 		ulBody, _ := io.ReadAll(respUl.Body)
 		return downloader.SpeedLimit{}, fmt.Errorf("upload limit request failed with status %d: %s", respUl.StatusCode, string(ulBody))
 	}
@@ -1464,7 +1637,7 @@ func (q *QbitClient) GetClientPaths() ([]string, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if !q.isSuccessStatus(resp.StatusCode) {
 		return nil, fmt.Errorf("preferences request failed with status code: %d", resp.StatusCode)
 	}
 
@@ -1498,7 +1671,7 @@ func (q *QbitClient) GetClientLabels() ([]string, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if !q.isSuccessStatus(resp.StatusCode) {
 		return nil, fmt.Errorf("categories request failed with status code: %d", resp.StatusCode)
 	}
 

--- a/thirdpart/downloader/qbit/qbit_v520_test.go
+++ b/thirdpart/downloader/qbit/qbit_v520_test.go
@@ -1,0 +1,306 @@
+package qbit
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sunerpy/pt-tools/thirdpart/downloader"
+)
+
+func mockQbitServer(t *testing.T, loginStatus int, loginBody, versionBody string, versionStatus int) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(loginStatus)
+		if loginBody != "" {
+			_, _ = w.Write([]byte(loginBody))
+		}
+	})
+	mux.HandleFunc("/api/v2/app/version", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(versionStatus)
+		if versionBody != "" {
+			_, _ = w.Write([]byte(versionBody))
+		}
+	})
+	return httptest.NewServer(mux)
+}
+
+func newVersionTestClient(baseURL string) *QbitClient {
+	return &QbitClient{
+		name:     "test-qbit",
+		baseURL:  baseURL,
+		username: "admin",
+		password: "password",
+		client:   &standardHTTPDoer{client: &http.Client{}},
+	}
+}
+
+func TestAuthenticate_200LegacyOkBody(t *testing.T) {
+	ts := mockQbitServer(t, http.StatusOK, "Ok.", "v4.6.5", http.StatusOK)
+	defer ts.Close()
+
+	client := newVersionTestClient(ts.URL)
+	if err := client.Authenticate(); err != nil {
+		t.Fatalf("Authenticate failed: %v", err)
+	}
+	if !client.IsHealthy() {
+		t.Fatal("expected client healthy after 200 Ok.")
+	}
+}
+
+func TestAuthenticate_200FailsBody(t *testing.T) {
+	ts := mockQbitServer(t, http.StatusOK, "Fails.", "", http.StatusOK)
+	defer ts.Close()
+
+	client := newVersionTestClient(ts.URL)
+	err := client.Authenticate()
+	if err == nil {
+		t.Fatal("expected authentication error")
+	}
+	if !strings.Contains(err.Error(), "用户名或密码错误") {
+		t.Fatalf("expected invalid credential error, got %v", err)
+	}
+}
+
+func TestAuthenticate_204LoginSuccess(t *testing.T) {
+	ts := mockQbitServer(t, http.StatusNoContent, "", "v5.2.0", http.StatusOK)
+	defer ts.Close()
+
+	client := newVersionTestClient(ts.URL)
+	if err := client.Authenticate(); err != nil {
+		t.Fatalf("Authenticate failed: %v", err)
+	}
+	if !client.IsHealthy() {
+		t.Fatal("expected client healthy after 204 login")
+	}
+}
+
+func TestAuthenticate_401InvalidCreds(t *testing.T) {
+	ts := mockQbitServer(t, http.StatusUnauthorized, "", "", http.StatusOK)
+	defer ts.Close()
+
+	client := newVersionTestClient(ts.URL)
+	err := client.Authenticate()
+	if err == nil {
+		t.Fatal("expected authentication error")
+	}
+	if !strings.Contains(err.Error(), "认证失败") {
+		t.Fatalf("expected 401 auth error, got %v", err)
+	}
+}
+
+func TestDetectVersion_520Plus(t *testing.T) {
+	ts := mockQbitServer(t, http.StatusOK, "Ok.", "v5.2.0", http.StatusOK)
+	defer ts.Close()
+
+	client := newVersionTestClient(ts.URL)
+	if err := client.Authenticate(); err != nil {
+		t.Fatalf("Authenticate failed: %v", err)
+	}
+
+	client.versionMu.RLock()
+	defer client.versionMu.RUnlock()
+	if !client.isV520Plus {
+		t.Fatal("expected v5.2.0+ mode")
+	}
+	if client.appVersion != "v5.2.0" {
+		t.Fatalf("expected appVersion v5.2.0, got %q", client.appVersion)
+	}
+}
+
+func TestDetectVersion_Legacy(t *testing.T) {
+	ts := mockQbitServer(t, http.StatusOK, "Ok.", "v4.6.5", http.StatusOK)
+	defer ts.Close()
+
+	client := newVersionTestClient(ts.URL)
+	if err := client.Authenticate(); err != nil {
+		t.Fatalf("Authenticate failed: %v", err)
+	}
+
+	client.versionMu.RLock()
+	defer client.versionMu.RUnlock()
+	if client.isV520Plus {
+		t.Fatal("expected legacy mode")
+	}
+	if client.appVersion != "v4.6.5" {
+		t.Fatalf("expected appVersion v4.6.5, got %q", client.appVersion)
+	}
+}
+
+func TestDetectVersion_Fallback(t *testing.T) {
+	ts := mockQbitServer(t, http.StatusOK, "Ok.", "server error", http.StatusInternalServerError)
+	defer ts.Close()
+
+	client := newVersionTestClient(ts.URL)
+	if err := client.Authenticate(); err != nil {
+		t.Fatalf("Authenticate failed: %v", err)
+	}
+
+	client.versionMu.RLock()
+	defer client.versionMu.RUnlock()
+	if client.isV520Plus {
+		t.Fatal("expected fallback legacy mode")
+	}
+	if client.appVersion != "" {
+		t.Fatalf("expected empty appVersion on detection failure, got %q", client.appVersion)
+	}
+}
+
+func TestParseQBitVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		raw         string
+		major       int
+		minor       int
+		patch       int
+		expectMatch bool
+	}{
+		{name: "prefixed", raw: "v5.2.0", major: 5, minor: 2, patch: 0, expectMatch: true},
+		{name: "plain", raw: "5.2.0", major: 5, minor: 2, patch: 0, expectMatch: true},
+		{name: "suffix", raw: "v5.2.0-rc1", major: 5, minor: 2, patch: 0, expectMatch: true},
+		{name: "legacy", raw: "v4.6.5", major: 4, minor: 6, patch: 5, expectMatch: true},
+		{name: "embedded", raw: "qBittorrent v5.2.0", major: 5, minor: 2, patch: 0, expectMatch: true},
+		{name: "new minor", raw: "v5.3.1", major: 5, minor: 3, patch: 1, expectMatch: true},
+		{name: "new major", raw: "v6.0.0", major: 6, minor: 0, patch: 0, expectMatch: true},
+		{name: "empty", raw: "", expectMatch: false},
+		{name: "invalid", raw: "not a version", expectMatch: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			major, minor, patch, ok := parseQBitVersion(tt.raw)
+			if ok != tt.expectMatch {
+				t.Fatalf("expected ok=%v, got %v", tt.expectMatch, ok)
+			}
+			if !tt.expectMatch {
+				return
+			}
+			if major != tt.major || minor != tt.minor || patch != tt.patch {
+				t.Fatalf("expected %d.%d.%d, got %d.%d.%d", tt.major, tt.minor, tt.patch, major, minor, patch)
+			}
+		})
+	}
+}
+
+func TestIsSuccessStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		isV520Plus bool
+		codes      map[int]bool
+	}{
+		{
+			name:       "v520plus",
+			isV520Plus: true,
+			codes: map[int]bool{
+				http.StatusOK:                  true,
+				http.StatusAccepted:            true,
+				http.StatusNoContent:           true,
+				299:                            true,
+				300:                            false,
+				http.StatusBadRequest:          false,
+				http.StatusInternalServerError: false,
+			},
+		},
+		{
+			name:       "legacy",
+			isV520Plus: false,
+			codes: map[int]bool{
+				http.StatusOK:                  true,
+				http.StatusAccepted:            false,
+				http.StatusNoContent:           false,
+				299:                            false,
+				300:                            false,
+				http.StatusBadRequest:          false,
+				http.StatusInternalServerError: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &QbitClient{}
+			client.versionMu.Lock()
+			client.isV520Plus = tt.isV520Plus
+			client.versionMu.Unlock()
+			for code, expected := range tt.codes {
+				if got := client.isSuccessStatus(code); got != expected {
+					t.Fatalf("code %d expected %v, got %v", code, expected, got)
+				}
+			}
+		})
+	}
+}
+
+func TestAddTorrentFileEx_202PendingJSON(t *testing.T) {
+	torrentData := fixtureTorrentBytes()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/torrents/add":
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success_count":     0,
+				"pending_count":     1,
+				"failure_count":     0,
+				"added_torrent_ids": []string{"hash-pending"},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	client := newVersionTestClient(ts.URL)
+	client.versionMu.Lock()
+	client.isV520Plus = true
+	client.appVersion = "v5.2.0"
+	client.versionMu.Unlock()
+
+	result, err := client.AddTorrentFileEx(torrentData, downloader.AddTorrentOptions{})
+	if err != nil {
+		t.Fatalf("AddTorrentFileEx failed: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success result, got %+v", result)
+	}
+	message := fmt.Sprint(result.Message)
+	if !strings.Contains(message, "待定 1") {
+		t.Fatalf("expected pending message, got %q", message)
+	}
+	if result.Hash != "hash-pending" {
+		t.Fatalf("expected returned hash, got %q", result.Hash)
+	}
+}
+
+func TestAddTorrentFileEx_409Duplicate(t *testing.T) {
+	torrentData := fixtureTorrentBytes()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/torrents/add" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer ts.Close()
+
+	client := newVersionTestClient(ts.URL)
+	client.versionMu.Lock()
+	client.isV520Plus = true
+	client.appVersion = "v5.2.0"
+	client.versionMu.Unlock()
+
+	result, err := client.AddTorrentFileEx(torrentData, downloader.AddTorrentOptions{})
+	if err != nil {
+		t.Fatalf("expected nil error for 409 duplicate, got %v", err)
+	}
+	if result.Success {
+		t.Fatalf("expected duplicate result failure, got %+v", result)
+	}
+	message := fmt.Sprint(result.Message)
+	if !strings.Contains(message, "已存在") {
+		t.Fatalf("expected duplicate message, got %q", message)
+	}
+}


### PR DESCRIPTION
## Summary
解决用户升级 qBit 到 v5.2.0 后看到「下载器状态 204」的问题。采用**版本探测 + 分支处理**策略，完全兼容旧版 qBit (4.x/5.0/5.1)。

## 问题根因

qBittorrent [PR #21349](https://github.com/qbittorrent/qBittorrent/pull/21349)（随 v5.2.0 发布，WebAPI 2.14.0）将大量无响应体的 endpoint 从 `200 OK` 改为 `204 No Content`；`/api/v2/torrents/add` 改用新 JSON 响应格式并新增 `202 Accepted` / `409 Conflict` 状态码。

pt-tools 原有 ~18 处 `resp.StatusCode != http.StatusOK` 严格检查，会把 `204` 误判为失败，UI 显示 `登录失败，HTTP 状态码: 204`。

数据流：`UI → /api/downloaders/:id/health → CreateFromConfig → NewQbitClient → Authenticate → 204 → wrapStatusCodeError(204) → default 分支 → "登录失败，HTTP 状态码: 204"`

## 实现方案

### 1. QbitClient 新增版本字段
```go
appVersion   string        // "v5.2.0" 等缓存
isV520Plus   bool          // semver >= 5.2.0
versionMu    sync.RWMutex  // 独立锁，不影响 q.mu
```

### 2. 破解循环依赖：登录阶段宽容处理
登录时版本信息还不可知，采用 bootstrap 容错：
- **接受 200 或 204** 作为登录成功
- **200**：仅当 body == `"Fails."` 时判定凭证错误；容忍空 body / 非 `"Ok."` 响应
- **204**：直接成功，跳过 body 读取
- **401/403**：走原有 `wrapStatusCodeError` 映射

登录成功后**立即调用** `detectVersion(ctx)` 探测版本，**探测失败静默回退 legacy**（WARN 日志），不阻塞登录。

### 3. 版本探测 & 分支判定
```go
func (q *QbitClient) detectVersion(ctx) error {
    // GET /api/v2/app/version
    // 正则 v?(\d+)\.(\d+)\.(\d+) 容错解析
    // semver 比较：major > 5 || (major == 5 && minor >= 2)
    // 失败 → isV520Plus=false (legacy) + WARN 日志
    // 成功 → INFO 日志 "qBit 版本探测: v5.2.0 (5.2.0+ 模式)"
}

func (q *QbitClient) isSuccessStatus(code int) bool {
    if q.isV520Plus { return code >= 200 && code < 300 }
    return code == http.StatusOK
}
```

### 4. 替换 20+ 处严格检查
所有非 Authenticate 路径的 `resp.StatusCode != http.StatusOK` 替换为 `!q.isSuccessStatus(resp.StatusCode)`。保留：
- **403 重新认证重试**（`doRequestWithRetry`）
- **404 回退**（pause/resume legacy 端点）
- **登录 200/204 专用逻辑**

### 5. AddTorrentEx / AddTorrentFileEx 完整适配新 JSON 响应
- **200/202/204**: 尝试解析 \`{success_count, pending_count, failure_count, added_torrent_ids}\`，解析失败回退 `Ok./Fails.` 字符串
- **409 Conflict**: 返回 `Success=false`，消息「种子已存在或添加失败 (409 Conflict)」
- **legacy 分支**: 保持原有 200 + `Ok.` 字符串解析

### 6. 容错版本解析
\`parseQBitVersion\` 兼容：\`v5.2.0\` / \`5.2.0\` / \`v5.2.0-rc1\` / \`qBittorrent v5.2.0\` / trailing whitespace

## 兼容性矩阵

| qBit 版本 | detectVersion 结果 | isSuccessStatus 行为 | 最终体验 |
|---|---|---|---|
| 4.x / 5.0 / 5.1 | `v4.6.5` 等 → `isV520Plus=false` | 仅 200 | **完全不变** |
| **5.2.0+** | `v5.2.0` → `isV520Plus=true` | 任意 2xx | **204/202/409 正确识别** |
| 版本探测失败（罕见） | 回退 `isV520Plus=false` | 仅 200 | 至少登录不阻塞 |

## 测试覆盖（11 新 test + 11 sub-test，全部 PASS）
- \`TestAuthenticate_200LegacyOkBody\` / \`_200FailsBody\` / \`_204LoginSuccess\` / \`_401InvalidCreds\`
- \`TestDetectVersion_520Plus\` / \`_Legacy\` / \`_Fallback\`
- \`TestParseQBitVersion\` (9 sub-cases)
- \`TestIsSuccessStatus\` (2 sub-cases)
- \`TestAddTorrentFileEx_202PendingJSON\` / \`_409Duplicate\`

## 验证
- \`go test ./... -race\` **21/21 包全通过**
- qbit 包 coverage **33.6%**
- \`make fmt\` + \`make lint-go\` **0 issues**
- 不变动：\`interface.go\` / \`transmission/\` / \`http_doer.go\` / \`manager.go\`

## 附带改动
CHANGELOG.md 12 行格式化（pre-commit hook oxfmt 自动修正，非本次 PR 新增变更）