### PR TITLE
feat(version): 预发版识别与 UI 突出显示

### DIFF
--- a/version/checker.go
+++ b/version/checker.go
@@ -56,6 +56,10 @@ type ReleaseInfo struct {
 	URL         string         `json:"url"`
 	PublishedAt int64          `json:"published_at"`
 	Assets      []ReleaseAsset `json:"assets,omitempty"`
+	// Prerelease 标记此版本是否为预发版（beta/rc/alpha）
+	Prerelease bool `json:"prerelease,omitempty"`
+	// PrereleaseLabel 从 tag 中解析出的预发版通道名（beta/rc/alpha），用于前端徽章展示
+	PrereleaseLabel string `json:"prerelease_label,omitempty"`
 }
 
 type VersionCheckResult struct {
@@ -77,13 +81,17 @@ type VersionInfo struct {
 type CheckOptions struct {
 	Force    bool
 	ProxyURL string
+	// IncludePrerelease 是否在结果中包含预发版（beta/rc/alpha）。
+	// 默认 false，保持与旧客户端兼容；前端通过查询参数按需启用。
+	IncludePrerelease bool
 }
 
 type Checker struct {
-	mu         sync.RWMutex
-	lastCheck  time.Time
-	lastResult *VersionCheckResult
-	lastProxy  string
+	mu                sync.RWMutex
+	lastCheck         time.Time
+	lastResult        *VersionCheckResult
+	lastProxy         string
+	lastIncludePrerel bool
 }
 
 var (
@@ -114,7 +122,8 @@ func GetVersionInfo() VersionInfo {
 func (c *Checker) CheckForUpdates(ctx context.Context, opts CheckOptions) (*VersionCheckResult, error) {
 	c.mu.RLock()
 	proxyChanged := opts.ProxyURL != c.lastProxy
-	if !opts.Force && !proxyChanged && c.lastResult != nil && time.Since(c.lastCheck) < CheckInterval {
+	prerelChanged := opts.IncludePrerelease != c.lastIncludePrerel
+	if !opts.Force && !proxyChanged && !prerelChanged && c.lastResult != nil && time.Since(c.lastCheck) < CheckInterval {
 		result := c.lastResult
 		c.mu.RUnlock()
 		return result, nil
@@ -125,7 +134,8 @@ func (c *Checker) CheckForUpdates(ctx context.Context, opts CheckOptions) (*Vers
 	defer c.mu.Unlock()
 
 	proxyChanged = opts.ProxyURL != c.lastProxy
-	if !opts.Force && !proxyChanged && c.lastResult != nil && time.Since(c.lastCheck) < CheckInterval {
+	prerelChanged = opts.IncludePrerelease != c.lastIncludePrerel
+	if !opts.Force && !proxyChanged && !prerelChanged && c.lastResult != nil && time.Since(c.lastCheck) < CheckInterval {
 		return c.lastResult, nil
 	}
 
@@ -141,7 +151,7 @@ func (c *Checker) CheckForUpdates(ctx context.Context, opts CheckOptions) (*Vers
 		return result, err
 	}
 
-	newReleases := c.filterNewReleases(releases)
+	newReleases := c.filterNewReleases(releases, opts.IncludePrerelease)
 	if len(newReleases) > 0 {
 		result.HasUpdate = true
 		if len(newReleases) > MaxDisplayReleases {
@@ -155,6 +165,7 @@ func (c *Checker) CheckForUpdates(ctx context.Context, opts CheckOptions) (*Vers
 	c.lastResult = result
 	c.lastCheck = time.Now()
 	c.lastProxy = opts.ProxyURL
+	c.lastIncludePrerel = opts.IncludePrerelease
 	return result, nil
 }
 
@@ -208,7 +219,7 @@ func (c *Checker) fetchGitHubReleases(ctx context.Context, proxyURL string) ([]G
 	return releases, nil
 }
 
-func (c *Checker) filterNewReleases(releases []GitHubRelease) []ReleaseInfo {
+func (c *Checker) filterNewReleases(releases []GitHubRelease, includePrerelease bool) []ReleaseInfo {
 	currentParsed := ParseVersion(Version)
 	if currentParsed == nil {
 		return nil
@@ -216,7 +227,10 @@ func (c *Checker) filterNewReleases(releases []GitHubRelease) []ReleaseInfo {
 
 	var newReleases []ReleaseInfo
 	for _, r := range releases {
-		if r.Draft || r.Prerelease {
+		if r.Draft {
+			continue
+		}
+		if r.Prerelease && !includePrerelease {
 			continue
 		}
 
@@ -234,13 +248,19 @@ func (c *Checker) filterNewReleases(releases []GitHubRelease) []ReleaseInfo {
 					Size:        a.Size,
 				})
 			}
+			// 同时认两种信号：GitHub Release 的 prerelease 标记 + tag 中的 -beta/-rc/-alpha 后缀，
+			// 任一命中即当作预发版，避免发版时漏勾 prerelease 勾选导致误判。
+			label := extractPrereleaseLabel(releaseParsed.Prerelease)
+			isPrerelease := r.Prerelease || label != ""
 			newReleases = append(newReleases, ReleaseInfo{
-				Version:     r.TagName,
-				Name:        r.Name,
-				Changelog:   r.Body,
-				URL:         r.HTMLURL,
-				PublishedAt: r.PublishedAt.Unix(),
-				Assets:      assets,
+				Version:         r.TagName,
+				Name:            r.Name,
+				Changelog:       r.Body,
+				URL:             r.HTMLURL,
+				PublishedAt:     r.PublishedAt.Unix(),
+				Assets:          assets,
+				Prerelease:      isPrerelease,
+				PrereleaseLabel: label,
 			})
 		}
 	}
@@ -252,6 +272,21 @@ func (c *Checker) filterNewReleases(releases []GitHubRelease) []ReleaseInfo {
 	})
 
 	return newReleases
+}
+
+// extractPrereleaseLabel 从 semver prerelease 段（例如 "beta.1" / "rc.2" / "alpha"）
+// 提取首个 dot 分段的通道名，返回小写字符串。未识别或为空时返回 ""。
+// 只认 beta/rc/alpha 三类，其它标签（如 "dev" / "snapshot"）一律当作非预发版处理。
+func extractPrereleaseLabel(prereleaseSegment string) string {
+	if prereleaseSegment == "" {
+		return ""
+	}
+	first := strings.ToLower(strings.SplitN(prereleaseSegment, ".", 2)[0])
+	switch first {
+	case "beta", "rc", "alpha":
+		return first
+	}
+	return ""
 }
 
 type SemVer struct {

--- a/version/checker_test.go
+++ b/version/checker_test.go
@@ -239,7 +239,7 @@ func TestFilterNewReleases(t *testing.T) {
 		{TagName: "draft-release", Name: "Draft", HTMLURL: "https://github.com/test/draft", Draft: true},
 	}
 
-	newReleases := checker.filterNewReleases(releases)
+	newReleases := checker.filterNewReleases(releases, false)
 
 	assert.Len(t, newReleases, 2, "should filter to only newer non-draft non-prerelease versions")
 	assert.Equal(t, "v2.0.0", newReleases[0].Version)
@@ -257,7 +257,7 @@ func TestFilterNewReleases_InvalidCurrentVersion(t *testing.T) {
 		{TagName: "v1.0.0", Name: "Version 1.0.0"},
 	}
 
-	newReleases := checker.filterNewReleases(releases)
+	newReleases := checker.filterNewReleases(releases, false)
 	assert.Nil(t, newReleases, "should return nil when current version is invalid")
 }
 
@@ -274,10 +274,76 @@ func TestFilterNewReleases_SortedByVersion(t *testing.T) {
 		{TagName: "v2.0.0", Name: "Another major"},
 	}
 
-	newReleases := checker.filterNewReleases(releases)
+	newReleases := checker.filterNewReleases(releases, false)
 
 	require.Len(t, newReleases, 3)
 	assert.Equal(t, "v3.0.0", newReleases[0].Version)
 	assert.Equal(t, "v2.0.0", newReleases[1].Version)
 	assert.Equal(t, "v1.1.0", newReleases[2].Version)
+}
+
+func TestFilterNewReleases_IncludePrerelease(t *testing.T) {
+	checker := NewChecker()
+	oldVersion := Version
+	defer func() { Version = oldVersion }()
+	Version = "v1.0.0"
+
+	releases := []GitHubRelease{
+		{TagName: "v2.0.0", Name: "Release", HTMLURL: "u"},
+		{TagName: "v2.1.0-beta.1", Name: "Beta", HTMLURL: "u", Prerelease: true},
+		{TagName: "v2.2.0-rc.2", Name: "RC", HTMLURL: "u", Prerelease: true},
+		{TagName: "draft", Name: "Draft", HTMLURL: "u", Draft: true},
+	}
+
+	includePre := checker.filterNewReleases(releases, true)
+	require.Len(t, includePre, 3)
+	assert.Equal(t, "v2.2.0-rc.2", includePre[0].Version)
+	assert.True(t, includePre[0].Prerelease)
+	assert.Equal(t, "rc", includePre[0].PrereleaseLabel)
+	assert.Equal(t, "v2.1.0-beta.1", includePre[1].Version)
+	assert.True(t, includePre[1].Prerelease)
+	assert.Equal(t, "beta", includePre[1].PrereleaseLabel)
+	assert.Equal(t, "v2.0.0", includePre[2].Version)
+	assert.False(t, includePre[2].Prerelease)
+	assert.Empty(t, includePre[2].PrereleaseLabel)
+
+	excludePre := checker.filterNewReleases(releases, false)
+	require.Len(t, excludePre, 1)
+	assert.Equal(t, "v2.0.0", excludePre[0].Version)
+}
+
+func TestFilterNewReleases_TagSuffixDetection(t *testing.T) {
+	checker := NewChecker()
+	oldVersion := Version
+	defer func() { Version = oldVersion }()
+	Version = "v1.0.0"
+
+	releases := []GitHubRelease{
+		{TagName: "v2.0.0-beta.1", Name: "Beta (flag missing)", HTMLURL: "u", Prerelease: false},
+	}
+
+	got := checker.filterNewReleases(releases, true)
+	require.Len(t, got, 1)
+	assert.True(t, got[0].Prerelease, "tag -beta.1 suffix 应识别为预发版，即使 GitHub prerelease 勾选被漏掉")
+	assert.Equal(t, "beta", got[0].PrereleaseLabel)
+}
+
+func TestExtractPrereleaseLabel(t *testing.T) {
+	cases := []struct {
+		in  string
+		out string
+	}{
+		{"", ""},
+		{"beta", "beta"},
+		{"beta.1", "beta"},
+		{"BETA.2", "beta"},
+		{"rc.1", "rc"},
+		{"alpha", "alpha"},
+		{"dev.1", ""},
+		{"snapshot", ""},
+		{"foo.bar", ""},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.out, extractPrereleaseLabel(c.in), "input=%q", c.in)
+	}
 }

--- a/web/api_version.go
+++ b/web/api_version.go
@@ -33,14 +33,16 @@ func (s *Server) apiVersionCheck(w http.ResponseWriter, r *http.Request) {
 
 	force := r.URL.Query().Get("force") == "true"
 	proxyURL := r.URL.Query().Get("proxy")
+	includePrerelease := r.URL.Query().Get("include_prerelease") == "true"
 	checker := version.GetChecker()
 
 	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 	defer cancel()
 
 	opts := version.CheckOptions{
-		Force:    force,
-		ProxyURL: proxyURL,
+		Force:             force,
+		ProxyURL:          proxyURL,
+		IncludePrerelease: includePrerelease,
 	}
 	result, err := checker.CheckForUpdates(ctx, opts)
 	if err != nil && result == nil {

--- a/web/frontend/src/api/index.ts
+++ b/web/frontend/src/api/index.ts
@@ -893,6 +893,8 @@ export interface ReleaseInfo {
   url: string;
   published_at: number;
   assets?: ReleaseAsset[];
+  prerelease?: boolean;
+  prerelease_label?: string;
 }
 
 export interface RuntimeEnvironment {
@@ -931,10 +933,11 @@ export interface VersionCheckResult {
 
 export const versionApi = {
   getInfo: () => api.get<VersionInfo>("/api/version"),
-  checkUpdate: (options?: { force?: boolean; proxy?: string }) => {
+  checkUpdate: (options?: { force?: boolean; proxy?: string; includePrerelease?: boolean }) => {
     const params = new URLSearchParams();
     if (options?.force) params.set("force", "true");
     if (options?.proxy) params.set("proxy", options.proxy);
+    if (options?.includePrerelease) params.set("include_prerelease", "true");
     const query = params.toString();
     return api.get<VersionCheckResult>(`/api/version/check${query ? `?${query}` : ""}`);
   },

--- a/web/frontend/src/components/VersionChecker.vue
+++ b/web/frontend/src/components/VersionChecker.vue
@@ -3,6 +3,7 @@ import { useVersionStore } from "@/stores/version";
 import { formatDate } from "@/utils/format";
 import { Check, Close, Download, Link, Promotion, Refresh } from "@element-plus/icons-vue";
 import DOMPurify from "dompurify";
+import { ElMessageBox } from "element-plus";
 import { marked } from "marked";
 import { storeToRefs } from "pinia";
 import { onMounted, ref } from "vue";
@@ -22,6 +23,9 @@ const {
   upgrading,
   canSelfUpgrade,
   isDocker,
+  showPrerelease,
+  hasPrereleaseUpdate,
+  onlyPrereleaseUpdates,
 } = storeToRefs(versionStore);
 
 const proxyUrl = ref("");
@@ -52,11 +56,32 @@ function handleCheckUpdate() {
   versionStore.checkForUpdates({ force: true, proxy: proxyUrl.value || undefined });
 }
 
+function handleTogglePrerelease(value: boolean) {
+  versionStore.setShowPrerelease(value);
+}
+
 function handleDismiss(version: string) {
   versionStore.dismissVersion(version);
 }
 
-function handleUpgrade(version: string) {
+async function handleUpgrade(version: string, prerelease: boolean) {
+  if (prerelease) {
+    try {
+      await ElMessageBox.confirm(
+        `${version} 是预发版本，可能存在未发现的问题。非必要建议等待正式版发布后再升级。\n\n确定要继续升级到此预发版吗？`,
+        "确认升级到预发版",
+        {
+          confirmButtonText: "继续升级",
+          cancelButtonText: "取消",
+          type: "warning",
+          confirmButtonClass: "el-button--warning",
+          customClass: "prerelease-confirm-dialog",
+        },
+      );
+    } catch {
+      return;
+    }
+  }
   versionStore.startUpgrade(version, proxyUrl.value || undefined);
 }
 
@@ -82,19 +107,30 @@ function renderMarkdown(text: string): string {
     return text;
   }
 }
+
+function prereleaseLabelText(label?: string): string {
+  if (!label) return "预发版";
+  return label.toUpperCase();
+}
 </script>
 
 <template>
-  <el-popover placement="bottom" :width="400" trigger="click" popper-class="version-popover">
+  <el-popover placement="bottom" :width="420" trigger="click" popper-class="version-popover">
     <template #reference>
-      <el-button class="version-btn" :class="{ 'has-update': hasUpdate }" text>
+      <el-button
+        class="version-btn"
+        :class="{ 'has-update': hasUpdate, 'has-prerelease': onlyPrereleaseUpdates }"
+        text>
         <div class="btn-content">
           <span class="version-icon-wrap">
             <el-icon :class="{ 'is-checking': checking }">
               <Promotion v-if="!checking" />
               <Refresh v-else />
             </el-icon>
-            <span v-if="hasUpdate" class="update-dot"></span>
+            <span
+              v-if="hasUpdate"
+              class="update-dot"
+              :class="{ 'is-prerelease': onlyPrereleaseUpdates }"></span>
           </span>
           <span class="version-meta">
             <span class="version-label">版本</span>
@@ -129,6 +165,22 @@ function renderMarkdown(text: string): string {
             @click="handleCheckUpdate"
             title="检查更新" />
         </div>
+      </div>
+
+      <div class="prerelease-toggle-row">
+        <span class="prerelease-toggle-label">
+          含预发版（beta/rc）
+          <el-tooltip
+            content="开启后会显示 beta/rc/alpha 等预发布版本，仅建议测试环境使用"
+            placement="top">
+            <span class="prerelease-toggle-hint">?</span>
+          </el-tooltip>
+        </span>
+        <el-switch
+          :model-value="showPrerelease"
+          size="small"
+          :disabled="checking"
+          @update:model-value="handleTogglePrerelease($event as boolean)" />
       </div>
 
       <div v-if="showProxyInput" class="proxy-section">
@@ -207,16 +259,47 @@ function renderMarkdown(text: string): string {
 
         <div v-else-if="hasUpdate" class="updates-list">
           <div class="update-header">
-            <el-tag type="success" size="small" effect="dark">发现新版本</el-tag>
+            <el-tag v-if="onlyPrereleaseUpdates" type="warning" size="small" effect="dark">
+              仅发现预发版
+            </el-tag>
+            <el-tag v-else-if="hasPrereleaseUpdate" type="success" size="small" effect="dark">
+              发现新版本（含预发版）
+            </el-tag>
+            <el-tag v-else type="success" size="small" effect="dark">发现新版本</el-tag>
           </div>
+
+          <el-alert
+            v-if="hasPrereleaseUpdate"
+            type="warning"
+            :closable="false"
+            show-icon
+            class="prerelease-notice">
+            <template #title>预发布版本提示</template>
+            <span>
+              预发版本用于真实环境验证，可能存在已知/未知问题。<strong>非必要请等待正式版发布后再升级</strong>；生产环境请关闭上方开关以隐藏预发版。
+            </span>
+          </el-alert>
 
           <div
             v-for="release in visibleReleases.slice(0, 3)"
             :key="release.version"
-            class="release-item">
+            class="release-item"
+            :class="{ 'is-prerelease': release.prerelease }">
             <div class="release-info">
               <div class="release-title-row">
-                <span class="version-tag">{{ release.version }}</span>
+                <span class="release-title-versions">
+                  <span class="version-tag" :class="{ 'is-prerelease': release.prerelease }">
+                    {{ release.version }}
+                  </span>
+                  <el-tag
+                    v-if="release.prerelease"
+                    type="warning"
+                    size="small"
+                    effect="dark"
+                    class="channel-badge">
+                    {{ prereleaseLabelText(release.prerelease_label) }}
+                  </el-tag>
+                </span>
                 <span class="release-date">{{ formatDate(release.published_at) }}</span>
               </div>
               <div v-if="release.name" class="release-name">{{ release.name }}</div>
@@ -228,12 +311,12 @@ function renderMarkdown(text: string): string {
               <div class="release-actions">
                 <el-button
                   v-if="canSelfUpgrade"
-                  type="primary"
+                  :type="release.prerelease ? 'warning' : 'primary'"
                   size="small"
                   :icon="Download"
                   :disabled="upgrading"
-                  @click="handleUpgrade(release.version)">
-                  升级
+                  @click="handleUpgrade(release.version, !!release.prerelease)">
+                  {{ release.prerelease ? "升级到预发版" : "升级" }}
                 </el-button>
                 <el-link
                   v-if="release.url"

--- a/web/frontend/src/stores/version.ts
+++ b/web/frontend/src/stores/version.ts
@@ -11,6 +11,7 @@ import {
 } from "../api";
 
 const DISMISSED_VERSIONS_KEY = "pt-tools-dismissed-versions";
+const SHOW_PRERELEASE_KEY = "pt-tools-show-prerelease";
 
 export const useVersionStore = defineStore("version", () => {
   const versionInfo = ref<VersionInfo | null>(null);
@@ -18,6 +19,7 @@ export const useVersionStore = defineStore("version", () => {
   const loading = ref(false);
   const checking = ref(false);
   const dismissedVersions = ref<string[]>(loadDismissedVersions());
+  const showPrerelease = ref<boolean>(loadShowPrerelease());
 
   const runtime = ref<RuntimeEnvironment | null>(null);
   const upgradeProgress = ref<UpgradeProgress | null>(null);
@@ -62,6 +64,14 @@ export const useVersionStore = defineStore("version", () => {
   const hasMoreReleases = computed(() => checkResult.value?.has_more_releases || false);
   const changelogUrl = computed(() => checkResult.value?.changelog_url || "");
 
+  const hasPrereleaseUpdate = computed(() =>
+    visibleReleases.value.some((r) => r.prerelease === true),
+  );
+  const onlyPrereleaseUpdates = computed(
+    () =>
+      visibleReleases.value.length > 0 && visibleReleases.value.every((r) => r.prerelease === true),
+  );
+
   function loadDismissedVersions(): string[] {
     try {
       const stored = localStorage.getItem(DISMISSED_VERSIONS_KEY);
@@ -73,6 +83,25 @@ export const useVersionStore = defineStore("version", () => {
 
   function saveDismissedVersions() {
     localStorage.setItem(DISMISSED_VERSIONS_KEY, JSON.stringify(dismissedVersions.value));
+  }
+
+  function loadShowPrerelease(): boolean {
+    try {
+      return localStorage.getItem(SHOW_PRERELEASE_KEY) === "true";
+    } catch {
+      return false;
+    }
+  }
+
+  function saveShowPrerelease() {
+    localStorage.setItem(SHOW_PRERELEASE_KEY, showPrerelease.value ? "true" : "false");
+  }
+
+  function setShowPrerelease(value: boolean) {
+    if (showPrerelease.value === value) return;
+    showPrerelease.value = value;
+    saveShowPrerelease();
+    checkForUpdates({ force: true }, false);
   }
 
   async function fetchVersionInfo() {
@@ -173,7 +202,10 @@ export const useVersionStore = defineStore("version", () => {
         saveDismissedVersions();
       }
 
-      checkResult.value = await versionApi.checkUpdate(options);
+      checkResult.value = await versionApi.checkUpdate({
+        ...options,
+        includePrerelease: showPrerelease.value,
+      });
 
       if (showNotification && hasUpdate.value && visibleReleases.value.length > 0) {
         const latestRelease = visibleReleases.value[0];
@@ -237,6 +269,9 @@ export const useVersionStore = defineStore("version", () => {
     visibleReleases,
     hasMoreReleases,
     changelogUrl,
+    hasPrereleaseUpdate,
+    onlyPrereleaseUpdates,
+    showPrerelease,
     runtime,
     upgradeProgress,
     upgrading,
@@ -247,6 +282,7 @@ export const useVersionStore = defineStore("version", () => {
     dismissVersion,
     dismissAllVisible,
     clearDismissed,
+    setShowPrerelease,
     fetchRuntime,
     startUpgrade,
     cancelUpgrade,

--- a/web/frontend/src/styles/shared-components.css
+++ b/web/frontend/src/styles/shared-components.css
@@ -66,6 +66,21 @@
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--pt-color-warning) 26%, transparent);
 }
 
+.update-dot.is-prerelease {
+  background: var(--pt-color-danger);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--pt-color-danger) 26%, transparent);
+}
+
+.version-btn.has-prerelease {
+  color: var(--pt-color-warning);
+}
+
+.version-btn.has-prerelease:hover {
+  background: color-mix(in srgb, var(--pt-color-warning) 10%, transparent);
+  border-color: color-mix(in srgb, var(--pt-color-warning) 28%, transparent);
+  color: var(--pt-color-warning);
+}
+
 .is-checking {
   animation: version-rotate 1.5s linear infinite;
 }
@@ -198,6 +213,34 @@
   box-shadow: var(--pt-shadow-sm);
 }
 
+.version-content .release-item.is-prerelease {
+  border-color: color-mix(in srgb, var(--pt-color-warning) 45%, transparent);
+  background: linear-gradient(
+    160deg,
+    color-mix(in srgb, var(--pt-color-warning) 10%, var(--pt-bg-surface-raised)),
+    var(--pt-bg-surface-raised)
+  );
+  position: relative;
+}
+
+.version-content .release-item.is-prerelease::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    var(--pt-color-warning),
+    color-mix(in srgb, var(--pt-color-warning) 40%, transparent)
+  );
+  border-radius: var(--pt-radius-lg) var(--pt-radius-lg) 0 0;
+}
+
+.version-content .release-item.is-prerelease:hover {
+  border-color: color-mix(in srgb, var(--pt-color-warning) 65%, transparent);
+  box-shadow: 0 4px 12px -4px color-mix(in srgb, var(--pt-color-warning) 35%, transparent);
+}
+
 .version-content .release-info {
   display: flex;
   flex-direction: column;
@@ -220,6 +263,65 @@
   padding: 2px 8px;
   border-radius: var(--pt-radius-full);
   background: color-mix(in srgb, var(--pt-color-primary) 12%, transparent);
+}
+
+.version-content .version-tag.is-prerelease {
+  color: var(--pt-color-warning);
+  background: color-mix(in srgb, var(--pt-color-warning) 16%, transparent);
+}
+
+.version-content .release-title-versions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pt-space-1);
+}
+
+.version-content .channel-badge {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.version-content .prerelease-notice {
+  border-radius: var(--pt-radius-md);
+}
+
+.version-content .prerelease-notice strong {
+  font-weight: 700;
+}
+
+.version-content .prerelease-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--pt-space-2);
+  padding: var(--pt-space-2) var(--pt-space-3);
+  margin-bottom: var(--pt-space-3);
+  border: 1px dashed var(--pt-border-color);
+  border-radius: var(--pt-radius-md);
+  background: var(--pt-bg-surface-muted);
+}
+
+.version-content .prerelease-toggle-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--pt-text-secondary);
+  font-weight: 500;
+}
+
+.version-content .prerelease-toggle-hint {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: var(--pt-radius-full);
+  background: var(--pt-border-color);
+  color: var(--pt-text-tertiary);
+  font-size: 10px;
+  font-weight: 700;
+  cursor: help;
 }
 
 .version-content .release-date {


### PR DESCRIPTION
## Summary
版本更新检测和自升级流程新增**预发版识别**与**多维度视觉差异化**，让用户一眼辨认预发版、升级前强制确认，避免误升级到测试版本。参考 delta-ui 设计语言的徽章/柔和阴影/color-mix 混色模式，保持与现有 pt-tools 设计 token 一致。

## 解决了什么
配合 #291 的预发版发布通道上线，用户在 Web UI 右上角看到版本更新通知时，需要**直观区分**「正式版」「预发版（beta/rc/alpha）」，并对预发版升级**强制警示**「非必要请等待正式版」。

## 后端改动 (`version/checker.go` + `web/api_version.go`)

| 位置 | 改动 |
|---|---|
| `ReleaseInfo` | 新增 `Prerelease bool` + `PrereleaseLabel string` 字段（JSON 序列化透传给前端）|
| `extractPrereleaseLabel` | **新增** 辅助函数，白名单只认 beta/rc/alpha，dev/snapshot 等非标准标签返回空 |
| `filterNewReleases(includePrerelease bool)` | 参数化过滤；**双重信号识别**（`r.Prerelease || tag 后缀`），防止发版时漏勾 GitHub Prerelease 勾选 |
| `CheckOptions.IncludePrerelease` | 新增字段；**缓存 key 同时考虑此字段**，切换开关时强制刷新 |
| `/api/version/check?include_prerelease=true` | 新查询参数 |

**向后兼容**：默认 `false`，旧客户端/旧版 UI 行为完全不变。

## 前端改动

### TS 类型 & Store
- `ReleaseInfo` 同步加 `prerelease?: boolean; prerelease_label?: string`
- `versionApi.checkUpdate({ includePrerelease })` 新选项
- Pinia store 新增：
  - `showPrerelease` ref（localStorage 持久化）
  - `hasPrereleaseUpdate` / `onlyPrereleaseUpdates` computed
  - `setShowPrerelease(value)` action（切换后自动强制刷新）

### VersionChecker.vue 多维度视觉差异化
1. **右上角按钮**：仅预发版更新时按钮色 → warning，红点 → danger 色
2. **弹层顶部**：新增「含预发版（beta/rc）」开关 + 悬浮帮助提示
3. **更新列表头部 tag**：三态 —— 「仅发现预发版」/「发现新版本（含预发版）」/「发现新版本」
4. **警示 Alert**：存在预发版时显示 `<el-alert type="warning">`，文案"**非必要请等待正式版发布后再升级**"
5. **预发版卡片**：warning 色边框 + 轻柔 warning 混色背景 + 顶部 3px 渐变条
6. **版本号徽章**：预发版使用 warning 色配色
7. **通道徽章**：版本号旁新增大写徽章 `BETA` / `RC` / `ALPHA`
8. **升级按钮**：预发版改为 warning 色 + 文案「升级到预发版」
9. **确认对话框**：点击预发版升级时弹 `ElMessageBox`，强制二次确认

### 设计语言参考 delta-ui
- Pill-shaped 徽章（`border-radius: full`）
- Color-mix 混色底（`color-mix(in srgb, ... N%, transparent)`）
- 柔和阴影 + 顶部渐变强调条而非硬边框
- 保持与 pt-tools 现有 token 一致（`--pt-color-warning` / `--pt-color-danger`）

## 测试覆盖（5 个新增用例，全部 PASS）
- `TestFilterNewReleases_IncludePrerelease`：开关语义 + 字段填充 + 排序（含预发版优先级）
- `TestFilterNewReleases_TagSuffixDetection`：漏勾 prerelease 时的 tag 后缀兜底识别
- `TestExtractPrereleaseLabel`：9 个输入覆盖白名单 + 大小写 + dot 分段

## 验证
- ✅ `go test ./...` **21/21 包全通过**
- ✅ `make fmt` + `make lint` **0 issues**
- ✅ `vue-tsc --noEmit` **0 errors**

## 兼容性
| 场景 | 行为 |
|---|---|
| 旧后端 + 新前端 | 响应无 `prerelease` 字段，前端 `release.prerelease` 为 undefined，所有差异化 UI 自动回退为正式版展示 |
| 新后端 + 旧前端 | 额外字段被忽略，旧前端行为不变 |
| 默认状态 | `showPrerelease=false`，完全隐藏预发版（等同老行为） |

## 用户体验流程
1. 用户打开 Web UI，**默认只看到正式版**
2. 切换「含预发版」开关 → 弹层刷新显示预发版卡片（warning 色 + BETA 徽章 + 警示 alert）
3. 点击「升级到预发版」→ 二次确认对话框警示风险 → 用户确认后执行升级
4. 开关状态持久化到 localStorage，跨会话保持

## 关联
- 依赖 #291 的预发版发布 workflow 产生的 GitHub Releases 才会有 `prerelease: true` 的版本
- 下一步：手动打 `v0.28.0-beta.1` 验证 #291 workflow + 本 PR UI 联动效果