### PR TITLE
fix(push): 修复磁盘保护漏洞 - 推送前考虑种子大小、待下载累计与并发预留 (Issue #299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -402,12 +402,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **site**: 新增 OpenCD 和 PTT 站点适配
 - 新增 site/v2/definitions/opencd.go 适配 open.cd (繁体 NexusPHP)
   _ 使用 div.title + td.rowtitle 替代标准 h1 + td.rowhead
-  _ 支持 plugin*details.php 链接格式
-  * 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
-  * 处理 font.promotion 替代 img.pro*_ 的非标准折扣标记
-  _ span.category 替代 img[alt] 的分类标记
-  _ 处理 info_block 隐藏列的 nth-child 索引偏移
-  _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
+  _ 支持 plugin\*details.php 链接格式
+  - 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
+  - 处理 font.promotion 替代 img.pro\*_ 的非标准折扣标记
+    _ span.category 替代 img[alt] 的分类标记
+    _ 处理 info_block 隐藏列的 nth-child 索引偏移
+    _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
 
 ## [0.23.0] - 2026-04-29
 

--- a/internal/common.go
+++ b/internal/common.go
@@ -327,21 +327,57 @@ func processSingleTorrentWithDownloader(
 		return nil
 	}
 
-	// 磁盘空间预检查：空间低于保底阈值时拒绝推送
+	// 磁盘空间预检查（修复 Issue #299）
+	//
+	// 旧实现仅比较 freeGB < threshold，存在两个 race：
+	//  1. 没扣除即将推送种子自身大小 —— 一次性多种子推送各自看到相同 free。
+	//  2. qBit 默认 preallocate_all=false，新推送种子直到下载完成才反映在
+	//     free_space_on_disk —— 多 RSS worker 并发推送基于过时数据通过检查。
+	// 修复策略 = 三层减法 + 全局互斥锁串行化：
+	//   effective_free = client_free - in_flight_pending - pre_reserved
+	//   gate           = effective_free - thisTorrentSize >= threshold
 	if glOnly.CleanupDiskProtect && glOnly.CleanupMinDiskSpaceGB > 0 {
+		mu := PushMutex()
+		mu.Lock()
+		defer mu.Unlock()
+
 		freeSpace, spaceErr := dl.GetClientFreeSpace(ctx)
 		if spaceErr != nil {
-			sLogger().Warnf("[磁盘保护] 获取磁盘空间失败，继续推送: %v", spaceErr)
-		} else {
-			freeGB := float64(freeSpace) / (1024 * 1024 * 1024)
-			if freeGB < glOnly.CleanupMinDiskSpaceGB {
-				sLogger().Warnf("[磁盘保护] %s: 磁盘空间不足 (%.1f GB < %.1f GB)，跳过推送: %s",
-					dl.GetName(), freeGB, glOnly.CleanupMinDiskSpaceGB, filePath)
-				if glOnly.CleanupEnabled {
-					events.Publish(events.Event{Type: events.DiskSpaceLow, Source: "rss", At: time.Now()})
-				}
-				return downloader.ErrInsufficientSpace
+			// fail-closed：磁盘保护启用时若无法读取空间，拒绝推送而非放行。
+			// 旧实现 fail-open ("继续推送")是 Issue #299 的次因之一。
+			sLogger().Warnf("[磁盘保护] %s: 获取磁盘空间失败，磁盘保护启用故拒绝推送: %v", dl.GetName(), spaceErr)
+			return downloader.ErrInsufficientSpace
+		}
+
+		pendingBytes, pendingErr := dl.GetIncompletePendingBytes(ctx)
+		if pendingErr != nil {
+			sLogger().Warnf("[磁盘保护] %s: 查询 in-flight pending 失败，仅以 reserved 推算: %v", dl.GetName(), pendingErr)
+			pendingBytes = 0
+		}
+		budget := GetDiskBudget()
+		effectiveFreeBytes := freeSpace - pendingBytes - budget.Reserved()
+		if effectiveFreeBytes < 0 {
+			effectiveFreeBytes = 0
+		}
+		var torrentSize int64
+		if torrent != nil {
+			torrentSize = torrent.TorrentSize
+		}
+		minBytes := int64(glOnly.CleanupMinDiskSpaceGB * 1024 * 1024 * 1024)
+		if effectiveFreeBytes-torrentSize < minBytes {
+			effGB := float64(effectiveFreeBytes) / (1024 * 1024 * 1024)
+			tGB := float64(torrentSize) / (1024 * 1024 * 1024)
+			sLogger().Warnf("[磁盘保护] %s: 空间不足 (有效 %.1f GB - 种子 %.1f GB < 保底 %.1f GB)，跳过推送: %s",
+				dl.GetName(), effGB, tGB, glOnly.CleanupMinDiskSpaceGB, filePath)
+			if glOnly.CleanupEnabled {
+				events.Publish(events.Event{Type: events.DiskSpaceLow, Source: "rss", At: time.Now()})
 			}
+			return downloader.ErrInsufficientSpace
+		}
+		// 通过检查后立刻预留，确保后续 worker 能看到本次扣减。
+		// 推送失败会在下方失败分支 Release 归还。
+		if torrentSize > 0 {
+			budget.Reserve(torrentSize)
 		}
 	}
 
@@ -361,6 +397,12 @@ func processSingleTorrentWithDownloader(
 	}
 	result, pushErr := dl.AddTorrentFileEx(torrentData, opt)
 	if pushErr != nil || !result.Success {
+		// 推送失败：归还预留配额，避免 budget 被永久占用。
+		// 注：torrent 可能为 nil（极少数情况下 GetTorrentBySiteAndHash 失败但仍走到这）；
+		// 由 Reserve 的零值守卫保证 Release(0) no-op。
+		if torrent != nil && glOnly.CleanupDiskProtect && torrent.TorrentSize > 0 {
+			GetDiskBudget().Release(torrent.TorrentSize)
+		}
 		errMsg := ""
 		if pushErr != nil {
 			errMsg = pushErr.Error()

--- a/internal/common_test.go
+++ b/internal/common_test.go
@@ -929,6 +929,7 @@ func TestProcessSingleTorrentWithDownloader_NewTorrentPushSuccess(t *testing.T) 
 	mockDl.EXPECT().GetType().Return(downloader.DownloaderQBittorrent).AnyTimes()
 	mockDl.EXPECT().CheckTorrentExists(hash).Return(false, nil)
 	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(int64(100*1024*1024*1024), nil)
+	mockDl.EXPECT().GetIncompletePendingBytes(gomock.Any()).Return(int64(0), nil)
 	mockDl.EXPECT().AddTorrentFileEx(gomock.Any(), gomock.Any()).Return(downloader.AddTorrentResult{Success: true, Hash: hash}, nil)
 
 	dlInfo := &DownloaderInfo{ID: 1, Name: "test-dl", AutoStart: true}
@@ -970,6 +971,7 @@ func TestProcessSingleTorrentWithDownloader_PushFailed(t *testing.T) {
 	mockDl.EXPECT().GetType().Return(downloader.DownloaderQBittorrent).AnyTimes()
 	mockDl.EXPECT().CheckTorrentExists(hash).Return(false, nil)
 	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(int64(100*1024*1024*1024), nil)
+	mockDl.EXPECT().GetIncompletePendingBytes(gomock.Any()).Return(int64(0), nil)
 	mockDl.EXPECT().AddTorrentFileEx(gomock.Any(), gomock.Any()).Return(downloader.AddTorrentResult{Success: false, Message: "push failed"}, fmt.Errorf("push failed"))
 
 	dlInfo := &DownloaderInfo{ID: 1, Name: "test-dl", AutoStart: true}
@@ -1405,6 +1407,7 @@ func TestProcessTorrentsWithDownloaderByRSS_WithDownloadPath(t *testing.T) {
 	mockDl.EXPECT().GetType().Return(downloader.DownloaderQBittorrent).AnyTimes()
 	mockDl.EXPECT().CheckTorrentExists(hash).Return(false, nil)
 	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(int64(100*1024*1024*1024), nil)
+	mockDl.EXPECT().GetIncompletePendingBytes(gomock.Any()).Return(int64(0), nil)
 	mockDl.EXPECT().AddTorrentFileEx(gomock.Any(), gomock.Any()).Return(downloader.AddTorrentResult{Success: true, Hash: hash}, nil)
 
 	dlInfo := &DownloaderInfo{ID: 1, Name: "test-dl", AutoStart: true}

--- a/internal/disk_budget.go
+++ b/internal/disk_budget.go
@@ -1,35 +1,68 @@
+// MIT License
+// Copyright (c) 2025 pt-tools
+
 package internal
 
 import (
+	"sync"
 	"sync/atomic"
 
 	"github.com/sunerpy/pt-tools/global"
 )
 
 // DiskBudget 跟踪已预留但尚未落盘的磁盘空间。
-// 多个并发 RSS worker 推送前先 Reserve，防止同时看到相同的空闲空间而并发越界。
+//
+// 多个并发 RSS worker 推送前先 Reserve，防止它们同时观察到相同的 OS 空闲空间
+// 而并发越界（Issue #299 根因之一）。Reserve/Release 使用原子计数 + 修正循环
+// 保证不会下溢到负数。
+//
+// 典型用法:
+//
+//	budget := internal.GetDiskBudget()
+//	if budget.EffectiveFreeGB(rawFreeBytes)-torrentSizeGB < threshold {
+//	    return ErrInsufficientSpace
+//	}
+//	budget.Reserve(torrentSize)
+//	if pushErr != nil {
+//	    budget.Release(torrentSize) // 推送失败时归还配额
+//	}
+//	// 推送成功的预留由 cleanup_monitor 周期 Reset，或上层在 qBit 已可见后调
+//	// Release（避免与 GetIncompletePendingBytes 双重计数）。
 type DiskBudget struct {
 	reserved atomic.Int64
 }
 
-// Reserve 预留指定字节数。
-// 返回预留后的总已预留字节数。
+// Reserve 预留指定字节数。bytes <= 0 视为 no-op。返回预留后的总已预留字节数。
 func (b *DiskBudget) Reserve(bytes int64) int64 {
+	if bytes <= 0 {
+		return b.reserved.Load()
+	}
 	return b.reserved.Add(bytes)
 }
 
-// Release 释放指定字节数（推送失败时调用）。
+// Release 释放指定字节数（推送失败 / 已被下游可见时调用）。
+//
+// 实现细节：原始版本用 Add(-bytes) + CAS(newVal, 0)，但若并发 Reserve 在
+// Add 与 CAS 之间发生，CAS 会失败保留负值，污染后续 Reserved() 读取。
+// 此版本用 CompareAndSwap 循环 ——每次基于最新值计算 desired，确保最终
+// 不会下溢到 < 0。
 func (b *DiskBudget) Release(bytes int64) {
 	if bytes <= 0 {
 		return
 	}
-	newVal := b.reserved.Add(-bytes)
-	if newVal < 0 {
-		b.reserved.CompareAndSwap(newVal, 0)
+	for {
+		current := b.reserved.Load()
+		desired := current - bytes
+		if desired < 0 {
+			desired = 0
+		}
+		if b.reserved.CompareAndSwap(current, desired) {
+			return
+		}
 	}
 }
 
-// Reserved 返回当前已预留的字节数。
+// Reserved 返回当前已预留的字节数。下溢的负值会被规范化为 0。
 func (b *DiskBudget) Reserved() int64 {
 	v := b.reserved.Load()
 	if v < 0 {
@@ -38,15 +71,20 @@ func (b *DiskBudget) Reserved() int64 {
 	return v
 }
 
-// Reset 重置预留计数（清理完成后调用以重新校准）。
+// Reset 重置预留计数（清理监控周期开始时调用以重新校准）。
 func (b *DiskBudget) Reset() {
 	old := b.reserved.Swap(0)
 	if old > 0 {
-		global.GetSlogger().Infof("[磁盘预算] 重置预留空间 (释放 %.1f GB)", float64(old)/(1024*1024*1024))
+		// 仅当真有预留被清空时才打日志，避免空闲期日志噪音。
+		// GetSloggerSafe 在 GlobalLogger 未初始化（如单测）时安全返回 nil。
+		if logger := global.GetSloggerSafe(); logger != nil {
+			logger.Infof("[磁盘预算] 重置预留空间 (释放 %.1f GB)", float64(old)/(1024*1024*1024))
+		}
 	}
 }
 
-// EffectiveFreeGB 计算有效可用空间 = 实际可用 - 已预留。
+// EffectiveFreeGB 计算"扣除已预留后"的有效可用空间（GB）。
+// actualFreeBytes 通常来自 downloader.GetClientFreeSpace。下溢钳位为 0。
 func (b *DiskBudget) EffectiveFreeGB(actualFreeBytes int64) float64 {
 	effective := actualFreeBytes - b.Reserved()
 	if effective < 0 {
@@ -55,10 +93,26 @@ func (b *DiskBudget) EffectiveFreeGB(actualFreeBytes int64) float64 {
 	return float64(effective) / (1024 * 1024 * 1024)
 }
 
-// globalDiskBudget 全局单例
-var globalDiskBudget = &DiskBudget{}
+// EffectiveFreeBytes 同 EffectiveFreeGB 但返回字节数。供下游做更精细比较。
+func (b *DiskBudget) EffectiveFreeBytes(actualFreeBytes int64) int64 {
+	effective := actualFreeBytes - b.Reserved()
+	if effective < 0 {
+		return 0
+	}
+	return effective
+}
+
+// 全局单例 + 推送互斥锁。pushMutex 串行化 disk-check + Reserve + AddTorrentFileEx
+// critical section，关闭多 RSS worker 之间的 race（即便有 Reserve，竞态读取
+// freeSpace 与 Reserve 之间的窗口仍可能让两个 worker 同时通过）。
+var (
+	globalDiskBudget = &DiskBudget{}
+	globalPushMutex  sync.Mutex
+)
 
 // GetDiskBudget 返回全局磁盘预算实例。
-func GetDiskBudget() *DiskBudget {
-	return globalDiskBudget
-}
+func GetDiskBudget() *DiskBudget { return globalDiskBudget }
+
+// PushMutex 返回全局推送互斥锁。调用方应在 disk-check 前 Lock，
+// 推送结束后 Unlock。注意：锁的范围是单实例进程级，多实例部署需要外部协调。
+func PushMutex() *sync.Mutex { return &globalPushMutex }

--- a/internal/disk_budget_test.go
+++ b/internal/disk_budget_test.go
@@ -1,0 +1,199 @@
+package internal
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const gb = int64(1024 * 1024 * 1024)
+
+// resetGlobalBudget 把全局 budget 清零，避免测试之间互相污染。
+func resetGlobalBudget() { GetDiskBudget().Reset() }
+
+func TestDiskBudget_ReserveAndReleaseBasic(t *testing.T) {
+	resetGlobalBudget()
+	b := &DiskBudget{}
+	assert.Equal(t, int64(0), b.Reserved())
+
+	b.Reserve(100 * gb)
+	assert.Equal(t, 100*gb, b.Reserved())
+
+	b.Reserve(50 * gb)
+	assert.Equal(t, 150*gb, b.Reserved())
+
+	b.Release(40 * gb)
+	assert.Equal(t, 110*gb, b.Reserved())
+
+	b.Release(110 * gb)
+	assert.Equal(t, int64(0), b.Reserved())
+}
+
+// TestDiskBudget_ReserveZeroNoop 验证 Reserve(0) 和 Release(0) 不影响计数。
+func TestDiskBudget_ReserveZeroNoop(t *testing.T) {
+	b := &DiskBudget{}
+	b.Reserve(0)
+	b.Reserve(-100)
+	b.Release(0)
+	b.Release(-100)
+	assert.Equal(t, int64(0), b.Reserved())
+}
+
+// TestDiskBudget_ReleaseClampsAtZero 验证 Release 超过当前持有量不会下溢负数。
+func TestDiskBudget_ReleaseClampsAtZero(t *testing.T) {
+	b := &DiskBudget{}
+	b.Reserve(50 * gb)
+	b.Release(200 * gb)
+	assert.Equal(t, int64(0), b.Reserved())
+}
+
+func TestDiskBudget_Reset(t *testing.T) {
+	b := &DiskBudget{}
+	b.Reserve(123 * gb)
+	assert.Equal(t, 123*gb, b.Reserved())
+	b.Reset()
+	assert.Equal(t, int64(0), b.Reserved())
+}
+
+func TestDiskBudget_EffectiveFreeGB(t *testing.T) {
+	b := &DiskBudget{}
+	b.Reserve(30 * gb)
+	got := b.EffectiveFreeGB(100 * gb)
+	assert.InDelta(t, 70.0, got, 0.01, "100GB - 30GB reserved = 70GB effective")
+
+	got = b.EffectiveFreeGB(20 * gb)
+	assert.Equal(t, 0.0, got, "actualFree < reserved 应钳位为 0")
+}
+
+func TestDiskBudget_EffectiveFreeBytes(t *testing.T) {
+	b := &DiskBudget{}
+	b.Reserve(30 * gb)
+	assert.Equal(t, 70*gb, b.EffectiveFreeBytes(100*gb))
+	assert.Equal(t, int64(0), b.EffectiveFreeBytes(10*gb), "下溢钳位 0")
+}
+
+// TestDiskBudget_ConcurrentReserveRelease 高并发下证明计数最终一致。
+// 1000 个 goroutine 各 Reserve 1MB 并随后 Release 1MB —— 最终应回 0 且无下溢。
+func TestDiskBudget_ConcurrentReserveRelease(t *testing.T) {
+	b := &DiskBudget{}
+	const n = 1000
+	const each = int64(1024 * 1024)
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			b.Reserve(each)
+			b.Release(each)
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int64(0), b.Reserved(), "并发 Reserve+Release 后应归零")
+}
+
+// TestDiskBudget_ConcurrentReleaseDoesNotUnderflow 证明并发 Release 在
+// 同时 Reserve 干扰下也不会下溢出去。这是修复"Add(-bytes)+CAS"竞态的回归测试。
+func TestDiskBudget_ConcurrentReleaseDoesNotUnderflow(t *testing.T) {
+	b := &DiskBudget{}
+	b.Reserve(1000 * gb)
+
+	var wg sync.WaitGroup
+	const releaseN = 500
+	const reserveN = 500
+	wg.Add(releaseN + reserveN)
+
+	for i := 0; i < releaseN; i++ {
+		go func() {
+			defer wg.Done()
+			b.Release(2 * gb) // 共释放 1000 GB
+		}()
+	}
+	for i := 0; i < reserveN; i++ {
+		go func() {
+			defer wg.Done()
+			b.Reserve(1 * gb) // 共预留 500 GB
+		}()
+	}
+	wg.Wait()
+
+	// 不变量：Reserved() 始终非负
+	got := b.Reserved()
+	assert.GreaterOrEqual(t, got, int64(0), "Reserved 必须 >= 0，旧版本会下溢")
+	// 期望终值：1000 - 1000 + 500 = 500 GB（由于钳位行为在并发下严格相等不可
+	// 保证，但应在 [0, 500GB] 范围内 —— 关键不变量是非负）
+	assert.LessOrEqual(t, got, 500*gb, "终值不可能超过最大预留量")
+}
+
+// TestDiskBudget_RaceConditionGate 模拟 Issue #299 race：两个 worker 同时读
+// "120 GB free"，各想推送 80 GB —— 没有 Reserve 的话两个都通过 (120-80=40>20
+// 阈值)；有 Reserve 后第二个看到的 effective_free=120-80=40，再减自己的 80=
+// -40 < 阈值，被拒。
+func TestDiskBudget_RaceConditionGate(t *testing.T) {
+	b := &DiskBudget{}
+	const rawFree = 120 * gb
+	const torrentSize = 80 * gb
+	const minThreshold = 20 * gb
+
+	// worker 1
+	eff1 := b.EffectiveFreeBytes(rawFree)
+	require.GreaterOrEqual(t, eff1-torrentSize, minThreshold, "worker 1 应通过")
+	b.Reserve(torrentSize)
+
+	// worker 2 同时跑（rawFree 还没变，因为 qBit 还没开始下载）
+	eff2 := b.EffectiveFreeBytes(rawFree)
+	assert.Equal(t, 40*gb, eff2, "worker 2 看到的有效空间应已扣除 worker 1 的预留")
+	assert.Less(t, eff2-torrentSize, minThreshold,
+		"worker 2 应被拦截（40-80 = -40 < 20）—— 这正是 Issue #299 的修复点")
+}
+
+// TestDiskBudget_GlobalSingleton 验证 GetDiskBudget 返回同一实例。
+func TestDiskBudget_GlobalSingleton(t *testing.T) {
+	a := GetDiskBudget()
+	c := GetDiskBudget()
+	assert.Same(t, a, c)
+}
+
+// TestPushMutex_Singleton 验证 PushMutex 返回同一实例并能正常上锁。
+func TestPushMutex_Singleton(t *testing.T) {
+	m1 := PushMutex()
+	m2 := PushMutex()
+	assert.Same(t, m1, m2, "PushMutex 必须是同一全局实例")
+
+	// 能锁并解锁，不死锁
+	m1.Lock()
+	m1.Unlock()
+}
+
+// TestPushMutex_SerializesPushers 用 mutex 串行化 100 个 worker 验证
+// "并发推送被序列化" 不变量：任意时刻最多 1 个临界区在执行。
+func TestPushMutex_SerializesPushers(t *testing.T) {
+	mu := PushMutex()
+	var inCritical atomic.Int32
+	var maxConcurrent atomic.Int32
+
+	var wg sync.WaitGroup
+	const n = 100
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			mu.Lock()
+			c := inCritical.Add(1)
+			// 更新峰值
+			for {
+				old := maxConcurrent.Load()
+				if c <= old || maxConcurrent.CompareAndSwap(old, c) {
+					break
+				}
+			}
+			inCritical.Add(-1)
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int32(1), maxConcurrent.Load(), "互斥锁应保证临界区最多 1 个 goroutine")
+}

--- a/internal/disk_budget_test.go
+++ b/internal/disk_budget_test.go
@@ -163,8 +163,10 @@ func TestPushMutex_Singleton(t *testing.T) {
 	m2 := PushMutex()
 	assert.Same(t, m1, m2, "PushMutex 必须是同一全局实例")
 
-	// 能锁并解锁，不死锁
+	// 能锁并解锁，不死锁。Lock + 其它操作 + Unlock 形式让 staticcheck SA2001
+	// 满意（empty critical section 误判）。
 	m1.Lock()
+	_ = m1
 	m1.Unlock()
 }
 

--- a/internal/disk_protect_test.go
+++ b/internal/disk_protect_test.go
@@ -1,0 +1,291 @@
+// MIT License
+// Copyright (c) 2025 pt-tools
+
+// Tests for Issue #299: 磁盘保护应在推送前考虑 (1) 即将推送种子大小,
+// (2) qBit/Transmission in-flight 待下载累计, (3) 跨 worker 的预留预算。
+// 全局 PushMutex 串行化整个 disk-check + Reserve + push 临界区。
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sunerpy/pt-tools/core"
+	"github.com/sunerpy/pt-tools/global"
+	sm "github.com/sunerpy/pt-tools/mocks"
+	"github.com/sunerpy/pt-tools/models"
+	"github.com/sunerpy/pt-tools/thirdpart/downloader"
+)
+
+// setUpDiskProtectTest 为磁盘保护测试初始化全局 DB + 写入 SettingsGlobal 行。
+// 每个测试都需要：(1) 干净的 GlobalDB；(2) CleanupDiskProtect=true；
+// (3) CleanupMinDiskSpaceGB=20；(4) 重置 budget。
+//
+// 使用 ConfigStore.SaveGlobalSettings 而非直接 db.Save —— 后者依赖 ID 主键
+// 匹配，可能与 setupDB 已写入的行冲突，导致测试看到 default 行而非我们配置。
+func setUpDiskProtectTest(t *testing.T) {
+	t.Helper()
+	db := setupDB(t)
+	global.GlobalDB = db
+	t.Cleanup(func() { global.GlobalDB = nil })
+
+	store := core.NewConfigStore(db)
+	require.NoError(t, store.SaveGlobalSettings(models.SettingsGlobal{
+		DownloadDir:           t.TempDir(),
+		MaxRetry:              0,
+		CleanupDiskProtect:    true,
+		CleanupMinDiskSpaceGB: 20,
+		CleanupEnabled:        false,
+	}))
+
+	// 验证 ConfigStore 真能取出
+	got, err := store.GetGlobalOnly()
+	require.NoError(t, err)
+	require.True(t, got.CleanupDiskProtect, "CleanupDiskProtect 应为 true")
+	require.Equal(t, float64(20), got.CleanupMinDiskSpaceGB)
+
+	// 重置全局预算，避免测试间泄漏
+	GetDiskBudget().Reset()
+	t.Cleanup(func() { GetDiskBudget().Reset() })
+}
+
+// makeTorrentInfoWithSize 创建一个带 TorrentSize 的种子记录。
+// FreeEndTime 必须置于未来，否则 processSingleTorrentWithDownloader 在 line 244
+// 会判定过期并提前 return nil（导致 mock 期望落空）。
+func makeTorrentInfoWithSize(t *testing.T, db *models.TorrentDB, hash string, sizeBytes int64) {
+	t.Helper()
+	pushed := false
+	future := time.Now().Add(1 * time.Hour)
+	ti := &models.TorrentInfo{
+		SiteName:     string(models.SiteGroup("springsunday")),
+		TorrentHash:  &hash,
+		IsPushed:     &pushed,
+		FreeEndTime:  &future,
+		TorrentSize:  sizeBytes,
+		IsDownloaded: true,
+	}
+	require.NoError(t, db.UpsertTorrent(ti))
+}
+
+// TestDiskProtect_RejectsWhenSizeExceedsEffectiveFree 验证：
+// 即将推送种子大小被纳入计算 — 80GB 种子 + 80GB free + 20GB 阈值 → 80-80=0 < 20 拒绝。
+// 旧实现（不减种子大小）会通过 (80 > 20)。
+func TestDiskProtect_RejectsWhenSizeExceedsEffectiveFree(t *testing.T) {
+	setUpDiskProtectTest(t)
+	dir := t.TempDir()
+	path, hash := makeTorrentFile(t, dir)
+	makeTorrentInfoWithSize(t, global.GlobalDB, hash, 80*gb)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDl := sm.NewMockDownloader(ctrl)
+	mockDl.EXPECT().GetName().Return("test-dl").AnyTimes()
+	mockDl.EXPECT().GetType().Return(downloader.DownloaderQBittorrent).AnyTimes()
+	mockDl.EXPECT().CheckTorrentExists(hash).Return(false, nil)
+	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(int64(80*gb), nil)
+	mockDl.EXPECT().GetIncompletePendingBytes(gomock.Any()).Return(int64(0), nil)
+	// AddTorrentFileEx 不应被调用 —— 这是关键断言
+
+	dlInfo := &DownloaderInfo{ID: 1, Name: "test-dl", AutoStart: true}
+	err := processSingleTorrentWithDownloader(context.Background(), mockDl, dlInfo,
+		path, "cat", "tag", "", models.SiteGroup("springsunday"), false)
+	require.ErrorIs(t, err, downloader.ErrInsufficientSpace,
+		"种子 80GB > effective_free 80GB - 阈值 20GB 应被拒")
+	assert.Equal(t, int64(0), GetDiskBudget().Reserved(),
+		"被拒后不应预留")
+}
+
+// TestDiskProtect_AllowsWhenSizeFits 验证：30GB 种子 + 80GB free 通过 (80-30=50 > 20)。
+func TestDiskProtect_AllowsWhenSizeFits(t *testing.T) {
+	setUpDiskProtectTest(t)
+	dir := t.TempDir()
+	path, hash := makeTorrentFile(t, dir)
+	makeTorrentInfoWithSize(t, global.GlobalDB, hash, 30*gb)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDl := sm.NewMockDownloader(ctrl)
+	mockDl.EXPECT().GetName().Return("test-dl").AnyTimes()
+	mockDl.EXPECT().GetType().Return(downloader.DownloaderQBittorrent).AnyTimes()
+	mockDl.EXPECT().CheckTorrentExists(hash).Return(false, nil)
+	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(int64(80*gb), nil)
+	mockDl.EXPECT().GetIncompletePendingBytes(gomock.Any()).Return(int64(0), nil)
+	mockDl.EXPECT().AddTorrentFileEx(gomock.Any(), gomock.Any()).
+		Return(downloader.AddTorrentResult{Success: true, Hash: hash}, nil)
+
+	dlInfo := &DownloaderInfo{ID: 1, Name: "test-dl", AutoStart: true}
+	err := processSingleTorrentWithDownloader(context.Background(), mockDl, dlInfo,
+		path, "cat", "tag", "", models.SiteGroup("springsunday"), false)
+	require.NoError(t, err)
+	assert.Equal(t, int64(30*gb), GetDiskBudget().Reserved(),
+		"推送成功后应保留预算 30GB（由 cleanup_monitor Reset 或上层回收）")
+}
+
+// TestDiskProtect_PendingDownloadsSubtracted 验证 in-flight pending 被扣除：
+// 100GB free + 60GB pending（已下载中的种子）+ 30GB 新种子 + 20GB 阈值
+// → effective=100-60=40，40-30=10 < 20 拒绝。
+// 这是 Issue #299 的核心修复 —— qBit 报告 100GB 但其实 60GB 已被在下载中的种子占用。
+func TestDiskProtect_PendingDownloadsSubtracted(t *testing.T) {
+	setUpDiskProtectTest(t)
+	dir := t.TempDir()
+	path, hash := makeTorrentFile(t, dir)
+	makeTorrentInfoWithSize(t, global.GlobalDB, hash, 30*gb)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDl := sm.NewMockDownloader(ctrl)
+	mockDl.EXPECT().GetName().Return("test-dl").AnyTimes()
+	mockDl.EXPECT().GetType().Return(downloader.DownloaderQBittorrent).AnyTimes()
+	mockDl.EXPECT().CheckTorrentExists(hash).Return(false, nil)
+	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(int64(100*gb), nil)
+	mockDl.EXPECT().GetIncompletePendingBytes(gomock.Any()).Return(int64(60*gb), nil)
+	// AddTorrentFileEx 不应被调用
+
+	dlInfo := &DownloaderInfo{ID: 1, Name: "test-dl", AutoStart: true}
+	err := processSingleTorrentWithDownloader(context.Background(), mockDl, dlInfo,
+		path, "cat", "tag", "", models.SiteGroup("springsunday"), false)
+	require.ErrorIs(t, err, downloader.ErrInsufficientSpace,
+		"100GB free - 60GB pending - 30GB new = 10 < 20 阈值 应被拒")
+}
+
+// TestDiskProtect_ReleaseOnPushFailure 验证推送失败时 Reserve 被归还。
+func TestDiskProtect_ReleaseOnPushFailure(t *testing.T) {
+	setUpDiskProtectTest(t)
+	dir := t.TempDir()
+	path, hash := makeTorrentFile(t, dir)
+	makeTorrentInfoWithSize(t, global.GlobalDB, hash, 30*gb)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDl := sm.NewMockDownloader(ctrl)
+	mockDl.EXPECT().GetName().Return("test-dl").AnyTimes()
+	mockDl.EXPECT().GetType().Return(downloader.DownloaderQBittorrent).AnyTimes()
+	mockDl.EXPECT().CheckTorrentExists(hash).Return(false, nil)
+	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(int64(100*gb), nil)
+	mockDl.EXPECT().GetIncompletePendingBytes(gomock.Any()).Return(int64(0), nil)
+	mockDl.EXPECT().AddTorrentFileEx(gomock.Any(), gomock.Any()).
+		Return(downloader.AddTorrentResult{Success: false, Message: "boom"}, errors.New("boom"))
+
+	dlInfo := &DownloaderInfo{ID: 1, Name: "test-dl", AutoStart: true}
+	err := processSingleTorrentWithDownloader(context.Background(), mockDl, dlInfo,
+		path, "cat", "tag", "", models.SiteGroup("springsunday"), false)
+	require.Error(t, err)
+	assert.Equal(t, int64(0), GetDiskBudget().Reserved(),
+		"推送失败必须 Release 归还预算，否则后续永远无法通过检查")
+}
+
+// TestDiskProtect_FailClosedOnFreeSpaceError 验证 fail-closed：
+// GetClientFreeSpace 出错时，磁盘保护启用应拒绝推送（旧版"继续推送"是 bug）。
+func TestDiskProtect_FailClosedOnFreeSpaceError(t *testing.T) {
+	setUpDiskProtectTest(t)
+	dir := t.TempDir()
+	path, hash := makeTorrentFile(t, dir)
+	makeTorrentInfoWithSize(t, global.GlobalDB, hash, 30*gb)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDl := sm.NewMockDownloader(ctrl)
+	mockDl.EXPECT().GetName().Return("test-dl").AnyTimes()
+	mockDl.EXPECT().GetType().Return(downloader.DownloaderQBittorrent).AnyTimes()
+	mockDl.EXPECT().CheckTorrentExists(hash).Return(false, nil)
+	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(int64(0), errors.New("qbit unreachable"))
+	// AddTorrentFileEx 不应被调用 —— fail-closed 验证
+
+	dlInfo := &DownloaderInfo{ID: 1, Name: "test-dl", AutoStart: true}
+	err := processSingleTorrentWithDownloader(context.Background(), mockDl, dlInfo,
+		path, "cat", "tag", "", models.SiteGroup("springsunday"), false)
+	require.ErrorIs(t, err, downloader.ErrInsufficientSpace,
+		"GetClientFreeSpace 失败时应 fail-closed（拒绝），而非 fail-open（旧实现）")
+}
+
+// TestDiskProtect_PendingErrorTreatedAsZero 验证 GetIncompletePendingBytes 出错时
+// 退化为 0（保守但仍生效）—— 不应整体 fail-closed，因为 pending 查询是辅助信号。
+func TestDiskProtect_PendingErrorTreatedAsZero(t *testing.T) {
+	setUpDiskProtectTest(t)
+	dir := t.TempDir()
+	path, hash := makeTorrentFile(t, dir)
+	makeTorrentInfoWithSize(t, global.GlobalDB, hash, 30*gb)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDl := sm.NewMockDownloader(ctrl)
+	mockDl.EXPECT().GetName().Return("test-dl").AnyTimes()
+	mockDl.EXPECT().GetType().Return(downloader.DownloaderQBittorrent).AnyTimes()
+	mockDl.EXPECT().CheckTorrentExists(hash).Return(false, nil)
+	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(int64(100*gb), nil)
+	mockDl.EXPECT().GetIncompletePendingBytes(gomock.Any()).Return(int64(0), errors.New("api fail"))
+	mockDl.EXPECT().AddTorrentFileEx(gomock.Any(), gomock.Any()).
+		Return(downloader.AddTorrentResult{Success: true, Hash: hash}, nil)
+
+	dlInfo := &DownloaderInfo{ID: 1, Name: "test-dl", AutoStart: true}
+	err := processSingleTorrentWithDownloader(context.Background(), mockDl, dlInfo,
+		path, "cat", "tag", "", models.SiteGroup("springsunday"), false)
+	require.NoError(t, err, "GetIncompletePendingBytes 失败应退化为 0，不阻止推送")
+}
+
+// TestDiskProtect_ConcurrentPushesSerializeAndReject 是 Issue #299 race 的端到端回归。
+//
+// 模拟 5 个并发 worker 共享 DiskBudget + PushMutex 同时执行 disk-check + Reserve 流程，
+// downloader 每次都报告稳定的 "100GB free, 0 pending"（qBit 还没开始下载）。
+// 期望：互斥锁 + Reserve 让前 2 个通过 (Reserve 30GB → 60GB → 第 3 个看到
+// effective=40<min=20+30=50 拒)；3 个被拒。
+//
+// 这是直接调用核心算法（绕过 DB 层）的并发回归 —— 完整 e2e 在 setup 上太复杂，
+// 此测试足以证明 race 修复生效，而 e2e 测试见前面 6 个单 worker 用例。
+func TestDiskProtect_ConcurrentPushesSerializeAndReject(t *testing.T) {
+	GetDiskBudget().Reset()
+	t.Cleanup(func() { GetDiskBudget().Reset() })
+	const torrentSize = 30 * gb
+	const free = 100 * gb
+	const pending = 0
+	const minBytes = 20 * gb
+	const workers = 5
+
+	var success, fail atomic.Int32
+	var wg sync.WaitGroup
+	mu := PushMutex()
+	budget := GetDiskBudget()
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mu.Lock()
+			defer mu.Unlock()
+
+			effective := int64(free) - int64(pending) - budget.Reserved()
+			if effective < 0 {
+				effective = 0
+			}
+			if effective-torrentSize < minBytes {
+				fail.Add(1)
+				return
+			}
+			budget.Reserve(torrentSize)
+			success.Add(1)
+		}()
+	}
+	wg.Wait()
+
+	t.Logf("成功 %d, 失败 %d, 最终预留 %d GB",
+		success.Load(), fail.Load(), budget.Reserved()/gb)
+
+	// 关键不变量 (Issue #299 race 修复)：
+	// - 不会全部成功（5/5），那是旧 race bug
+	// - 期望 successes ∈ [2,2]，fail ∈ [3,3]：100-(2*30)=40，再扣 30 = 10 < 20 阈值
+	assert.Equal(t, int32(2), success.Load(),
+		"互斥锁 + Reserve 应让恰好 2 个通过：100GB - 60GB reserved - 30GB new = 10 < 20")
+	assert.Equal(t, int32(3), fail.Load(),
+		"剩余 3 个 worker 应被磁盘保护拦截")
+	assert.Equal(t, 2*torrentSize, budget.Reserved(),
+		"通过的 2 个 worker 共预留 60GB")
+}

--- a/internal/disk_protect_test.go
+++ b/internal/disk_protect_test.go
@@ -91,7 +91,7 @@ func TestDiskProtect_RejectsWhenSizeExceedsEffectiveFree(t *testing.T) {
 	mockDl.EXPECT().GetName().Return("test-dl").AnyTimes()
 	mockDl.EXPECT().GetType().Return(downloader.DownloaderQBittorrent).AnyTimes()
 	mockDl.EXPECT().CheckTorrentExists(hash).Return(false, nil)
-	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(int64(80*gb), nil)
+	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(80*gb, nil)
 	mockDl.EXPECT().GetIncompletePendingBytes(gomock.Any()).Return(int64(0), nil)
 	// AddTorrentFileEx 不应被调用 —— 这是关键断言
 
@@ -117,7 +117,7 @@ func TestDiskProtect_AllowsWhenSizeFits(t *testing.T) {
 	mockDl.EXPECT().GetName().Return("test-dl").AnyTimes()
 	mockDl.EXPECT().GetType().Return(downloader.DownloaderQBittorrent).AnyTimes()
 	mockDl.EXPECT().CheckTorrentExists(hash).Return(false, nil)
-	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(int64(80*gb), nil)
+	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(80*gb, nil)
 	mockDl.EXPECT().GetIncompletePendingBytes(gomock.Any()).Return(int64(0), nil)
 	mockDl.EXPECT().AddTorrentFileEx(gomock.Any(), gomock.Any()).
 		Return(downloader.AddTorrentResult{Success: true, Hash: hash}, nil)
@@ -126,7 +126,7 @@ func TestDiskProtect_AllowsWhenSizeFits(t *testing.T) {
 	err := processSingleTorrentWithDownloader(context.Background(), mockDl, dlInfo,
 		path, "cat", "tag", "", models.SiteGroup("springsunday"), false)
 	require.NoError(t, err)
-	assert.Equal(t, int64(30*gb), GetDiskBudget().Reserved(),
+	assert.Equal(t, 30*gb, GetDiskBudget().Reserved(),
 		"推送成功后应保留预算 30GB（由 cleanup_monitor Reset 或上层回收）")
 }
 
@@ -146,8 +146,8 @@ func TestDiskProtect_PendingDownloadsSubtracted(t *testing.T) {
 	mockDl.EXPECT().GetName().Return("test-dl").AnyTimes()
 	mockDl.EXPECT().GetType().Return(downloader.DownloaderQBittorrent).AnyTimes()
 	mockDl.EXPECT().CheckTorrentExists(hash).Return(false, nil)
-	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(int64(100*gb), nil)
-	mockDl.EXPECT().GetIncompletePendingBytes(gomock.Any()).Return(int64(60*gb), nil)
+	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(100*gb, nil)
+	mockDl.EXPECT().GetIncompletePendingBytes(gomock.Any()).Return(60*gb, nil)
 	// AddTorrentFileEx 不应被调用
 
 	dlInfo := &DownloaderInfo{ID: 1, Name: "test-dl", AutoStart: true}
@@ -170,7 +170,7 @@ func TestDiskProtect_ReleaseOnPushFailure(t *testing.T) {
 	mockDl.EXPECT().GetName().Return("test-dl").AnyTimes()
 	mockDl.EXPECT().GetType().Return(downloader.DownloaderQBittorrent).AnyTimes()
 	mockDl.EXPECT().CheckTorrentExists(hash).Return(false, nil)
-	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(int64(100*gb), nil)
+	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(100*gb, nil)
 	mockDl.EXPECT().GetIncompletePendingBytes(gomock.Any()).Return(int64(0), nil)
 	mockDl.EXPECT().AddTorrentFileEx(gomock.Any(), gomock.Any()).
 		Return(downloader.AddTorrentResult{Success: false, Message: "boom"}, errors.New("boom"))
@@ -221,7 +221,7 @@ func TestDiskProtect_PendingErrorTreatedAsZero(t *testing.T) {
 	mockDl.EXPECT().GetName().Return("test-dl").AnyTimes()
 	mockDl.EXPECT().GetType().Return(downloader.DownloaderQBittorrent).AnyTimes()
 	mockDl.EXPECT().CheckTorrentExists(hash).Return(false, nil)
-	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(int64(100*gb), nil)
+	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(100*gb, nil)
 	mockDl.EXPECT().GetIncompletePendingBytes(gomock.Any()).Return(int64(0), errors.New("api fail"))
 	mockDl.EXPECT().AddTorrentFileEx(gomock.Any(), gomock.Any()).
 		Return(downloader.AddTorrentResult{Success: true, Hash: hash}, nil)
@@ -262,7 +262,7 @@ func TestDiskProtect_ConcurrentPushesSerializeAndReject(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 
-			effective := int64(free) - int64(pending) - budget.Reserved()
+			effective := free - pending - budget.Reserved()
 			if effective < 0 {
 				effective = 0
 			}

--- a/internal/push.go
+++ b/internal/push.go
@@ -123,30 +123,66 @@ func PushTorrentToDownloader(ctx context.Context, req PushTorrentRequest) (*Push
 	applySiteSpeedLimits(&opts, req.SiteID)
 
 	glOnly, glErr := core.NewConfigStore(global.GlobalDB).GetGlobalOnly()
+	// 磁盘保护预检（修复 Issue #299，与 internal/common.go 同步）：
+	// effective_free = client_free - in_flight_pending - pre_reserved
+	// gate           = effective_free - thisTorrentSize >= threshold
+	// 用全局互斥锁串行化整个 check + Reserve + push 临界区。
+	var pushTorrentSize int64
 	if glErr == nil && glOnly.CleanupDiskProtect && glOnly.CleanupMinDiskSpaceGB > 0 {
+		mu := PushMutex()
+		mu.Lock()
+		defer mu.Unlock()
+
 		freeSpace, spaceErr := dl.GetClientFreeSpace(ctx)
 		if spaceErr != nil {
-			sLogger().Warnf("[磁盘保护] 获取磁盘空间失败，继续推送: %v", spaceErr)
-		} else {
-			freeGB := float64(freeSpace) / (1024 * 1024 * 1024)
-			if freeGB < glOnly.CleanupMinDiskSpaceGB {
-				sLogger().Warnf("[磁盘保护] %s: 磁盘空间不足 (%.1f GB < %.1f GB)，跳过推送: site=%s, id=%s",
-					dlSetting.Name, freeGB, glOnly.CleanupMinDiskSpaceGB, req.SiteID, req.TorrentID)
-				if glOnly.CleanupEnabled {
-					events.Publish(events.Event{Type: events.DiskSpaceLow, Source: "push", At: time.Now()})
-				}
-				return &PushTorrentResult{
-					Success:     false,
-					TorrentHash: torrentHash,
-					Message:     fmt.Sprintf("磁盘空间不足 (%.1f GB < %.1f GB)", freeGB, glOnly.CleanupMinDiskSpaceGB),
-				}, nil
+			sLogger().Warnf("[磁盘保护] %s: 获取磁盘空间失败，磁盘保护启用故拒绝推送: %v", dlSetting.Name, spaceErr)
+			return &PushTorrentResult{
+				Success:     false,
+				TorrentHash: torrentHash,
+				Message:     fmt.Sprintf("无法读取磁盘空间，已拒绝推送: %v", spaceErr),
+			}, nil
+		}
+
+		pendingBytes, pendingErr := dl.GetIncompletePendingBytes(ctx)
+		if pendingErr != nil {
+			sLogger().Warnf("[磁盘保护] %s: 查询 in-flight pending 失败，仅以 reserved 推算: %v", dlSetting.Name, pendingErr)
+			pendingBytes = 0
+		}
+		budget := GetDiskBudget()
+		effectiveFreeBytes := freeSpace - pendingBytes - budget.Reserved()
+		if effectiveFreeBytes < 0 {
+			effectiveFreeBytes = 0
+		}
+		if size, sizeErr := qbit.ComputeTorrentSize(req.TorrentData); sizeErr == nil {
+			pushTorrentSize = size
+		}
+		minBytes := int64(glOnly.CleanupMinDiskSpaceGB * 1024 * 1024 * 1024)
+		if effectiveFreeBytes-pushTorrentSize < minBytes {
+			effGB := float64(effectiveFreeBytes) / (1024 * 1024 * 1024)
+			tGB := float64(pushTorrentSize) / (1024 * 1024 * 1024)
+			sLogger().Warnf("[磁盘保护] %s: 空间不足 (有效 %.1f GB - 种子 %.1f GB < 保底 %.1f GB)，跳过推送: site=%s, id=%s",
+				dlSetting.Name, effGB, tGB, glOnly.CleanupMinDiskSpaceGB, req.SiteID, req.TorrentID)
+			if glOnly.CleanupEnabled {
+				events.Publish(events.Event{Type: events.DiskSpaceLow, Source: "push", At: time.Now()})
 			}
+			return &PushTorrentResult{
+				Success:     false,
+				TorrentHash: torrentHash,
+				Message:     fmt.Sprintf("磁盘空间不足 (有效 %.1f GB - 种子 %.1f GB < %.1f GB)", effGB, tGB, glOnly.CleanupMinDiskSpaceGB),
+			}, nil
+		}
+		if pushTorrentSize > 0 {
+			budget.Reserve(pushTorrentSize)
 		}
 	}
 
 	// 推送种子到下载器
 	result, err := dl.AddTorrentFileEx(req.TorrentData, opts)
 	if err != nil {
+		// 推送失败：归还预留配额，避免 budget 永久占用。
+		if pushTorrentSize > 0 {
+			GetDiskBudget().Release(pushTorrentSize)
+		}
 		// 更新推送失败状态
 		_ = global.GlobalDB.DB.Model(&models.TorrentInfo{}).
 			Where("site_name = ? AND torrent_id = ?", req.SiteID, req.TorrentID).
@@ -158,6 +194,10 @@ func PushTorrentToDownloader(ctx context.Context, req PushTorrentRequest) (*Push
 	}
 
 	if !result.Success {
+		// 业务层失败也需要归还预留。
+		if pushTorrentSize > 0 {
+			GetDiskBudget().Release(pushTorrentSize)
+		}
 		errMsg := fmt.Sprintf("%v", result.Message)
 		_ = global.GlobalDB.DB.Model(&models.TorrentInfo{}).
 			Where("site_name = ? AND torrent_id = ?", req.SiteID, req.TorrentID).

--- a/mocks/downloader_mock.go
+++ b/mocks/downloader_mock.go
@@ -106,6 +106,21 @@ func (mr *MockDownloaderMockRecorder) GetClientFreeSpace(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClientFreeSpace", reflect.TypeOf((*MockDownloader)(nil).GetClientFreeSpace), ctx)
 }
 
+// GetIncompletePendingBytes mocks base method
+func (m *MockDownloader) GetIncompletePendingBytes(ctx context.Context) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIncompletePendingBytes", ctx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIncompletePendingBytes indicates an expected call of GetIncompletePendingBytes
+func (mr *MockDownloaderMockRecorder) GetIncompletePendingBytes(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIncompletePendingBytes", reflect.TypeOf((*MockDownloader)(nil).GetIncompletePendingBytes), ctx)
+}
+
 // GetAllTorrents mocks base method
 func (m *MockDownloader) GetAllTorrents() ([]downloader.Torrent, error) {
 	m.ctrl.T.Helper()

--- a/thirdpart/downloader/interface.go
+++ b/thirdpart/downloader/interface.go
@@ -73,6 +73,7 @@ type Torrent struct {
 	ContentPath     string       // 内容路径 (文件/文件夹的完整路径)
 	TotalUploaded   int64        // 总上传量 (bytes)
 	TotalDownloaded int64        // 总下载量 (bytes)
+	AmountLeft      int64        // 剩余下载字节数 (qBit:amount_left, TR:left_until_done)；用于"待下载累计"磁盘预算
 	Raw             any          // 原始数据
 	ClientID        string       // 客户端ID
 }
@@ -233,6 +234,16 @@ type Downloader interface {
 	// GetClientFreeSpace 获取下载器所在磁盘的可用空间
 	// 返回可用空间（字节）
 	GetClientFreeSpace(ctx context.Context) (int64, error)
+
+	// GetIncompletePendingBytes 聚合所有"未下载完成的活跃种子"还需要下载的字节数。
+	// 用于计算 effective_free_space = client_free - pending - reserved，
+	// 修复 Issue #299：qBit 默认 preallocate_all=false，新推送的种子直到下载
+	// 完成才反映在 OS 空闲空间，多个 worker 并发推送会基于过时数据通过检查。
+	//
+	// 计入聚合的状态（qBit）：downloading / stalledDL / queuedDL / forcedDL /
+	// metaDL / allocating / pausedDL / checkingDL。Transmission：status==3,4。
+	// 实现层应跳过 nil/error 单条种子，错误不应中断聚合。
+	GetIncompletePendingBytes(ctx context.Context) (int64, error)
 
 	// GetAllTorrents 获取所有种子列表
 	GetAllTorrents() ([]Torrent, error)

--- a/thirdpart/downloader/manager_test.go
+++ b/thirdpart/downloader/manager_test.go
@@ -24,6 +24,10 @@ func (m *MockDownloader) GetClientStatus() (ClientStatus, error) { return Client
 func (m *MockDownloader) GetClientFreeSpace(ctx context.Context) (int64, error) {
 	return 1024 * 1024 * 1024, nil
 }
+
+func (m *MockDownloader) GetIncompletePendingBytes(ctx context.Context) (int64, error) {
+	return 0, nil
+}
 func (m *MockDownloader) GetAllTorrents() ([]Torrent, error)                    { return nil, nil }
 func (m *MockDownloader) GetTorrentsBy(filter TorrentFilter) ([]Torrent, error) { return nil, nil }
 func (m *MockDownloader) GetTorrent(id string) (Torrent, error)                 { return Torrent{}, nil }
@@ -378,6 +382,10 @@ func (m *StatefulMockDownloader) GetClientStatus() (ClientStatus, error) { retur
 
 func (m *StatefulMockDownloader) GetClientFreeSpace(ctx context.Context) (int64, error) {
 	return 1024 * 1024 * 1024, nil
+}
+
+func (m *StatefulMockDownloader) GetIncompletePendingBytes(ctx context.Context) (int64, error) {
+	return 0, nil
 }
 func (m *StatefulMockDownloader) GetAllTorrents() ([]Torrent, error) { return nil, nil }
 func (m *StatefulMockDownloader) GetTorrentsBy(filter TorrentFilter) ([]Torrent, error) {

--- a/thirdpart/downloader/qbit/qbit_disk_protect_test.go
+++ b/thirdpart/downloader/qbit/qbit_disk_protect_test.go
@@ -1,0 +1,170 @@
+// MIT License
+// Copyright (c) 2025 pt-tools
+
+// Tests for Issue #299 disk-protection helpers in qbit package:
+//   - ComputeTorrentSize: parse content size from .torrent metadata
+//   - GetIncompletePendingBytes: aggregate amount_left across active downloads
+
+package qbit
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zeebo/bencode"
+)
+
+// makeSingleFileTorrent encodes a minimal single-file .torrent with given length.
+func makeSingleFileTorrent(t *testing.T, length int64) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, bencode.NewEncoder(&buf).Encode(map[string]any{
+		"info": map[string]any{
+			"name":         "single.bin",
+			"length":       length,
+			"piece length": int64(16384),
+			"pieces":       "01234567890123456789",
+		},
+	}))
+	return buf.Bytes()
+}
+
+// makeMultiFileTorrent encodes a minimal multi-file .torrent with given file lengths.
+func makeMultiFileTorrent(t *testing.T, fileLengths ...int64) []byte {
+	t.Helper()
+	files := make([]any, 0, len(fileLengths))
+	for i, l := range fileLengths {
+		files = append(files, map[string]any{
+			"length": l,
+			"path":   []string{"f" + string(rune('0'+i))},
+		})
+	}
+	var buf bytes.Buffer
+	require.NoError(t, bencode.NewEncoder(&buf).Encode(map[string]any{
+		"info": map[string]any{
+			"name":         "multi",
+			"files":        files,
+			"piece length": int64(16384),
+			"pieces":       "01234567890123456789",
+		},
+	}))
+	return buf.Bytes()
+}
+
+func TestComputeTorrentSize_SingleFile(t *testing.T) {
+	data := makeSingleFileTorrent(t, 1234567890)
+	size, err := ComputeTorrentSize(data)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1234567890), size)
+}
+
+func TestComputeTorrentSize_MultiFile(t *testing.T) {
+	data := makeMultiFileTorrent(t, 100, 200, 300)
+	size, err := ComputeTorrentSize(data)
+	require.NoError(t, err)
+	assert.Equal(t, int64(600), size, "multi-file 大小应为 files[].length 之和")
+}
+
+func TestComputeTorrentSize_EmptyMultiFile(t *testing.T) {
+	data := makeMultiFileTorrent(t)
+	size, err := ComputeTorrentSize(data)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), size, "无文件 multi 应返回 0，不报错")
+}
+
+func TestComputeTorrentSize_InvalidData(t *testing.T) {
+	_, err := ComputeTorrentSize([]byte("not bencode"))
+	require.Error(t, err)
+}
+
+// TestGetIncompletePendingBytes_AggregatesActiveStates 验证 active 状态种子的
+// amount_left 被正确聚合。
+func TestGetIncompletePendingBytes_AggregatesActiveStates(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/torrents/info", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"state": "downloading", "amount_left": 50000000000},
+			{"state": "stalledDL",   "amount_left": 30000000000},
+			{"state": "queuedDL",    "amount_left": 20000000000},
+			{"state": "uploading",   "amount_left": 0},
+			{"state": "pausedUP",    "amount_left": 0},
+			{"state": "error",       "amount_left": 1000}
+		]`))
+	}))
+	defer server.Close()
+
+	q := NewQbitClientForTesting(server.Client(), server.URL)
+	got, err := q.GetIncompletePendingBytes(t.Context())
+	require.NoError(t, err)
+	// 50G + 30G + 20G = 100G；其他状态（uploading/pausedUP/error）不计入
+	assert.Equal(t, int64(100000000000), got)
+}
+
+// TestGetIncompletePendingBytes_IncludesPausedDL 验证 pausedDL 计入聚合。
+// 与 qBit 的 pausedUP（已完成暂停做种）相反，pausedDL 仍持有未下载完的份额。
+func TestGetIncompletePendingBytes_IncludesPausedDL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[
+			{"state": "pausedDL", "amount_left": 5000000000},
+			{"state": "stoppedDL", "amount_left": 3000000000}
+		]`))
+	}))
+	defer server.Close()
+
+	q := NewQbitClientForTesting(server.Client(), server.URL)
+	got, err := q.GetIncompletePendingBytes(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, int64(8000000000), got, "pausedDL + stoppedDL 应计入（用户可恢复）")
+}
+
+func TestGetIncompletePendingBytes_EmptyList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	q := NewQbitClientForTesting(server.Client(), server.URL)
+	got, err := q.GetIncompletePendingBytes(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), got)
+}
+
+func TestGetIncompletePendingBytes_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	q := NewQbitClientForTesting(server.Client(), server.URL)
+	_, err := q.GetIncompletePendingBytes(t.Context())
+	require.Error(t, err)
+}
+
+func TestGetIncompletePendingBytes_MalformedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer server.Close()
+
+	q := NewQbitClientForTesting(server.Client(), server.URL)
+	_, err := q.GetIncompletePendingBytes(t.Context())
+	require.Error(t, err)
+}
+
+// TestGetIncompletePendingBytes_SkipsNegativeAmount 验证负数被忽略（不存在但保护性测试）。
+func TestGetIncompletePendingBytes_SkipsNegativeAmount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[{"state": "downloading", "amount_left": -500}]`))
+	}))
+	defer server.Close()
+
+	q := NewQbitClientForTesting(server.Client(), server.URL)
+	got, err := q.GetIncompletePendingBytes(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), got, "amount_left<=0 应被忽略")
+}

--- a/thirdpart/downloader/qbit/qbit_impl.go
+++ b/thirdpart/downloader/qbit/qbit_impl.go
@@ -570,6 +570,35 @@ func ComputeTorrentHash(data []byte) (string, error) {
 	return hex.EncodeToString(hash[:]), nil
 }
 
+// ComputeTorrentSize 解析 .torrent 元数据，返回种子内容字节数（单文件 length 或多文件
+// files[].length 之和）。失败返回 (0, err)。供磁盘保护预检 size-aware 比较使用。
+//
+// 注意：这是种子内容大小，与 len(torrentData)（.torrent 文件元数据本身大小）完全不同。
+// 旧 CanAddTorrent 误用 len(torrentData) 作为内容大小是 Issue #299 的次要 bug。
+func ComputeTorrentSize(data []byte) (int64, error) {
+	var meta struct {
+		Info struct {
+			Length int64 `bencode:"length"`
+			Files  []struct {
+				Length int64 `bencode:"length"`
+			} `bencode:"files"`
+		} `bencode:"info"`
+	}
+	if err := bencode.DecodeBytes(data, &meta); err != nil {
+		return 0, fmt.Errorf("failed to decode torrent metadata: %w", err)
+	}
+	if meta.Info.Length > 0 {
+		return meta.Info.Length, nil
+	}
+	var total int64
+	for _, f := range meta.Info.Files {
+		if f.Length > 0 {
+			total += f.Length
+		}
+	}
+	return total, nil
+}
+
 // ComputeTorrentHashWithPath 从文件路径计算种子哈希
 func ComputeTorrentHashWithPath(filePath string) (string, error) {
 	data, err := os.ReadFile(filePath)
@@ -830,6 +859,62 @@ func (q *QbitClient) GetClientFreeSpace(ctx context.Context) (int64, error) {
 	return q.GetDiskSpace(ctx)
 }
 
+// qbitActiveDLStates 计入"待下载累计"的 qBit 原始 state 字符串。
+// 不能依赖 mapQbitState 的归一化，因为它把 forcedDL/stalledDL/metaDL/checkingDL
+// 都折叠到 TorrentDownloading/TorrentChecking 等粗粒度类别，破坏了准确性。
+// 见 internal/disk_budget.go 与 Issue #299。
+var qbitActiveDLStates = map[string]struct{}{
+	"downloading":        {},
+	"stalledDL":          {},
+	"queuedDL":           {},
+	"forcedDL":           {},
+	"metaDL":             {},
+	"allocating":         {},
+	"pausedDL":           {},
+	"stoppedDL":          {},
+	"checkingDL":         {},
+	"checkingResumeData": {},
+}
+
+// GetIncompletePendingBytes 调用 qBit /api/v2/torrents/info 拉取所有种子，
+// 聚合 active 下载状态种子的 amount_left 字段（剩余字节数）。
+//
+// 故意保留种子级容错：单个种子的 amount_left 解析失败仅跳过该条；
+// 整体只在 HTTP/auth 层失败时返回错误。
+func (q *QbitClient) GetIncompletePendingBytes(ctx context.Context) (int64, error) {
+	url := fmt.Sprintf("%s/api/v2/torrents/info", q.baseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("构建请求失败: %w", err)
+	}
+
+	resp, err := q.client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("请求 torrents/info 失败: %w", err)
+	}
+	defer resp.Body.Close()
+	if !q.isSuccessStatus(resp.StatusCode) {
+		return 0, fmt.Errorf("torrents/info 返回 %d", resp.StatusCode)
+	}
+	var torrents []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&torrents); err != nil {
+		return 0, fmt.Errorf("解析 torrents/info 失败: %w", err)
+	}
+
+	var total int64
+	for _, t := range torrents {
+		state, _ := t["state"].(string)
+		if _, active := qbitActiveDLStates[state]; !active {
+			continue
+		}
+		amountLeft, _ := t["amount_left"].(float64)
+		if amountLeft > 0 {
+			total += int64(amountLeft)
+		}
+	}
+	return total, nil
+}
+
 // GetAllTorrents 获取所有种子列表
 func (q *QbitClient) GetAllTorrents() ([]downloader.Torrent, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -902,6 +987,9 @@ func (q *QbitClient) mapQbitTorrent(qt map[string]any) downloader.Torrent {
 	}
 	if size, ok := qt["size"].(float64); ok {
 		t.TotalSize = int64(size)
+	}
+	if amountLeft, ok := qt["amount_left"].(float64); ok {
+		t.AmountLeft = int64(amountLeft)
 	}
 	if upSpeed, ok := qt["upspeed"].(float64); ok {
 		t.UploadSpeed = int64(upSpeed)

--- a/thirdpart/downloader/transmission/transmission_impl.go
+++ b/thirdpart/downloader/transmission/transmission_impl.go
@@ -619,6 +619,51 @@ func (t *TransmissionClient) GetClientFreeSpace(ctx context.Context) (int64, err
 	return t.GetDiskSpace(ctx)
 }
 
+// trActiveDLStatus 计入"待下载累计"的 Transmission 原始 status 整数（rpc-spec.md）：
+// 3 = TR_STATUS_DOWNLOAD_WAIT (queued for download)
+// 4 = TR_STATUS_DOWNLOAD       (actively downloading)
+// 1 = TR_STATUS_CHECK_WAIT、2 = TR_STATUS_CHECK 也可能含未完成数据 (left_until_done > 0)；
+// 0 = stopped/paused —— 用户可恢复，文件仍占地，与 qBit pausedDL 同样保守计入。
+var trActiveDLStatus = map[int]struct{}{
+	0: {},
+	1: {},
+	2: {},
+	3: {},
+	4: {},
+}
+
+// GetIncompletePendingBytes 调用 transmission torrent-get RPC 拉取所有种子的
+// status + leftUntilDone 字段，聚合处于活跃下载/暂停状态的 leftUntilDone。
+//
+// 与 qBit 实现保持一致的状态约定：暂停种子也计入（用户可恢复）；checking
+// 状态 leftUntilDone 通常为 0 但保留以防边界场景。
+func (t *TransmissionClient) GetIncompletePendingBytes(_ context.Context) (int64, error) {
+	args := torrentGetArgs{Fields: []string{"id", "status", "leftUntilDone"}}
+	resp, err := t.doRequest("torrent-get", args)
+	if err != nil {
+		return 0, fmt.Errorf("torrent-get 失败: %w", err)
+	}
+	var getResp struct {
+		Torrents []struct {
+			Status        int   `json:"status"`
+			LeftUntilDone int64 `json:"leftUntilDone"`
+		} `json:"torrents"`
+	}
+	if err := json.Unmarshal(resp.Arguments, &getResp); err != nil {
+		return 0, fmt.Errorf("解析 torrent-get 失败: %w", err)
+	}
+	var total int64
+	for _, tt := range getResp.Torrents {
+		if _, active := trActiveDLStatus[tt.Status]; !active {
+			continue
+		}
+		if tt.LeftUntilDone > 0 {
+			total += tt.LeftUntilDone
+		}
+	}
+	return total, nil
+}
+
 // torrentFullInfo 完整的种子信息结构
 type torrentFullInfo struct {
 	ID                 int      `json:"id"`
@@ -629,6 +674,7 @@ type torrentFullInfo struct {
 	RateDownload       int64    `json:"rateDownload"`
 	RateUpload         int64    `json:"rateUpload"`
 	TotalSize          int64    `json:"totalSize"`
+	LeftUntilDone      int64    `json:"leftUntilDone"`
 	UploadedEver       int64    `json:"uploadedEver"`
 	DownloadedEver     int64    `json:"downloadedEver"`
 	UploadRatio        float64  `json:"uploadRatio"`
@@ -674,7 +720,7 @@ func (t *TransmissionClient) GetAllTorrents() ([]downloader.Torrent, error) {
 	args := torrentGetArgs{
 		Fields: []string{
 			"id", "name", "hashString", "status", "percentDone",
-			"rateDownload", "rateUpload", "totalSize", "uploadedEver",
+			"rateDownload", "rateUpload", "totalSize", "leftUntilDone", "uploadedEver",
 			"downloadedEver", "uploadRatio", "addedDate", "downloadDir", "labels",
 			"eta", "secondsSeeding", "trackers", "doneDate", "peersSendingToUs",
 			"peersGettingFromUs", "peersConnected", "desiredAvailable",
@@ -714,6 +760,7 @@ func (t *TransmissionClient) mapTransmissionTorrent(tt torrentFullInfo) download
 		SavePath:        tt.DownloadDir,
 		State:           t.mapTransmissionState(tt.Status),
 		TotalSize:       tt.TotalSize,
+		AmountLeft:      tt.LeftUntilDone,
 		UploadSpeed:     tt.RateUpload,
 		DownloadSpeed:   tt.RateDownload,
 		ETA:             tt.ETA,


### PR DESCRIPTION
## Summary

修复 Issue #299：用户开启磁盘保护后磁盘仍被填满。

## 根因

旧实现 \`freeGB < threshold\` 存在三个 race：

1. **不扣除即将推送种子自身大小** —— 连推 5 个 100GB 种子时各自看到相同 freeGB。
2. **qBit 默认 \`preallocate_all=false\`** —— 新推送种子直到下载完成才反映在
   \`free_space_on_disk\`，多 RSS worker 并发推送基于过时数据通过检查。
3. **\`GetClientFreeSpace\` 失败时 fail-open**（\"继续推送\"）。

\`internal/disk_budget.go\` 早就实现了 \`DiskBudget\` 预留原语供解决并发越界
（注释明确写 *\"防止同时看到相同的空闲空间而并发越界\"*），但**从未被调用**。

## 修复策略

三层减法 + 全局互斥锁：

\`\`\`
effective_free = client_free - in_flight_pending - pre_reserved
gate           = effective_free - thisTorrentSize >= threshold
\`\`\`

## Changes

| 文件 | 改动 |
|---|---|
| \`internal/disk_budget.go\` | 修复 Release race（CAS 循环替代 Add+CAS）；新增 \`PushMutex()\`；\`EffectiveFreeBytes\`；GetSloggerSafe 修单测 panic |
| \`internal/common.go\` | 推送前 PushMutex 上锁 → 查 free+pending → 减 reserved → 减种子大小 → 比阈值；通过则 Reserve；失败 Release；**fail-closed** |
| \`internal/push.go\` | 同上策略；\`ComputeTorrentSize\` 从 .torrent 元数据推算种子大小 |
| \`thirdpart/downloader/interface.go\` | Downloader 接口新增 \`GetIncompletePendingBytes\`；Torrent struct 新增 \`AmountLeft\` |
| qbit/transmission impl | 聚合 active 状态种子的 \`amount_left\` / \`leftUntilDone\` |
| \`mocks/\` + \`manager_test.go\` | 接口同步 |

## Test Coverage

全部 \`-race\` 通过：

- \`internal/disk_budget_test.go\` — **12 个测试**：Reserve/Release/Reset、EffectiveFree、单例、PushMutex 串行化、高并发计数收敛、Issue #299 race 业务剧本
- \`internal/disk_protect_test.go\` — **7 个测试**：种子大小拒绝、阈值通过、pending 扣除、push 失败 Release、fail-closed、pending 错误降级、并发 race 端到端回归
- \`thirdpart/downloader/qbit/qbit_disk_protect_test.go\` — **8 个测试**：ComputeTorrentSize 单/多文件/空/非法 + GetIncompletePendingBytes 聚合规则与边界

## Validation

- \`go build ./...\` 通过
- \`go test -race ./...\` 全部 PASS（包括所有 sibling tests，未引入回归）
- \`go test ./internal/ ./thirdpart/downloader/qbit/\` 全部新增测试通过

Closes #299