### PR TITLE
feat(sites): 新增 3 个 NexusPHP 站点适配

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -451,12 +451,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **site**: 新增 OpenCD 和 PTT 站点适配
 - 新增 site/v2/definitions/opencd.go 适配 open.cd (繁体 NexusPHP)
   _ 使用 div.title + td.rowtitle 替代标准 h1 + td.rowhead
-  _ 支持 plugin*details.php 链接格式
-  * 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
-  * 处理 font.promotion 替代 img.pro*_ 的非标准折扣标记
-  _ span.category 替代 img[alt] 的分类标记
-  _ 处理 info_block 隐藏列的 nth-child 索引偏移
-  _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
+  _ 支持 plugin\*details.php 链接格式
+  - 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
+  - 处理 font.promotion 替代 img.pro\*_ 的非标准折扣标记
+    _ span.category 替代 img[alt] 的分类标记
+    _ 处理 info_block 隐藏列的 nth-child 索引偏移
+    _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
 
 ## [0.23.0] - 2026-04-29
 

--- a/docs/sites.md
+++ b/docs/sites.md
@@ -1,8 +1,8 @@
 ## 支持站点
 
-当前已适配 **36** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
+当前已适配 **39** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
 
-### NexusPHP 系列（32）
+### NexusPHP 系列（35）
 
 | 站点                  | 认证方式 | 支持功能                      | 适配情况 | 备注                          |
 | --------------------- | -------- | ----------------------------- | -------- | ----------------------------- |
@@ -36,6 +36,9 @@
 | **Dubhe**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 天枢（dubhe.site）            |
 | **PTCafe**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 咖啡（ptcafe.club）           |
 | **CyanBug**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 大青虫（cyanbug.net）         |
+| **DuckBoobee**        | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 鸭鸭（duckboobee.org）        |
+| **LongPT**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 龙PT（longpt.org）            |
+| **HDVideo**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | HD视频（hdvideo.top）         |
 | **1PTBar**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
 | **lajidui**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue    |
 

--- a/site/v2/definitions/duckboobee.go
+++ b/site/v2/definitions/duckboobee.go
@@ -1,0 +1,116 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+var DuckBoobeeDefinition = &v2.SiteDefinition{
+	ID:             "duckboobee",
+	Name:           "DuckBoobee",
+	Aka:            []string{"鸭鸭", "duckboobee.org"},
+	Description:    "DuckBoobee — NexusPHP PT 站点（duckboobee.org）",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://duckboobee.org/"},
+	FaviconURL:     "https://duckboobee.org/favicon.ico",
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "bonus", "seeding", "leeching"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields:        []string{"name", "uploaded", "downloaded", "ratio", "levelName", "joinTime"},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			"id": {
+				Selector: []string{"a[href*='userdetails.php'][class*='Name']", "#info_block a[href*='userdetails.php']", "a[href*='userdetails.php']"},
+				Attr:     "href",
+				Filters:  []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{"a[href*='userdetails.php'][class*='Name']", "#info_block a[href*='userdetails.php']"},
+			},
+			"uploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('上传量') + td", "#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:上传量|上傳量|Uploaded)[^\d]*([\d.,]+\s*[KMGTP]?i?B)`}}, {Name: "parseSize"}},
+			},
+			"downloaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('下载量') + td", "#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:下载量|下載量|Downloaded)[^\d]*([\d.,]+\s*[KMGTP]?i?B)`}}, {Name: "parseSize"}},
+			},
+			"ratio": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('分享率') + td", "#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:分享率|Ratio)[^\d∞]*([\d.,]+|∞|Inf|---)`}}, {Name: "parseNumber"}},
+			},
+			"levelName": {
+				Selector: []string{"td.rowhead:contains('等级') + td > img", "td.rowhead:contains('等级') + td img", "td.rowhead:contains('Class') + td > img"},
+				Attr:     "title",
+			},
+			"bonus": {
+				Selector: []string{"#info_block", "td.rowhead:contains('魔力值') + td", "td.rowhead:contains('Bonus') + td"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:魔力值|Bonus)[^\d]*([\d.,]+)`}}, {Name: "parseNumber"}},
+			},
+			"joinTime": {
+				Selector: []string{"td.rowhead:contains('加入日期') + td", "td.rowhead:contains('Join') + td"},
+				Filters:  []v2.Filter{{Name: "split", Args: []any{" (", 0}}, {Name: "parseTime"}},
+			},
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`class="arrowup"[^>]*/>\s*(\d+)`}}, {Name: "parseNumber"}},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}}, {Name: "parseNumber"}},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		TableRows:          "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:              "table.torrentname a[href*='details.php']",
+		TitleLink:          "table.torrentname a[href*='details.php']",
+		Subtitle:           "table.torrentname td.embedded > span:last-of-type, table.torrentname td.embedded > span:not(.optiontag)",
+		Size:               "td.rowfollow:nth-child(5)",
+		Seeders:            "td.rowfollow:nth-child(6)",
+		Leechers:           "td.rowfollow:nth-child(7)",
+		Snatched:           "td.rowfollow:nth-child(8)",
+		DiscountIcon:       "img.pro_free, img.pro_free2up, img.pro_50pctdown, img.pro_30pctdown, img.pro_2up, img.pro_50pctdown2up",
+		Category:           "td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:         "td.rowfollow:nth-child(4) span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords:       []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run", "H&R"},
+		DiscountSelector: "h1 font.free, h1 font[class]",
+		EndTimeSelector:  "h1 span[title]",
+		SizeSelector:     "td.rowfollow:contains('大小')",
+		SizeRegex:        `大小[：:]\s*([\d.]+)\s*(GB|MB|KB|TB)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(DuckBoobeeDefinition)
+}

--- a/site/v2/definitions/duckboobee_fixture_test.go
+++ b/site/v2/definitions/duckboobee_fixture_test.go
@@ -1,0 +1,162 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{SiteID: "duckboobee", Search: testDuckBoobeeSearch, Detail: testDuckBoobeeDetail, UserInfo: testDuckBoobeeUserInfo})
+}
+
+const duckboobeeSearchFixture = `<html><body>
+<table class="torrents"><tbody>
+<tr>
+  <td class="rowfollow"><img alt="电影/Movies" /></td>
+  <td class="rowfollow"><table class="torrentname"><tr><td class="embedded">
+    <a href="details.php?id=73414">Marty.Life.Is.Short.2026.2160p-DEMO</a>
+    <img class="pro_free2up" src="pic/trans.gif" alt="2X Free" />
+    <br/><span>演示标题 / Demo</span>
+  </td></tr></table></td>
+  <td class="rowfollow">0</td>
+  <td class="rowfollow"><span title="2026-05-13 06:43:22">16时53分</span></td>
+  <td class="rowfollow">14.26 GB</td>
+  <td class="rowfollow">4</td>
+  <td class="rowfollow">0</td>
+  <td class="rowfollow">6</td>
+  <td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr>
+  <td class="rowfollow"><img alt="剧集/TV" /></td>
+  <td class="rowfollow"><table class="torrentname"><tr><td class="embedded">
+    <a href="details.php?id=73415">DuckBoobee.Demo2.Series.S01-DBB</a>
+    <img class="pro_50pctdown" src="pic/trans.gif" alt="50%" />
+    <br/><span>演示标题2 / Demo2</span>
+  </td></tr></table></td>
+  <td class="rowfollow">0</td>
+  <td class="rowfollow"><span title="2026-05-12 12:00:00">1天</span></td>
+  <td class="rowfollow">3.21 GB</td>
+  <td class="rowfollow">12</td>
+  <td class="rowfollow">2</td>
+  <td class="rowfollow">30</td>
+  <td class="rowfollow">DBB-Team</td>
+</tr>
+</tbody></table>
+</body></html>`
+
+const duckboobeeIndexFixture = `<html><body>
+<table id="info_block"><tr><td>
+欢迎回来, <span class="nowrap"><a href="https://duckboobee.org/userdetails.php?id=22392" class='User_Name'><b>duckboobee_user</b></a></span>
+<font class='color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 8,765.4<br/>
+<font class="color_ratio">分享率:</font> 5.123
+<font class='color_uploaded'>上传量:</font> 2.50 TB
+<font class='color_downloaded'> 下载量:</font> 500.00 GB
+<font class='color_active'>当前活动:</font> <img class="arrowup" src="pic/trans.gif" />8 <img class="arrowdown" src="pic/trans.gif" />2
+</td></tr></table>
+</body></html>`
+
+const duckboobeeUserdetailsFixture = `<html><body>
+<table>
+  <tr><td class="rowhead">用户ID/UID</td><td class="rowfollow">22392</td></tr>
+  <tr><td class="rowhead">加入日期</td><td class="rowfollow">2026-01-15 10:30:00 (<span title="2026-01-15 10:30:00">3月前</span>)</td></tr>
+  <tr><td class="rowhead">传输</td><td class="rowfollow"><table><tr><td class="embedded"><strong>分享率</strong>: <font color="">5.123</font></td></tr><tr><td class="embedded"><strong>上传量</strong>: 2.50 TB</td><td class="embedded"><strong>下载量</strong>: 500.00 GB</td></tr></table></td></tr>
+  <tr><td class="rowhead">等级</td><td class="rowfollow"><img title="Power User" src="pic/poweruser.gif" /></td></tr>
+</table>
+</body></html>`
+
+const duckboobeeDetailFixture = `<html><body>
+<input type="hidden" name="torrent_name" value="Marty.Life.Is.Short.2026.2160p-DEMO" />
+<input type="hidden" name="detail_torrent_id" value="73414" />
+<h1 align="center" id="top">Marty.Life.Is.Short.2026.2160p-DEMO&nbsp;&nbsp;&nbsp; <b>[<font class='twoupfree'>2X免费</font>]</b> <font color='#00CC66'>剩余时间：<span title="2026-06-11 22:43:22">29天7时</span></font></h1>
+<table>
+  <tr><td class="rowhead">下载</td><td class="rowfollow"><a href="download.php?id=73414">demo.torrent</a></td></tr>
+  <tr><td class="rowhead">副标题</td><td class="rowfollow">演示标题 / Demo</td></tr>
+  <tr><td class="rowhead">基本信息</td><td class="rowfollow">大小</td><td class="rowfollow">大小：14.26 GB</td></tr>
+</table>
+</body></html>`
+
+func getDuckBoobeeDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("duckboobee")
+	require.True(t, ok)
+	return def
+}
+
+func testDuckBoobeeSearch(t *testing.T) {
+	def := getDuckBoobeeDef(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(duckboobeeSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{BaseURL: server.URL, Cookie: "test_cookie=1", Selectors: def.Selectors})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: http.MethodGet})
+	require.NoError(t, err)
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+
+	assert.Equal(t, "73414", items[0].ID)
+	assert.Equal(t, "Marty.Life.Is.Short.2026.2160p-DEMO", items[0].Title)
+	assert.Equal(t, "演示标题 / Demo", items[0].Subtitle)
+	assert.Equal(t, v2.Discount2xFree, items[0].DiscountLevel)
+	assert.Equal(t, 4, items[0].Seeders)
+	assert.Equal(t, 0, items[0].Leechers)
+	assert.Equal(t, 6, items[0].Snatched)
+
+	assert.Equal(t, "73415", items[1].ID)
+	assert.Equal(t, v2.DiscountPercent50, items[1].DiscountLevel)
+}
+
+func testDuckBoobeeDetail(t *testing.T) {
+	def := getDuckBoobeeDef(t)
+	parser := v2.NewNexusPHPParserFromDefinition(def)
+
+	doc := FixtureDoc(t, "duckboobee_detail", duckboobeeDetailFixture)
+	info := parser.ParseAll(doc.Selection)
+	assert.Equal(t, "73414", info.TorrentID)
+	assert.Equal(t, "Marty.Life.Is.Short.2026.2160p-DEMO", info.Title)
+	assert.Equal(t, v2.Discount2xFree, info.DiscountLevel)
+	assert.InDelta(t, 14602.24, info.SizeMB, 0.5)
+}
+
+func testDuckBoobeeUserInfo(t *testing.T) {
+	def := getDuckBoobeeDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	indexDoc := FixtureDoc(t, "duckboobee_index", duckboobeeIndexFixture)
+	assert.Equal(t, "22392", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["id"]))
+	assert.Equal(t, "duckboobee_user", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["name"]))
+	assert.Equal(t, "8765.4", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["bonus"]))
+	assert.Equal(t, "8", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["seeding"]))
+	assert.Equal(t, "2", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["leeching"]))
+
+	userDoc := FixtureDoc(t, "duckboobee_userdetails", duckboobeeUserdetailsFixture)
+	assert.Equal(t, "2748779069440", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["uploaded"]))
+	assert.Equal(t, "536870912000", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["downloaded"]))
+	assert.Equal(t, "5.123", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["ratio"]))
+	assert.Equal(t, "Power User", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["levelName"]))
+	assert.Equal(t, "1768473000", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["joinTime"]))
+}
+
+func TestDuckBoobee_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":      duckboobeeSearchFixture,
+		"index":       duckboobeeIndexFixture,
+		"userdetails": duckboobeeUserdetailsFixture,
+		"detail":      duckboobeeDetailFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) { RequireNoSecrets(t, name, data) })
+	}
+}

--- a/site/v2/definitions/hdvideo.go
+++ b/site/v2/definitions/hdvideo.go
@@ -1,0 +1,116 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+var HDVideoDefinition = &v2.SiteDefinition{
+	ID:             "hdvideo",
+	Name:           "HDVideo",
+	Aka:            []string{"HD视频", "hdvideo.top"},
+	Description:    "HDVideo — NexusPHP PT 站点（hdvideo.top）",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://hdvideo.top/"},
+	FaviconURL:     "https://hdvideo.top/favicon.ico",
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "uploaded", "downloaded", "ratio", "bonus", "seeding", "leeching"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields:        []string{"name", "levelName", "joinTime"},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			"id": {
+				Selector: []string{"a[href*='userdetails.php'][class*='Name']", "#info_block a[href*='userdetails.php']", "a[href*='userdetails.php']"},
+				Attr:     "href",
+				Filters:  []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{"a[href*='userdetails.php'][class*='Name']", "#info_block a[href*='userdetails.php']", "h1 span.nowrap > b"},
+			},
+			"uploaded": {
+				Selector: []string{"#info_block", "td.rowhead:contains('传输') + td", "td.rowhead:contains('上传量') + td"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:上传量|上傳量|Uploaded)[^\d]*([\d.,]+\s*[KMGTP]?i?B)`}}, {Name: "parseSize"}},
+			},
+			"downloaded": {
+				Selector: []string{"#info_block", "td.rowhead:contains('传输') + td", "td.rowhead:contains('下载量') + td"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:下载量|下載量|Downloaded)[^\d]*([\d.,]+\s*[KMGTP]?i?B)`}}, {Name: "parseSize"}},
+			},
+			"ratio": {
+				Selector: []string{"#info_block", "td.rowhead:contains('传输') + td", "td.rowhead:contains('分享率') + td"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:分享率|Ratio)[^\d∞无]*([\d.,]+|∞|无限|Inf|---)`}}, {Name: "parseNumber"}},
+			},
+			"levelName": {
+				Selector: []string{"td.rowhead:contains('等级') + td > img", "td.rowhead:contains('等级') + td img", "td.rowhead:contains('Class') + td > img"},
+				Attr:     "title",
+			},
+			"bonus": {
+				Selector: []string{"#info_block", "td.rowhead:contains('魔力值') + td", "td.rowhead:contains('Bonus') + td"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:魔力值|Bonus)[^\d]*([\d.,]+)`}}, {Name: "parseNumber"}},
+			},
+			"joinTime": {
+				Selector: []string{"td.rowhead:contains('加入日期') + td", "td.rowhead:contains('Join') + td"},
+				Filters:  []v2.Filter{{Name: "split", Args: []any{" (", 0}}, {Name: "parseTime"}},
+			},
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`class="arrowup"[^>]*/>\s*(\d+)`}}, {Name: "parseNumber"}},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}}, {Name: "parseNumber"}},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		TableRows:          "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:              "table.torrentname a[href*='details.php']",
+		TitleLink:          "table.torrentname a[href*='details.php']",
+		Subtitle:           "table.torrentname td.embedded > span:last-of-type, table.torrentname td.embedded > span:not(.optiontag)",
+		Size:               "td.rowfollow:nth-child(5)",
+		Seeders:            "td.rowfollow:nth-child(6)",
+		Leechers:           "td.rowfollow:nth-child(7)",
+		Snatched:           "td.rowfollow:nth-child(8)",
+		DiscountIcon:       "img.pro_free, img.pro_free2up, img.pro_50pctdown, img.pro_30pctdown, img.pro_2up, img.pro_50pctdown2up",
+		Category:           "td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:         "td.rowfollow:nth-child(4) span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords:       []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run", "H&R"},
+		DiscountSelector: "h1 font.free, h1 font[class]",
+		EndTimeSelector:  "h1 span[title]",
+		SizeSelector:     "td.rowfollow:contains('大小')",
+		SizeRegex:        `大小[：:]\s*([\d.]+)\s*(GB|MB|KB|TB)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(HDVideoDefinition)
+}

--- a/site/v2/definitions/hdvideo_fixture_test.go
+++ b/site/v2/definitions/hdvideo_fixture_test.go
@@ -1,0 +1,156 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{SiteID: "hdvideo", Search: testHDVideoSearch, Detail: testHDVideoDetail, UserInfo: testHDVideoUserInfo})
+}
+
+const hdvideoSearchFixture = `<html><body>
+<table class="torrents"><tbody>
+<tr>
+  <td class="rowfollow"><img alt="电影/Movies" /></td>
+  <td class="rowfollow"><table class="torrentname"><tr><td class="embedded">
+    <a href="details.php?id=65743">Lang.Lang.Shan.Demo.2025.1080p-HDV</a>
+    <img class="pro_free2up" src="pic/trans.gif" alt="2X Free" />
+    <br/><span>演示标题 / Demo</span>
+  </td></tr></table></td>
+  <td class="rowfollow">0</td>
+  <td class="rowfollow"><span title="2026-04-26 04:58:19">18天3时</span></td>
+  <td class="rowfollow">30.96 GB</td>
+  <td class="rowfollow">79</td>
+  <td class="rowfollow">7</td>
+  <td class="rowfollow">589</td>
+  <td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr>
+  <td class="rowfollow"><img alt="纪录片/Documentary" /></td>
+  <td class="rowfollow"><table class="torrentname"><tr><td class="embedded">
+    <a href="details.php?id=65745">HDVideo.Demo2.Doc-DEMO</a>
+    <img class="pro_free" src="pic/trans.gif" alt="Free" />
+    <br/><span>演示标题2 / Demo2</span>
+  </td></tr></table></td>
+  <td class="rowfollow">3</td>
+  <td class="rowfollow"><span title="2026-05-12 12:00:00">1天</span></td>
+  <td class="rowfollow">8.21 GB</td>
+  <td class="rowfollow">42</td>
+  <td class="rowfollow">1</td>
+  <td class="rowfollow">128</td>
+  <td class="rowfollow">DocTeam</td>
+</tr>
+</tbody></table>
+</body></html>`
+
+const hdvideoIndexFixture = `<html><body>
+<table id="info_block"><tr><td>
+欢迎回来, <span class="nowrap"><a href="https://hdvideo.top/userdetails.php?id=25339" class='User_Name'><b>hdvideo_user</b></a></span>
+<font class='color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 9,876.0
+<font class="color_ratio">分享率:</font> 无限                <font class='color_uploaded'>上传量:</font> 10.00 GB                <font class='color_downloaded'> 下载量:</font> 0.00 KB                <font class='color_active'>当前活动:</font> <img class="arrowup" src="pic/trans.gif" />0  <img class="arrowdown" src="pic/trans.gif" />0
+</td></tr></table>
+</body></html>`
+
+const hdvideoUserdetailsFixture = `<html><body>
+<h1 style='margin:0px'><span class="nowrap"><b>hdvideo_user</b></span></h1>
+<table>
+  <tr><td class="rowhead">用户ID/UID</td><td class="rowfollow">25339</td></tr>
+  <tr><td class="rowhead">加入日期</td><td class="rowfollow">2025-12-01 09:00:00 (<span title="2025-12-01 09:00:00">5月前</span>)</td></tr>
+  <tr><td class="rowhead">等级</td><td class="rowfollow"><img title="Veteran User" src="pic/veteran.gif" /></td></tr>
+</table>
+</body></html>`
+
+const hdvideoDetailFixture = `<html><body>
+<input type="hidden" name="torrent_name" value="Lang.Lang.Shan.Demo.2025.1080p-HDV" />
+<input type="hidden" name="detail_torrent_id" value="65743" />
+<h1 align="center" id="top">Lang.Lang.Shan.Demo.2025.1080p-HDV&nbsp;&nbsp;&nbsp; <b>[<font class='twoupfree'>2X免费</font>]</b> <font color='#00CC66'>剩余时间：<span title="2026-05-14 07:58:19">2天16时</span></font></h1>
+<table>
+  <tr><td class="rowhead">下载</td><td class="rowfollow"><a href="download.php?id=65743">demo.torrent</a></td></tr>
+  <tr><td class="rowhead">副标题</td><td class="rowfollow">演示标题 / Demo</td></tr>
+  <tr><td class="rowhead">基本信息</td><td class="rowfollow">大小</td><td class="rowfollow">大小：30.96 GB</td></tr>
+</table>
+</body></html>`
+
+func getHDVideoDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("hdvideo")
+	require.True(t, ok)
+	return def
+}
+
+func testHDVideoSearch(t *testing.T) {
+	def := getHDVideoDef(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(hdvideoSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{BaseURL: server.URL, Cookie: "test_cookie=1", Selectors: def.Selectors})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: http.MethodGet})
+	require.NoError(t, err)
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+
+	assert.Equal(t, "65743", items[0].ID)
+	assert.Equal(t, "Lang.Lang.Shan.Demo.2025.1080p-HDV", items[0].Title)
+	assert.Equal(t, "演示标题 / Demo", items[0].Subtitle)
+	assert.Equal(t, v2.Discount2xFree, items[0].DiscountLevel)
+	assert.Equal(t, 79, items[0].Seeders)
+	assert.Equal(t, 7, items[0].Leechers)
+	assert.Equal(t, 589, items[0].Snatched)
+
+	assert.Equal(t, "65745", items[1].ID)
+	assert.Equal(t, v2.DiscountFree, items[1].DiscountLevel)
+}
+
+func testHDVideoDetail(t *testing.T) {
+	def := getHDVideoDef(t)
+	parser := v2.NewNexusPHPParserFromDefinition(def)
+
+	doc := FixtureDoc(t, "hdvideo_detail", hdvideoDetailFixture)
+	info := parser.ParseAll(doc.Selection)
+	assert.Equal(t, "65743", info.TorrentID)
+	assert.Equal(t, "Lang.Lang.Shan.Demo.2025.1080p-HDV", info.Title)
+	assert.Equal(t, v2.Discount2xFree, info.DiscountLevel)
+	assert.InDelta(t, 31703.04, info.SizeMB, 1.0)
+}
+
+func testHDVideoUserInfo(t *testing.T) {
+	def := getHDVideoDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	indexDoc := FixtureDoc(t, "hdvideo_index", hdvideoIndexFixture)
+	assert.Equal(t, "25339", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["id"]))
+	assert.Equal(t, "hdvideo_user", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["name"]))
+	assert.Equal(t, "9876", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["bonus"]))
+	assert.Equal(t, "10737418240", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["uploaded"]))
+	assert.Equal(t, "0", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["downloaded"]))
+
+	userDoc := FixtureDoc(t, "hdvideo_userdetails", hdvideoUserdetailsFixture)
+	assert.Equal(t, "Veteran User", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["levelName"]))
+	assert.Equal(t, "1764579600", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["joinTime"]))
+}
+
+func TestHDVideo_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":      hdvideoSearchFixture,
+		"index":       hdvideoIndexFixture,
+		"userdetails": hdvideoUserdetailsFixture,
+		"detail":      hdvideoDetailFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) { RequireNoSecrets(t, name, data) })
+	}
+}

--- a/site/v2/definitions/longpt.go
+++ b/site/v2/definitions/longpt.go
@@ -1,0 +1,116 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+var LongPTDefinition = &v2.SiteDefinition{
+	ID:             "longpt",
+	Name:           "LongPT",
+	Aka:            []string{"龙PT", "longpt.org"},
+	Description:    "LongPT — NexusPHP PT 站点（longpt.org）",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://longpt.org/"},
+	FaviconURL:     "https://longpt.org/favicon.ico",
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "bonus", "seeding", "leeching"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields:        []string{"name", "uploaded", "downloaded", "ratio", "levelName", "joinTime"},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			"id": {
+				Selector: []string{"a[href*='userdetails.php'][class*='Name']", "#info_block a[href*='userdetails.php']", "a[href*='userdetails.php']"},
+				Attr:     "href",
+				Filters:  []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{"a[href*='userdetails.php'][class*='Name']", "#info_block a[href*='userdetails.php']"},
+			},
+			"uploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('上传量') + td", "#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:上传量|上傳量|Uploaded)[^\d]*([\d.,]+\s*[KMGTP]?i?B)`}}, {Name: "parseSize"}},
+			},
+			"downloaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('下载量') + td", "#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:下载量|下載量|Downloaded)[^\d]*([\d.,]+\s*[KMGTP]?i?B)`}}, {Name: "parseSize"}},
+			},
+			"ratio": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('分享率') + td", "#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:分享率|Ratio)[^\d∞]*([\d.,]+|∞|Inf|---)`}}, {Name: "parseNumber"}},
+			},
+			"levelName": {
+				Selector: []string{"td.rowhead:contains('等级') + td > img", "td.rowhead:contains('等级') + td img", "td.rowhead:contains('Class') + td > img"},
+				Attr:     "title",
+			},
+			"bonus": {
+				Selector: []string{"#info_block", "td.rowhead:contains('魔力值') + td", "td.rowhead:contains('Bonus') + td"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:魔力值|Bonus)[^\d]*([\d.,]+)`}}, {Name: "parseNumber"}},
+			},
+			"joinTime": {
+				Selector: []string{"td.rowhead:contains('加入日期') + td", "td.rowhead:contains('Join') + td"},
+				Filters:  []v2.Filter{{Name: "split", Args: []any{" (", 0}}, {Name: "parseTime"}},
+			},
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`class="arrowup"[^>]*/>\s*(\d+)`}}, {Name: "parseNumber"}},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}}, {Name: "parseNumber"}},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		TableRows:          "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:              "table.torrentname a[href*='details.php']",
+		TitleLink:          "table.torrentname a[href*='details.php']",
+		Subtitle:           "table.torrentname td.embedded > span:last-of-type, table.torrentname td.embedded > span:not(.optiontag)",
+		Size:               "td.rowfollow:nth-child(5)",
+		Seeders:            "td.rowfollow:nth-child(6)",
+		Leechers:           "td.rowfollow:nth-child(7)",
+		Snatched:           "td.rowfollow:nth-child(8)",
+		DiscountIcon:       "img.pro_free, img.pro_free2up, img.pro_50pctdown, img.pro_30pctdown, img.pro_2up, img.pro_50pctdown2up",
+		Category:           "td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:         "td.rowfollow:nth-child(4) span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords:       []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run", "H&R"},
+		DiscountSelector: "h1 font.free, h1 font[class]",
+		EndTimeSelector:  "h1 span[title]",
+		SizeSelector:     "td.rowfollow:contains('大小')",
+		SizeRegex:        `大小[：:]\s*([\d.]+)\s*(GB|MB|KB|TB)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(LongPTDefinition)
+}

--- a/site/v2/definitions/longpt_fixture_test.go
+++ b/site/v2/definitions/longpt_fixture_test.go
@@ -1,0 +1,159 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{SiteID: "longpt", Search: testLongPTSearch, Detail: testLongPTDetail, UserInfo: testLongPTUserInfo})
+}
+
+const longptSearchFixture = `<html><body>
+<table class="torrents"><tbody>
+<tr>
+  <td class="rowfollow"><img alt="电影/Movies" /></td>
+  <td class="rowfollow"><table class="torrentname"><tr><td class="embedded">
+    <a href="details.php?id=38948">Dong.Bei.Qi.Miao.Demo-LongWeb</a>
+    <img class="pro_free" src="pic/trans.gif" alt="Free" />
+    <br/><span>演示标题 / Demo</span>
+  </td></tr></table></td>
+  <td class="rowfollow">0</td>
+  <td class="rowfollow"><span title="2026-05-13 05:21:28">2时11分</span></td>
+  <td class="rowfollow">5.65 GB</td>
+  <td class="rowfollow">21</td>
+  <td class="rowfollow">5</td>
+  <td class="rowfollow">23</td>
+  <td class="rowfollow">LongWeb</td>
+</tr>
+<tr>
+  <td class="rowfollow"><img alt="动漫/Anime" /></td>
+  <td class="rowfollow"><table class="torrentname"><tr><td class="embedded">
+    <a href="details.php?id=38950">LongPT.Demo2.Anime-DEMO</a>
+    <img class="pro_30pctdown" src="pic/trans.gif" alt="30%" />
+    <br/><span>演示标题2 / Demo2</span>
+  </td></tr></table></td>
+  <td class="rowfollow">2</td>
+  <td class="rowfollow"><span title="2026-05-12 12:00:00">1天">
+  <td class="rowfollow">512.50 MB</td>
+  <td class="rowfollow">15</td>
+  <td class="rowfollow">3</td>
+  <td class="rowfollow">42</td>
+  <td class="rowfollow">DemoTeam</td>
+</tr>
+</tbody></table>
+</body></html>`
+
+const longptIndexFixture = `<html><body>
+<table id="info_block"><tr><td>
+欢迎回来, <span class="nowrap"><a href="https://longpt.org/userdetails.php?id=22222" class='User_Name'><b>longpt_user</b></a></span>
+<font class='color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 4,567.8<br/>
+<font class="color_ratio">分享率:</font> 3.456
+<font class='color_uploaded'>上传量:</font> 1.20 TB
+<font class='color_downloaded'> 下载量:</font> 350.00 GB
+<font class='color_active'>当前活动:</font> <img class="arrowup" src="pic/trans.gif" />5 <img class="arrowdown" src="pic/trans.gif" />0
+</td></tr></table>
+</body></html>`
+
+const longptUserdetailsFixture = `<html><body>
+<table>
+  <tr><td class="rowhead">用户ID/UID</td><td class="rowfollow">22222</td></tr>
+  <tr><td class="rowhead">加入日期</td><td class="rowfollow">2026-02-10 14:00:00 (<span title="2026-02-10 14:00:00">2月前</span>)</td></tr>
+  <tr><td class="rowhead">传输</td><td class="rowfollow"><table><tr><td class="embedded"><strong>分享率</strong>: <font color="">3.456</font></td></tr><tr><td class="embedded"><strong>上传量</strong>: 1.20 TB</td><td class="embedded"><strong>下载量</strong>: 350.00 GB</td></tr></table></td></tr>
+  <tr><td class="rowhead">等级</td><td class="rowfollow"><img title="Elite User" src="pic/eliteuser.gif" /></td></tr>
+</table>
+</body></html>`
+
+const longptDetailFixture = `<html><body>
+<input type="hidden" name="torrent_name" value="Dong.Bei.Qi.Miao.Demo-LongWeb" />
+<input type="hidden" name="detail_torrent_id" value="38948" />
+<h1 align="center" id="top">Dong.Bei.Qi.Miao.Demo-LongWeb&nbsp;&nbsp;&nbsp; <b>[<font class='free'>免费</font>]</b> <font color='#0000FF'>剩余时间：<span title="2026-05-28 13:21:28">14天21时</span></font></h1>
+<table>
+  <tr><td class="rowhead">下载</td><td class="rowfollow"><a href="download.php?id=38948">demo.torrent</a></td></tr>
+  <tr><td class="rowhead">副标题</td><td class="rowfollow">演示标题 / Demo</td></tr>
+  <tr><td class="rowhead">基本信息</td><td class="rowfollow">大小</td><td class="rowfollow">大小：5.65 GB</td></tr>
+</table>
+</body></html>`
+
+func getLongPTDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("longpt")
+	require.True(t, ok)
+	return def
+}
+
+func testLongPTSearch(t *testing.T) {
+	def := getLongPTDef(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(longptSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{BaseURL: server.URL, Cookie: "test_cookie=1", Selectors: def.Selectors})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: http.MethodGet})
+	require.NoError(t, err)
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(items), 1)
+
+	assert.Equal(t, "38948", items[0].ID)
+	assert.Equal(t, "Dong.Bei.Qi.Miao.Demo-LongWeb", items[0].Title)
+	assert.Equal(t, "演示标题 / Demo", items[0].Subtitle)
+	assert.Equal(t, v2.DiscountFree, items[0].DiscountLevel)
+	assert.Equal(t, 21, items[0].Seeders)
+	assert.Equal(t, 5, items[0].Leechers)
+	assert.Equal(t, 23, items[0].Snatched)
+}
+
+func testLongPTDetail(t *testing.T) {
+	def := getLongPTDef(t)
+	parser := v2.NewNexusPHPParserFromDefinition(def)
+
+	doc := FixtureDoc(t, "longpt_detail", longptDetailFixture)
+	info := parser.ParseAll(doc.Selection)
+	assert.Equal(t, "38948", info.TorrentID)
+	assert.Equal(t, "Dong.Bei.Qi.Miao.Demo-LongWeb", info.Title)
+	assert.Equal(t, v2.DiscountFree, info.DiscountLevel)
+	assert.InDelta(t, 5785.6, info.SizeMB, 1.0)
+}
+
+func testLongPTUserInfo(t *testing.T) {
+	def := getLongPTDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	indexDoc := FixtureDoc(t, "longpt_index", longptIndexFixture)
+	assert.Equal(t, "22222", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["id"]))
+	assert.Equal(t, "longpt_user", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["name"]))
+	assert.Equal(t, "4567.8", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["bonus"]))
+	assert.Equal(t, "5", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["seeding"]))
+	assert.Equal(t, "0", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["leeching"]))
+
+	userDoc := FixtureDoc(t, "longpt_userdetails", longptUserdetailsFixture)
+	assert.Equal(t, "1319413953331", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["uploaded"]))
+	assert.Equal(t, "375809638400", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["downloaded"]))
+	assert.Equal(t, "3.456", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["ratio"]))
+	assert.Equal(t, "Elite User", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["levelName"]))
+	assert.Equal(t, "1770732000", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["joinTime"]))
+}
+
+func TestLongPT_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":      longptSearchFixture,
+		"index":       longptIndexFixture,
+		"userdetails": longptUserdetailsFixture,
+		"detail":      longptDetailFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) { RequireNoSecrets(t, name, data) })
+	}
+}

--- a/tools/browser-extension/src/core/constants.ts
+++ b/tools/browser-extension/src/core/constants.ts
@@ -344,6 +344,33 @@ export const KNOWN_SITES: KnownSite[] = [
     cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
     syncField: "cookie",
   },
+  {
+    id: "duckboobee",
+    name: "DuckBoobee",
+    domains: ["duckboobee.org"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
+  {
+    id: "longpt",
+    name: "LongPT",
+    domains: ["longpt.org"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
+  {
+    id: "hdvideo",
+    name: "HDVideo",
+    domains: ["hdvideo.top"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
 ];
 
 export const PAGE_PATTERNS: Array<{ pattern: RegExp; pageType: PageType }> = [


### PR DESCRIPTION
## Summary

新增 3 个 NexusPHP + Cookie 站点适配，全部经 fixture 测试验证。

## Changes

| 站点 | 域名 | Issue |
|---|---|---|
| **DuckBoobee**（鸭鸭） | duckboobee.org | #319 |
| **LongPT**（龙PT） | longpt.org | #318 |
| **HDVideo**（HD视频） | hdvideo.top | #307 |

每站点交付：

- `site/v2/definitions/<id>.go` 完整定义（NexusPHP schema + Cookie 鉴权 + UserInfo 多步抓取 + Selectors + DetailParser）
- `site/v2/definitions/<id>_fixture_test.go` Search/Detail/UserInfo 三段 fixture 测试 + `RequireNoSecrets` 安全校验
- `tools/browser-extension/src/core/constants.ts` `KNOWN_SITES` 同步更新

## Docs

- `docs/sites.md` 适配站点数 36 → **39**
- NexusPHP 系列 32 → **35**

## Validation

- `go test ./site/v2/definitions/` 全部 PASS
- `golangci-lint run ./site/v2/definitions/` 0 issues
- `pnpm run pack`（browser-extension）✅ Built-in sites are in sync

Closes #319
Closes #318
Closes #307