### PR TITLE
ci: 新增预发版发布工作流 (beta/rc/alpha)

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -1,15 +1,18 @@
-name: Release Assets
+name: Release Prerelease
 
 on:
   push:
     tags:
-      # 仅匹配正式版 tag（v1.2.3），排除预发版（v1.2.3-beta.1 / -rc.1 / -alpha.1）
-      # 预发版由 release-prerelease.yml 处理。
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      # 预发版 tag 格式：v<semver>-<channel>.<N>
+      # 例如 v0.28.0-beta.1 / v0.28.0-rc.1 / v0.28.0-alpha.1
+      # 与 release-assets.yml 的正式版 tag（v1.2.3）完全互斥。
+      - "v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+"
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to build (example: v0.12.3)"
+        description: "预发版 tag（例如 v0.28.0-beta.1）"
         required: true
         type: string
 
@@ -17,19 +20,28 @@ permissions:
   contents: write
 
 jobs:
-  build-and-release:
-    name: Build and Release
+  build-and-prerelease:
+    name: Build and Prerelease
     runs-on: ubuntu-latest
 
     steps:
-      - name: Resolve tag
+      - name: Resolve tag and channel
         id: vars
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag_name=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            TAG_NAME="${{ inputs.tag }}"
           else
-            echo "tag_name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            TAG_NAME="${{ github.ref_name }}"
           fi
+          # 从 v0.28.0-beta.1 中提取 channel=beta
+          CHANNEL=$(echo "$TAG_NAME" | sed -E 's/^v[0-9]+\.[0-9]+\.[0-9]+-([a-z]+)\.[0-9]+$/\1/')
+          if [ -z "$CHANNEL" ] || [ "$CHANNEL" = "$TAG_NAME" ]; then
+            echo "错误：无法从 tag '$TAG_NAME' 中解析预发版通道（期望格式 vX.Y.Z-<channel>.N）"
+            exit 1
+          fi
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "解析结果：tag=$TAG_NAME channel=$CHANNEL"
 
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -60,6 +72,13 @@ jobs:
           cd web/frontend
           pnpm install --frozen-lockfile
           pnpm build
+
+      - name: Build Extension
+        run: |
+          cd tools/browser-extension
+          pnpm install --frozen-lockfile
+          pnpm build
+          cd dist && zip -r ../pt-tools-helper.zip .
 
       - name: Install Dependencies
         run: |
@@ -108,11 +127,12 @@ jobs:
       - name: List organized files
         run: ls -la dist/
 
-      - name: Build and Push Docker Images
+      - name: Build and Push Prerelease Docker Images
         run: |
           TAG="${{ steps.vars.outputs.tag_name }}"
-          echo "Building and pushing Docker images with tag $TAG"
-          make build-remote-docker TAG="$TAG"
+          CHANNEL="${{ steps.vars.outputs.channel }}"
+          echo "Building prerelease Docker: $TAG + :$CHANNEL (NOT tagging :latest)"
+          make build-prerelease-docker TAG="$TAG" CHANNEL="$CHANNEL"
         env:
           DOCKER_BUILDKIT: 1
 
@@ -121,7 +141,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --latest --strip header
+          args: --unreleased --strip header
         env:
           OUTPUT: RELEASE_CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}
@@ -129,8 +149,13 @@ jobs:
       - name: Prepare release notes
         run: |
           TAG_NAME="${{ steps.vars.outputs.tag_name }}"
+          CHANNEL="${{ steps.vars.outputs.channel }}"
 
-          cat > RELEASE_NOTES.md << 'HEADER'
+          cat > RELEASE_NOTES.md << HEADER
+          > ⚠️ **这是 ${CHANNEL} 预发版，不建议在生产环境使用**
+          >
+          > 如遇问题请在 [GitHub Issues](https://github.com/sunerpy/pt-tools/issues) 反馈，测试通过后将合入正式版。
+
           ## What's Changed
 
           HEADER
@@ -143,36 +168,45 @@ jobs:
 
           ---
 
-          ## Installation
+          ## Installation (Prerelease)
 
-          ### Using Docker (Recommended)
+          ### Using Docker
           \`\`\`bash
+          # 固定版本（推荐用于回滚）
           docker pull sunerpy/pt-tools:${TAG_NAME}
+
+          # 滚动 ${CHANNEL} 通道（自动跟进最新预发版）
+          docker pull sunerpy/pt-tools:${CHANNEL}
           \`\`\`
+
+          > 注意：此版本 **不会** 更新 \`:latest\` 标签。生产环境请继续使用正式版。
 
           ### From Binary
           Download the appropriate binary for your platform from the assets below.
 
-          | Platform | Architecture | File | Latest Link |
-          |----------|--------------|------|-------------|
-          | Linux | x86_64 | \`pt-tools-linux-amd64.tar.gz\` | [Download](https://github.com/sunerpy/pt-tools/releases/latest/download/pt-tools-linux-amd64.tar.gz) |
-          | Linux | aarch64 | \`pt-tools-linux-arm64.tar.gz\` | [Download](https://github.com/sunerpy/pt-tools/releases/latest/download/pt-tools-linux-arm64.tar.gz) |
-          | Windows | x86_64 | \`pt-tools-windows-amd64.exe.zip\` | [Download](https://github.com/sunerpy/pt-tools/releases/latest/download/pt-tools-windows-amd64.exe.zip) |
-          | Windows | aarch64 | \`pt-tools-windows-arm64.exe.zip\` | [Download](https://github.com/sunerpy/pt-tools/releases/latest/download/pt-tools-windows-arm64.exe.zip) |
+          | Platform | Architecture | File |
+          |----------|--------------|------|
+          | Linux | x86_64 | \`pt-tools-linux-amd64.tar.gz\` |
+          | Linux | aarch64 | \`pt-tools-linux-arm64.tar.gz\` |
+          | Windows | x86_64 | \`pt-tools-windows-amd64.exe.zip\` |
+          | Windows | aarch64 | \`pt-tools-windows-arm64.exe.zip\` |
 
           ### Docker Images
 
-          - \`sunerpy/pt-tools:${TAG_NAME}\`
-          - \`sunerpy/pt-tools:latest\`
+          - \`sunerpy/pt-tools:${TAG_NAME}\` （固定版本）
+          - \`sunerpy/pt-tools:${CHANNEL}\` （滚动 ${CHANNEL} 通道）
           EOF
 
-      - name: Upload Release Assets
+      - name: Upload Prerelease Assets
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.vars.outputs.tag_name }}
+          name: "Prerelease ${{ steps.vars.outputs.tag_name }}"
           body_path: RELEASE_NOTES.md
+          prerelease: true
           files: |
             dist/*.tar.gz
             dist/*.zip
+            tools/browser-extension/pt-tools-helper.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,12 +171,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **site**: 新增 OpenCD 和 PTT 站点适配
 - 新增 site/v2/definitions/opencd.go 适配 open.cd (繁体 NexusPHP)
   _ 使用 div.title + td.rowtitle 替代标准 h1 + td.rowhead
-  _ 支持 plugin*details.php 链接格式
-  * 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
-  * 处理 font.promotion 替代 img.pro*_ 的非标准折扣标记
-  _ span.category 替代 img[alt] 的分类标记
-  _ 处理 info_block 隐藏列的 nth-child 索引偏移
-  _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
+  _ 支持 plugin\*details.php 链接格式
+  - 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
+  - 处理 font.promotion 替代 img.pro\*_ 的非标准折扣标记
+    _ span.category 替代 img[alt] 的分类标记
+    _ 处理 info_block 隐藏列的 nth-child 索引偏移
+    _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
 
 ## [0.23.0] - 2026-04-29
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ BASE_IMAGE ?= alpine:3.20.3
 NODE_IMAGE ?= node:25.2.0-alpine
 BUILD_ENV ?= remote
 
-.PHONY: build-local build-binaries build-local-docker build-remote-docker push-image clean fmt fmt-oxfmt fmt-go fmt-check lint unit-test coverage-summary build-extension generate-icons check-sites
+.PHONY: build-local build-binaries build-local-docker build-remote-docker build-prerelease-docker push-image clean fmt fmt-oxfmt fmt-go fmt-check lint unit-test coverage-summary build-extension generate-icons check-sites
 
 # 本地构建二进制
 build-local: fmt build-frontend
@@ -151,6 +151,35 @@ build-remote-docker:
 	--build-arg COMMIT_ID=$(COMMIT_ID) \
 	-t $(DOCKER_IMAGE_FULL):$(TAG) \
 	-t $(DOCKER_IMAGE_FULL):latest \
+	--push .
+
+# Docker 镜像远程构建（预发版专用）
+# 与 build-remote-docker 的区别：
+#   1. 不打 :latest 标签（避免 docker pull :latest 误拉到预发版）
+#   2. 新增 :$(CHANNEL) 滚动标签（beta/rc/alpha），方便测试者 docker pull sunerpy/pt-tools:beta
+# 用法：make build-prerelease-docker TAG=v0.28.0-beta.1 CHANNEL=beta
+build-prerelease-docker: BUILD_ENV = remote
+build-prerelease-docker:
+	@if [ -z "$(TAG)" ] || [ -z "$(CHANNEL)" ]; then \
+		echo "Usage: make build-prerelease-docker TAG=v0.28.0-beta.1 CHANNEL=beta"; \
+		exit 1; \
+	fi
+	@echo "Preparing dependencies"
+	@mkdir -p dist
+	go mod vendor
+	@echo "Building prerelease Docker image: $(TAG) + :$(CHANNEL)"
+	docker buildx build \
+	--progress=plain \
+	--platform $(DOCKERPLATFORMS) \
+	--build-arg BASE_IMAGE=$(BASE_IMAGE) \
+	--build-arg BUILD_IMAGE=$(BUILD_IMAGE) \
+	--build-arg NODE_IMAGE=$(NODE_IMAGE) \
+	--build-arg BUILD_ENV=$(BUILD_ENV) \
+	--build-arg TAG=$(TAG) \
+	--build-arg BUILD_TIME=$(BUILD_TIME) \
+	--build-arg COMMIT_ID=$(COMMIT_ID) \
+	-t $(DOCKER_IMAGE_FULL):$(TAG) \
+	-t $(DOCKER_IMAGE_FULL):$(CHANNEL) \
 	--push .
 
 # 清理构建文件

--- a/cmd/rss_test.go
+++ b/cmd/rss_test.go
@@ -119,7 +119,9 @@ func (s *errSite) DownloadTorrent(url, title, dir string) (string, error) {
 func (s *errSite) MaxRetries() int                                                     { return 1 }
 func (s *errSite) RetryDelay() time.Duration                                           { return 0 }
 func (s *errSite) SendTorrentToDownloader(c context.Context, r models.RSSConfig) error { return nil }
-func (s *errSite) Context() context.Context                                            { return context.Background() }
+
+func (s *errSite) Context() context.Context { return context.Background() }
+
 func TestExecuteTask_ErrorPath_NoPanic(t *testing.T) {
 	dir := t.TempDir()
 	db, err := core.NewTempDBDir(dir)
@@ -138,12 +140,16 @@ func (s *siteStub) GetTorrentDetails(item *gofeed.Item) (*models.APIResponse[mod
 	d := models.PHPTorrentInfo{Title: "x", TorrentID: "id", Discount: models.DISCOUNT_FREE, EndTime: time.Now().Add(1 * time.Hour), SizeMB: 1}
 	return &models.APIResponse[models.PHPTorrentInfo]{Code: "success", Data: d}, nil
 }
-func (s *siteStub) IsEnabled() bool                                                     { return true }
+
+func (s *siteStub) IsEnabled() bool { return true }
+
 func (s *siteStub) DownloadTorrent(url, title, dir string) (string, error)              { return "h", nil }
 func (s *siteStub) MaxRetries() int                                                     { return 1 }
 func (s *siteStub) RetryDelay() time.Duration                                           { return 0 }
 func (s *siteStub) SendTorrentToDownloader(c context.Context, r models.RSSConfig) error { return nil }
-func (s *siteStub) Context() context.Context                                            { return context.Background() }
+
+func (s *siteStub) Context() context.Context { return context.Background() }
+
 func TestRunSiteJobs_WithSingleMode(t *testing.T) {
 	baseCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/models/init.go
+++ b/models/init.go
@@ -143,7 +143,8 @@ func NewDBWithVersion(gormLg zapgorm2.Logger, appVersion string) (*TorrentDB, er
 	db, err := gorm.Open(
 		sqlite.Open(dsn), &gorm.Config{
 			Logger: gormLg,
-		})
+		},
+	)
 	if err != nil {
 		return nil, fmt.Errorf("无法初始化 GORM: %w", err)
 	}

--- a/site/v2/base_site.go
+++ b/site/v2/base_site.go
@@ -108,7 +108,8 @@ func (b *BaseSite[Req, Res]) Search(ctx context.Context, query SearchQuery) ([]T
 	}
 
 	startTime := time.Now()
-	b.logger.Debug("Starting search",
+	b.logger.Debug(
+		"Starting search",
 		zap.String("site", b.name),
 		zap.String("keyword", query.Keyword),
 		zap.Bool("freeOnly", query.FreeOnly),
@@ -140,7 +141,8 @@ func (b *BaseSite[Req, Res]) Search(ctx context.Context, query SearchQuery) ([]T
 		items[i].SourceSite = b.id
 	}
 
-	b.logger.Info("Search completed",
+	b.logger.Info(
+		"Search completed",
 		zap.String("site", b.name),
 		zap.Int("results", len(items)),
 		zap.Duration("duration", time.Since(startTime)),
@@ -170,7 +172,8 @@ func (b *BaseSite[Req, Res]) GetUserInfo(ctx context.Context) (UserInfo, error) 
 	info.Site = b.id
 	info.LastUpdate = time.Now().Unix()
 
-	b.logger.Info("User info fetched",
+	b.logger.Info(
+		"User info fetched",
 		zap.String("site", b.name),
 		zap.String("username", info.Username),
 		zap.Duration("duration", time.Since(startTime)),
@@ -187,7 +190,8 @@ func (b *BaseSite[Req, Res]) Download(ctx context.Context, torrentID string) ([]
 	}
 
 	startTime := time.Now()
-	b.logger.Debug("Downloading torrent",
+	b.logger.Debug(
+		"Downloading torrent",
 		zap.String("site", b.name),
 		zap.String("torrentID", torrentID),
 	)
@@ -213,7 +217,8 @@ func (b *BaseSite[Req, Res]) Download(ctx context.Context, torrentID string) ([]
 		return nil, fmt.Errorf("parse download: %w", err)
 	}
 
-	b.logger.Info("Torrent downloaded",
+	b.logger.Info(
+		"Torrent downloaded",
 		zap.String("site", b.name),
 		zap.String("torrentID", torrentID),
 		zap.Int("size", len(data)),

--- a/site/v2/batch_download.go
+++ b/site/v2/batch_download.go
@@ -90,7 +90,8 @@ func (s *BatchDownloadService) FetchFreeTorrents(ctx context.Context) ([]Torrent
 		}
 	}
 
-	s.logger.Info("Found free torrents",
+	s.logger.Info(
+		"Found free torrents",
 		zap.String("site", s.site.ID()),
 		zap.Int("count", len(freeTorrents)),
 	)
@@ -133,7 +134,8 @@ func (s *BatchDownloadService) DownloadFreeTorrents(
 		default:
 		}
 
-		s.logger.Debug("Downloading torrent",
+		s.logger.Debug(
+			"Downloading torrent",
 			zap.String("id", t.ID),
 			zap.String("title", t.Title),
 		)
@@ -141,7 +143,8 @@ func (s *BatchDownloadService) DownloadFreeTorrents(
 		// Download torrent file
 		data, dlErr := s.site.Download(ctx, t.ID)
 		if dlErr != nil {
-			s.logger.Warn("Failed to download torrent",
+			s.logger.Warn(
+				"Failed to download torrent",
 				zap.String("id", t.ID),
 				zap.Error(dlErr),
 			)
@@ -152,7 +155,8 @@ func (s *BatchDownloadService) DownloadFreeTorrents(
 		filename := fmt.Sprintf("%s.torrent", sanitizeFilename(t.Title))
 		filepath := filepath.Join(tempDir, filename)
 		if writeErr := os.WriteFile(filepath, data, 0o644); writeErr != nil {
-			s.logger.Warn("Failed to save torrent file",
+			s.logger.Warn(
+				"Failed to save torrent file",
 				zap.String("id", t.ID),
 				zap.Error(writeErr),
 			)
@@ -207,7 +211,8 @@ func (s *BatchDownloadService) DownloadFreeTorrents(
 		}
 	}
 
-	s.logger.Info("Created archive",
+	s.logger.Info(
+		"Created archive",
 		zap.String("path", archivePath),
 		zap.Int("torrentCount", len(manifest)),
 	)

--- a/site/v2/factory.go
+++ b/site/v2/factory.go
@@ -188,7 +188,8 @@ func (f *SiteFactory) CreateSitesFromJSON(jsonData []byte) ([]Site, error) {
 	for _, config := range configs {
 		site, err := f.CreateSite(config)
 		if err != nil {
-			f.logger.Warn("Failed to create site",
+			f.logger.Warn(
+				"Failed to create site",
 				zap.String("id", config.ID),
 				zap.Error(err),
 			)

--- a/site/v2/failover.go
+++ b/site/v2/failover.go
@@ -114,7 +114,8 @@ func (m *URLFailoverManager) ExecuteWithFailover(
 			}
 
 			if retry > 0 {
-				m.logger.Debug("Retrying URL",
+				m.logger.Debug(
+					"Retrying URL",
 					zap.String("url", baseURL),
 					zap.Int("retry", retry),
 				)
@@ -128,7 +129,8 @@ func (m *URLFailoverManager) ExecuteWithFailover(
 					m.mu.Lock()
 					m.currentIdx = idx
 					m.mu.Unlock()
-					m.logger.Info("Switched to new base URL",
+					m.logger.Info(
+						"Switched to new base URL",
 						zap.String("url", baseURL),
 						zap.Int("index", idx),
 					)
@@ -137,7 +139,8 @@ func (m *URLFailoverManager) ExecuteWithFailover(
 			}
 
 			lastErr = err
-			m.logger.Warn("URL request failed",
+			m.logger.Warn(
+				"URL request failed",
 				zap.String("url", baseURL),
 				zap.Int("retry", retry),
 				zap.Error(err),
@@ -149,7 +152,8 @@ func (m *URLFailoverManager) ExecuteWithFailover(
 			}
 		}
 
-		m.logger.Debug("Moving to next URL",
+		m.logger.Debug(
+			"Moving to next URL",
 			zap.String("failedURL", baseURL),
 			zap.Int("nextIndex", (idx+1)%urlCount),
 		)

--- a/site/v2/http_client.go
+++ b/site/v2/http_client.go
@@ -346,7 +346,8 @@ func (c *RetryableHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	for attempt := 0; attempt <= c.config.MaxRetries; attempt++ {
 		if attempt > 0 {
 			backoff := c.calculateBackoff(attempt)
-			c.logger.Debug("Retrying request",
+			c.logger.Debug(
+				"Retrying request",
 				zap.Int("attempt", attempt),
 				zap.Duration("backoff", backoff),
 				zap.String("url", req.URL.String()),
@@ -372,7 +373,8 @@ func (c *RetryableHTTPClient) Do(req *http.Request) (*http.Response, error) {
 		resp, err := c.client.Do(reqClone)
 		if err != nil {
 			lastErr = err
-			c.logger.Warn("Request failed",
+			c.logger.Warn(
+				"Request failed",
 				zap.Int("attempt", attempt),
 				zap.Error(err),
 			)
@@ -383,7 +385,8 @@ func (c *RetryableHTTPClient) Do(req *http.Request) (*http.Response, error) {
 		if c.shouldRetry(resp.StatusCode) {
 			lastResp = resp
 			lastErr = fmt.Errorf("HTTP %d: %s", resp.StatusCode, http.StatusText(resp.StatusCode))
-			c.logger.Warn("Retryable status code",
+			c.logger.Warn(
+				"Retryable status code",
 				zap.Int("attempt", attempt),
 				zap.Int("status", resp.StatusCode),
 			)

--- a/site/v2/migration.go
+++ b/site/v2/migration.go
@@ -71,7 +71,8 @@ func AddAtPausedToAutoStart(addAtPaused bool) bool {
 
 // MigrateDownloaderConfig converts an old downloader config to the new format
 func (m *ConfigMigrator) MigrateDownloaderConfig(old OldDownloaderConfig) NewDownloaderConfig {
-	m.logger.Info("Migrating downloader config",
+	m.logger.Info(
+		"Migrating downloader config",
 		zap.String("name", old.Name),
 		zap.Bool("autoStart", old.AutoStart),
 	)
@@ -99,7 +100,8 @@ func (m *ConfigMigrator) MigrateDownloaderConfigJSON(oldJSON []byte) ([]byte, er
 
 // MigrateSiteConfig converts an old site config to the new SiteConfig format
 func (m *ConfigMigrator) MigrateSiteConfig(old OldSiteConfig) SiteConfig {
-	m.logger.Info("Migrating site config",
+	m.logger.Info(
+		"Migrating site config",
 		zap.String("name", old.Name),
 		zap.String("type", old.Type),
 	)
@@ -265,7 +267,8 @@ func (m *ConfigMigrator) CheckForDeprecatedFields(configJSON []byte) []Deprecati
 
 	for _, warning := range allWarnings {
 		if _, exists := data[warning.Field]; exists {
-			m.logger.Warn("Deprecated field detected",
+			m.logger.Warn(
+				"Deprecated field detected",
 				zap.String("field", warning.Field),
 				zap.String("message", warning.Message),
 				zap.String("replacement", warning.Replacement),
@@ -467,7 +470,8 @@ func NewSiteMigrationManager(logger *zap.Logger) *SiteMigrationManager {
 // RegisterSite registers a site with both old and new implementations
 func (m *SiteMigrationManager) RegisterSite(siteID string, oldSite any, newSite Site, useNew bool) {
 	m.adapters[siteID] = NewSiteAdapter(oldSite, newSite, useNew)
-	m.logger.Info("Registered site for migration",
+	m.logger.Info(
+		"Registered site for migration",
 		zap.String("siteId", siteID),
 		zap.Bool("useNew", useNew),
 	)
@@ -499,7 +503,8 @@ func (m *SiteMigrationManager) MigrateToNew(siteID string) error {
 		return fmt.Errorf("new implementation not available for site: %s", siteID)
 	}
 	adapter.UseNew = true
-	m.logger.Info("Migrated site to new implementation",
+	m.logger.Info(
+		"Migrated site to new implementation",
 		zap.String("siteId", siteID),
 	)
 	return nil
@@ -515,7 +520,8 @@ func (m *SiteMigrationManager) RollbackToOld(siteID string) error {
 		return fmt.Errorf("old implementation not available for site: %s", siteID)
 	}
 	adapter.UseNew = false
-	m.logger.Info("Rolled back site to old implementation",
+	m.logger.Info(
+		"Rolled back site to old implementation",
 		zap.String("siteId", siteID),
 	)
 	return nil

--- a/site/v2/mtorrent_driver.go
+++ b/site/v2/mtorrent_driver.go
@@ -296,7 +296,8 @@ func NewMTorrentDriver(config MTorrentDriverConfig) *MTorrentDriver {
 	// Initialize failover client if enabled
 	if config.UseFailover {
 		registry := GetGlobalRegistry()
-		if failoverClient, err := registry.GetFailoverClient(SiteNameMTeam,
+		if failoverClient, err := registry.GetFailoverClient(
+			SiteNameMTeam,
 			WithUserAgent(userAgent),
 		); err == nil {
 			driver.failoverClient = failoverClient

--- a/site/v2/nexusphp_driver.go
+++ b/site/v2/nexusphp_driver.go
@@ -186,7 +186,8 @@ func NewNexusPHPDriver(config NexusPHPDriverConfig) *NexusPHPDriver {
 	// Initialize failover client if enabled and site name is provided
 	if config.UseFailover && config.SiteName != "" {
 		registry := GetGlobalRegistry()
-		if failoverClient, err := registry.GetFailoverClient(config.SiteName,
+		if failoverClient, err := registry.GetFailoverClient(
+			config.SiteName,
 			WithUserAgent(userAgent),
 		); err == nil {
 			driver.failoverClient = failoverClient

--- a/site/v2/search_orchestrator.go
+++ b/site/v2/search_orchestrator.go
@@ -195,7 +195,8 @@ func (o *SearchOrchestrator) searchConcurrently(ctx context.Context, sites []Sit
 	)
 
 	startTime := time.Now()
-	o.logger.Info("Starting concurrent search",
+	o.logger.Info(
+		"Starting concurrent search",
 		zap.Int("siteCount", len(sites)),
 		zap.String("keyword", query.Keyword),
 	)
@@ -228,7 +229,8 @@ func (o *SearchOrchestrator) searchConcurrently(ctx context.Context, sites []Sit
 			defer mu.Unlock()
 
 			if err != nil {
-				o.logger.Warn("Search failed",
+				o.logger.Warn(
+					"Search failed",
 					zap.String("site", s.ID()),
 					zap.Duration("duration", siteDuration),
 					zap.Error(err),
@@ -240,7 +242,8 @@ func (o *SearchOrchestrator) searchConcurrently(ctx context.Context, sites []Sit
 				return
 			}
 
-			o.logger.Info("Site search completed",
+			o.logger.Info(
+				"Site search completed",
 				zap.String("site", s.ID()),
 				zap.Int("results", len(items)),
 				zap.Duration("duration", siteDuration),
@@ -250,7 +253,8 @@ func (o *SearchOrchestrator) searchConcurrently(ctx context.Context, sites []Sit
 	}
 
 	wg.Wait()
-	o.logger.Info("All site searches completed",
+	o.logger.Info(
+		"All site searches completed",
 		zap.Int("totalResults", len(results)),
 		zap.Int("errorCount", len(errors)),
 		zap.Duration("totalDuration", time.Since(startTime)),

--- a/site/v2/search_orchestrator_test.go
+++ b/site/v2/search_orchestrator_test.go
@@ -26,6 +26,7 @@ func (m *mockSearchSite) Name() string                                       { r
 func (m *mockSearchSite) Kind() SiteKind                                     { return m.kind }
 func (m *mockSearchSite) Login(ctx context.Context, creds Credentials) error { return nil }
 func (m *mockSearchSite) GetUserInfo(ctx context.Context) (UserInfo, error)  { return m.userInfo, nil }
+
 func (m *mockSearchSite) Download(ctx context.Context, torrentID string) ([]byte, error) {
 	return nil, nil
 }

--- a/site/v2/site_urls.go
+++ b/site/v2/site_urls.go
@@ -117,7 +117,8 @@ func (r *SiteURLRegistry) RegisterURLs(siteName SiteName, urls []string) {
 	urlsCopy := make([]string, len(urls))
 	copy(urlsCopy, urls)
 	r.urls[siteName] = urlsCopy
-	r.logger.Debug("Registered site URLs",
+	r.logger.Debug(
+		"Registered site URLs",
 		zap.String("site", siteName.String()),
 		zap.Strings("urls", urlsCopy),
 	)

--- a/site/v2/userinfo_service.go
+++ b/site/v2/userinfo_service.go
@@ -111,7 +111,8 @@ func (s *UserInfoService) FetchAndSave(ctx context.Context, siteID string) (User
 
 	info, err := site.GetUserInfo(ctx)
 	if err != nil {
-		s.logger.Error("Failed to fetch user info",
+		s.logger.Error(
+			"Failed to fetch user info",
 			zap.String("site", siteID),
 			zap.Error(err),
 		)
@@ -120,7 +121,8 @@ func (s *UserInfoService) FetchAndSave(ctx context.Context, siteID string) (User
 
 	// Save to repository
 	if err := s.repo.Save(ctx, info); err != nil {
-		s.logger.Error("Failed to save user info",
+		s.logger.Error(
+			"Failed to save user info",
 			zap.String("site", siteID),
 			zap.Error(err),
 		)
@@ -130,7 +132,8 @@ func (s *UserInfoService) FetchAndSave(ctx context.Context, siteID string) (User
 	// Update cache
 	s.cache.set(siteID, info)
 
-	s.logger.Info("User info fetched and saved",
+	s.logger.Info(
+		"User info fetched and saved",
 		zap.String("site", siteID),
 		zap.String("username", info.Username),
 		zap.Int64("uploaded", info.Uploaded),
@@ -282,7 +285,8 @@ func (s *UserInfoService) FetchAndSaveAllWithConcurrency(
 		return nil, nil
 	}
 
-	s.logger.Info("Starting concurrent user info fetch",
+	s.logger.Info(
+		"Starting concurrent user info fetch",
 		zap.Int("sites", len(siteIDs)),
 		zap.Int("maxConcurrent", maxConcurrent),
 		zap.Duration("timeout", timeout),
@@ -319,14 +323,16 @@ func (s *UserInfoService) FetchAndSaveAllWithConcurrency(
 			defer mu.Unlock()
 
 			if err != nil {
-				s.logger.Warn("Failed to fetch user info",
+				s.logger.Warn(
+					"Failed to fetch user info",
 					zap.String("site", siteID),
 					zap.Duration("duration", time.Since(siteStartTime)),
 					zap.Error(err),
 				)
 				errors = append(errors, SyncError{Site: siteID, Error: err})
 			} else {
-				s.logger.Debug("Fetched user info successfully",
+				s.logger.Debug(
+					"Fetched user info successfully",
 					zap.String("site", siteID),
 					zap.Duration("duration", time.Since(siteStartTime)),
 				)
@@ -339,7 +345,8 @@ func (s *UserInfoService) FetchAndSaveAllWithConcurrency(
 	// Wait for all to complete (errors are collected, not returned)
 	_ = g.Wait()
 
-	s.logger.Info("Completed concurrent user info fetch",
+	s.logger.Info(
+		"Completed concurrent user info fetch",
 		zap.Int("successful", len(results)),
 		zap.Int("failed", len(errors)),
 		zap.Duration("totalDuration", time.Since(startTime)),

--- a/thirdpart/downloader/manager_test.go
+++ b/thirdpart/downloader/manager_test.go
@@ -27,6 +27,7 @@ func (m *MockDownloader) GetClientFreeSpace(ctx context.Context) (int64, error) 
 func (m *MockDownloader) GetAllTorrents() ([]Torrent, error)                    { return nil, nil }
 func (m *MockDownloader) GetTorrentsBy(filter TorrentFilter) ([]Torrent, error) { return nil, nil }
 func (m *MockDownloader) GetTorrent(id string) (Torrent, error)                 { return Torrent{}, nil }
+
 func (m *MockDownloader) AddTorrentEx(url string, opt AddTorrentOptions) (AddTorrentResult, error) {
 	return AddTorrentResult{Success: true}, nil
 }
@@ -34,22 +35,26 @@ func (m *MockDownloader) AddTorrentEx(url string, opt AddTorrentOptions) (AddTor
 func (m *MockDownloader) AddTorrentFileEx(fileData []byte, opt AddTorrentOptions) (AddTorrentResult, error) {
 	return AddTorrentResult{Success: true}, nil
 }
-func (m *MockDownloader) PauseTorrent(id string) error                            { return nil }
-func (m *MockDownloader) ResumeTorrent(id string) error                           { return nil }
-func (m *MockDownloader) RemoveTorrent(id string, removeData bool) error          { return nil }
-func (m *MockDownloader) PauseTorrents(ids []string) error                        { return nil }
-func (m *MockDownloader) ResumeTorrents(ids []string) error                       { return nil }
-func (m *MockDownloader) RemoveTorrents(ids []string, removeData bool) error      { return nil }
-func (m *MockDownloader) SetTorrentCategory(id, category string) error            { return nil }
-func (m *MockDownloader) SetTorrentTags(id, tags string) error                    { return nil }
-func (m *MockDownloader) SetTorrentSavePath(id, path string) error                { return nil }
-func (m *MockDownloader) RecheckTorrent(id string) error                          { return nil }
-func (m *MockDownloader) GetTorrentFiles(id string) ([]TorrentFile, error)        { return nil, nil }
-func (m *MockDownloader) GetTorrentTrackers(id string) ([]TorrentTracker, error)  { return nil, nil }
-func (m *MockDownloader) GetDiskInfo() (DiskInfo, error)                          { return DiskInfo{}, nil }
-func (m *MockDownloader) GetSpeedLimit() (SpeedLimit, error)                      { return SpeedLimit{}, nil }
-func (m *MockDownloader) SetSpeedLimit(limit SpeedLimit) error                    { return nil }
-func (m *MockDownloader) GetClientPaths() ([]string, error)                       { return nil, nil }
+func (m *MockDownloader) PauseTorrent(id string) error                       { return nil }
+func (m *MockDownloader) ResumeTorrent(id string) error                      { return nil }
+func (m *MockDownloader) RemoveTorrent(id string, removeData bool) error     { return nil }
+func (m *MockDownloader) PauseTorrents(ids []string) error                   { return nil }
+func (m *MockDownloader) ResumeTorrents(ids []string) error                  { return nil }
+func (m *MockDownloader) RemoveTorrents(ids []string, removeData bool) error { return nil }
+func (m *MockDownloader) SetTorrentCategory(id, category string) error       { return nil }
+func (m *MockDownloader) SetTorrentTags(id, tags string) error               { return nil }
+func (m *MockDownloader) SetTorrentSavePath(id, path string) error           { return nil }
+func (m *MockDownloader) RecheckTorrent(id string) error                     { return nil }
+func (m *MockDownloader) GetTorrentFiles(id string) ([]TorrentFile, error)   { return nil, nil }
+
+func (m *MockDownloader) GetTorrentTrackers(id string) ([]TorrentTracker, error) { return nil, nil }
+
+func (m *MockDownloader) GetDiskInfo() (DiskInfo, error) { return DiskInfo{}, nil }
+
+func (m *MockDownloader) GetSpeedLimit() (SpeedLimit, error)   { return SpeedLimit{}, nil }
+func (m *MockDownloader) SetSpeedLimit(limit SpeedLimit) error { return nil }
+func (m *MockDownloader) GetClientPaths() ([]string, error)    { return nil, nil }
+
 func (m *MockDownloader) GetClientLabels() ([]string, error)                      { return nil, nil }
 func (m *MockDownloader) AddTorrent(fileData []byte, category, tags string) error { return nil }
 func (m *MockDownloader) AddTorrentWithPath(fileData []byte, category, tags, downloadPath string) error {
@@ -370,6 +375,7 @@ func (m *StatefulMockDownloader) Authenticate() error                    { retur
 func (m *StatefulMockDownloader) Ping() (bool, error)                    { return m.healthy, nil }
 func (m *StatefulMockDownloader) GetClientVersion() (string, error)      { return "1.0.0", nil }
 func (m *StatefulMockDownloader) GetClientStatus() (ClientStatus, error) { return ClientStatus{}, nil }
+
 func (m *StatefulMockDownloader) GetClientFreeSpace(ctx context.Context) (int64, error) {
 	return 1024 * 1024 * 1024, nil
 }
@@ -400,6 +406,7 @@ func (m *StatefulMockDownloader) SetTorrentTags(id, tags string) error          
 func (m *StatefulMockDownloader) SetTorrentSavePath(id, path string) error         { return nil }
 func (m *StatefulMockDownloader) RecheckTorrent(id string) error                   { return nil }
 func (m *StatefulMockDownloader) GetTorrentFiles(id string) ([]TorrentFile, error) { return nil, nil }
+
 func (m *StatefulMockDownloader) GetTorrentTrackers(id string) ([]TorrentTracker, error) {
 	return nil, nil
 }

--- a/web/api_search_test.go
+++ b/web/api_search_test.go
@@ -35,8 +35,10 @@ type mockSearchSiteForAPI struct {
 	userInfo v2.UserInfo
 }
 
-func (m *mockSearchSiteForAPI) ID() string                                            { return m.id }
-func (m *mockSearchSiteForAPI) Name() string                                          { return m.name }
+func (m *mockSearchSiteForAPI) ID() string { return m.id }
+
+func (m *mockSearchSiteForAPI) Name() string { return m.name }
+
 func (m *mockSearchSiteForAPI) Kind() v2.SiteKind                                     { return m.kind }
 func (m *mockSearchSiteForAPI) Login(ctx context.Context, creds v2.Credentials) error { return nil }
 func (m *mockSearchSiteForAPI) GetUserInfo(ctx context.Context) (v2.UserInfo, error) {

--- a/web/api_userinfo_test.go
+++ b/web/api_userinfo_test.go
@@ -48,6 +48,7 @@ func (m *mockSite) GetUserInfo(ctx context.Context) (v2.UserInfo, error) {
 	}
 	return m.userInfo, nil
 }
+
 func (m *mockSite) Download(ctx context.Context, torrentID string) ([]byte, error) { return nil, nil }
 func (m *mockSite) Close() error                                                   { return nil }
 

--- a/web/server.go
+++ b/web/server.go
@@ -175,6 +175,7 @@ type statusRecorder struct {
 }
 
 func (s *statusRecorder) WriteHeader(code int) { s.status = code; s.ResponseWriter.WriteHeader(code) }
+
 func logMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		origin := r.Header.Get("Origin")


### PR DESCRIPTION
## Summary
新增独立的预发版发布通道，支持在正式版之前发布 beta/rc/alpha 进行真实环境测试，测试通过后再合入正式版。

**背景**：近期 qBit 5.2.0 兼容性这类涉及外部系统变更的修复，合入正式版前需要让用户在真实环境验证。当前 release-assets.yml 只有正式版通道，缺少预发版支持。

## 实现方式

### 1. 新增 `.github/workflows/release-prerelease.yml`
- **触发**：push tag 匹配 `v*-beta.N` / `v*-rc.N` / `v*-alpha.N`（例如 `v0.28.0-beta.1`）
- **channel 解析**：sed 从 tag 中提取 `beta` / `rc` / `alpha`
- **产物**：
  - 跨平台二进制（linux/windows × amd64/arm64）
  - Docker 镜像 `sunerpy/pt-tools:<version>` 和 `:<channel>` **不打 `:latest`**
  - 浏览器扩展 zip
- **GitHub Release**：带 `prerelease: true` 标志，**Release notes 头部警示不建议生产环境使用**
- **防呆**：channel 解析失败立即 exit 1

### 2. 收窄 `release-assets.yml` tag 过滤器
从 `v*` 改为 `v[0-9]+.[0-9]+.[0-9]+`，防止预发版误触发两个 workflow 重复发布 + 错打 `:latest`。两个 workflow 的 tag 正则完全互斥。

### 3. 新增 `make build-prerelease-docker TAG=... CHANNEL=...` target
与 `build-remote-docker` 的关键差异：
- ❌ 不打 `:latest`（避免 `docker pull :latest` 误拉预发版）
- ✅ 新增 `:<channel>` 滚动标签（`beta` / `rc` / `alpha`）

### 4. 附带修复
`web/server.go` 函数间缺失空行（gofumpt 历史遗留，CI Format Check 已报警）

## 使用方式

### 发布预发版
```bash
# 在需要测试的 commit 上打预发版 tag
git tag v0.28.0-beta.1 <commit-sha>
git push origin v0.28.0-beta.1

# 自动触发 release-prerelease.yml
# 用户可通过以下方式测试：
docker pull sunerpy/pt-tools:v0.28.0-beta.1   # 固定版本
docker pull sunerpy/pt-tools:beta             # 滚动 beta 通道
```

### 测试通过后发正式版
走现有 `release-please` 流程（不变），合并 release-please PR 后 `release-assets.yml` 发 `v0.28.0` 正式版，自动更新 `:latest`。

## Tag 正则验证

| Tag | release-assets.yml | release-prerelease.yml |
|---|---|---|
| `v0.28.0` | ✅ 触发 | ❌ 不触发 |
| `v0.28.0-beta.1` | ❌ 不触发 | ✅ 触发 channel=beta |
| `v1.0.0-rc.2` | ❌ 不触发 | ✅ 触发 channel=rc |
| `v0.27.1-alpha.5` | ❌ 不触发 | ✅ 触发 channel=alpha |
| `v1.2.3-dev` | ❌ 不触发 | ❌ 不触发（格式非法） |

## 验证
- YAML 语法合法
- Tag 正则覆盖测试全部通过
- `make build-prerelease-docker` dry-run 只打 `:<version>` + `:<channel>` 两个 tag，**无 `:latest`**
- `make fmt` + `make lint-go` 0 issues

## 后续计划
本 PR 合并后：
1. 手动打 `v0.27.1-beta.1` 烟测 workflow（如果本身发一个小的可观测变更做首次验证，也可以略过直接下一步）
2. 重新提交 qBit v5.2.0 兼容修复，走预发版 `v0.28.0-beta.1` 让真实用户测试
3. 测试通过后 merge release-please PR 发正式 `v0.28.0`

Related to: follow-up of closed #290 (qBit v5.2.0 compat)