### PR TITLE
fix(web): 修正 favicon 全站刷新行为并增加已支持站点视图

### DIFF
--- a/web/api_favicon.go
+++ b/web/api_favicon.go
@@ -61,7 +61,8 @@ func (fs *FaviconService) backgroundRefresh() {
 	}
 }
 
-// refreshExpiredFavicons 刷新所有过期的图标
+// refreshExpiredFavicons 仅刷新用户在 SiteSetting 中已启用的站点图标。
+// 不要扩展为遍历全部 SiteDefinition，否则会对未配置的站点发起无意义请求。
 func (fs *FaviconService) refreshExpiredFavicons() {
 	if global.GlobalDB == nil {
 		return
@@ -70,23 +71,29 @@ func (fs *FaviconService) refreshExpiredFavicons() {
 	db := global.GlobalDB.DB
 	expiredTime := time.Now().Add(-fs.refreshInterval)
 
-	// 查找所有过期的缓存
+	enabledIDs := loadEnabledSiteIDsLower()
+	if len(enabledIDs) == 0 {
+		return
+	}
+
 	var expiredCaches []models.FaviconCache
 	if err := db.Where("last_fetched < ? OR last_fetched IS NULL", expiredTime).Find(&expiredCaches).Error; err != nil {
 		global.GetSlogger().Warnf("[Favicon] 查询过期缓存失败: %v", err)
 		return
 	}
 
-	// 获取所有注册的站点定义
 	definitions := v2.GetDefinitionRegistry().GetAll()
-	defMap := make(map[string]*v2.SiteDefinition)
+	defMap := make(map[string]*v2.SiteDefinition, len(definitions))
 	for _, def := range definitions {
 		defMap[strings.ToLower(def.ID)] = def
 	}
 
-	// 刷新过期的缓存
 	for _, cache := range expiredCaches {
-		def, ok := defMap[strings.ToLower(cache.SiteID)]
+		siteIDLower := strings.ToLower(cache.SiteID)
+		if !enabledIDs[siteIDLower] {
+			continue
+		}
+		def, ok := defMap[siteIDLower]
 		if !ok {
 			continue
 		}
@@ -105,32 +112,54 @@ func (fs *FaviconService) refreshExpiredFavicons() {
 			global.GetSlogger().Infof("[Favicon] 刷新图标成功: site=%s", cache.SiteID)
 		}
 
-		// 避免请求过于频繁
 		time.Sleep(2 * time.Second)
 	}
 
-	// 检查是否有新站点需要添加缓存
-	for _, def := range definitions {
+	for siteIDLower := range enabledIDs {
+		def, ok := defMap[siteIDLower]
+		if !ok {
+			continue
+		}
 		var count int64
 		db.Model(&models.FaviconCache{}).Where("site_id = ?", def.ID).Count(&count)
-		if count == 0 {
-			faviconURL := def.FaviconURL
-			if faviconURL == "" && len(def.URLs) > 0 {
-				faviconURL = strings.TrimSuffix(def.URLs[0], "/") + "/favicon.ico"
-			}
-			if faviconURL == "" {
-				continue
-			}
+		if count != 0 {
+			continue
+		}
 
-			if err := fs.fetchAndSave(def.ID, def.Name, faviconURL); err != nil {
-				global.GetSlogger().Warnf("[Favicon] 新站点图标获取失败: site=%s, err=%v", def.ID, err)
-			} else {
-				global.GetSlogger().Infof("[Favicon] 新站点图标已缓存: site=%s", def.ID)
-			}
+		faviconURL := def.FaviconURL
+		if faviconURL == "" && len(def.URLs) > 0 {
+			faviconURL = strings.TrimSuffix(def.URLs[0], "/") + "/favicon.ico"
+		}
+		if faviconURL == "" {
+			continue
+		}
 
-			time.Sleep(2 * time.Second)
+		if err := fs.fetchAndSave(def.ID, def.Name, faviconURL); err != nil {
+			global.GetSlogger().Warnf("[Favicon] 新站点图标获取失败: site=%s, err=%v", def.ID, err)
+		} else {
+			global.GetSlogger().Infof("[Favicon] 新站点图标已缓存: site=%s", def.ID)
+		}
+
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func loadEnabledSiteIDsLower() map[string]bool {
+	if global.GlobalDB == nil {
+		return nil
+	}
+	var settings []models.SiteSetting
+	if err := global.GlobalDB.DB.Where("enabled = ?", true).Find(&settings).Error; err != nil {
+		global.GetSlogger().Warnf("[Favicon] 查询已启用站点失败: %v", err)
+		return nil
+	}
+	result := make(map[string]bool, len(settings))
+	for _, st := range settings {
+		if st.Name != "" {
+			result[strings.ToLower(st.Name)] = true
 		}
 	}
+	return result
 }
 
 // fetchAndSave 下载并保存图标到数据库
@@ -263,15 +292,16 @@ func (s *Server) apiFavicon(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 初始化服务（如果尚未初始化）
 	if faviconService == nil {
 		initFaviconService()
 	}
 
-	// 从数据库获取缓存
 	cache, err := faviconService.GetFavicon(siteID)
 	if err != nil || cache == nil || len(cache.Data) == 0 {
-		// 缓存不存在，尝试获取
+		if r.URL.Query().Get("nofetch") == "1" {
+			http.Error(w, "图标尚未缓存", http.StatusNotFound)
+			return
+		}
 		def := v2.GetDefinitionRegistry().GetOrDefault(strings.ToLower(siteID))
 		if def == nil {
 			http.Error(w, "站点不存在", http.StatusNotFound)
@@ -287,14 +317,12 @@ func (s *Server) apiFavicon(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// 同步获取并缓存
 		if fetchErr := faviconService.fetchAndSave(siteID, def.Name, faviconURL); fetchErr != nil {
 			global.GetSlogger().Warnf("[Favicon] 获取图标失败: site=%s, err=%v", siteID, fetchErr)
 			http.Error(w, "获取图标失败", http.StatusNotFound)
 			return
 		}
 
-		// 重新获取
 		cache, err = faviconService.GetFavicon(siteID)
 		if err != nil || cache == nil {
 			http.Error(w, "获取图标失败", http.StatusNotFound)
@@ -344,10 +372,9 @@ func (s *Server) apiFaviconList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 获取所有注册的站点定义
 	definitions := v2.GetDefinitionRegistry().GetAll()
+	enabledIDs := loadEnabledSiteIDsLower()
 
-	// 获取数据库中的缓存信息
 	db := global.GlobalDB.DB
 	var caches []models.FaviconCache
 	db.Find(&caches)
@@ -357,9 +384,12 @@ func (s *Server) apiFaviconList(w http.ResponseWriter, r *http.Request) {
 		cacheMap[strings.ToLower(caches[i].SiteID)] = &caches[i]
 	}
 
-	result := make([]SiteFaviconInfo, 0, len(definitions))
+	result := make([]SiteFaviconInfo, 0, len(enabledIDs))
 
 	for _, def := range definitions {
+		if !enabledIDs[strings.ToLower(def.ID)] {
+			continue
+		}
 		info := SiteFaviconInfo{
 			SiteID:     def.ID,
 			SiteName:   def.Name,

--- a/web/api_site.go
+++ b/web/api_site.go
@@ -521,3 +521,43 @@ func (s *Server) apiSiteFreeTorrentsList(w http.ResponseWriter, r *http.Request)
 	// Return empty list for now
 	writeJSON(w, []TorrentManifestItem{})
 }
+
+type SupportedSiteDefinition struct {
+	ID                string   `json:"id"`
+	Name              string   `json:"name"`
+	Aka               []string `json:"aka,omitempty"`
+	Description       string   `json:"description,omitempty"`
+	Schema            string   `json:"schema"`
+	URLs              []string `json:"urls"`
+	FaviconURL        string   `json:"faviconUrl,omitempty"`
+	AuthMethod        string   `json:"authMethod,omitempty"`
+	HREnabled         bool     `json:"hrEnabled"`
+	Unavailable       bool     `json:"unavailable,omitempty"`
+	UnavailableReason string   `json:"unavailableReason,omitempty"`
+}
+
+func (s *Server) apiSiteDefinitions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	defs := v2.GetDefinitionRegistry().GetAll()
+	out := make([]SupportedSiteDefinition, 0, len(defs))
+	for _, d := range defs {
+		out = append(out, SupportedSiteDefinition{
+			ID:                d.ID,
+			Name:              d.Name,
+			Aka:               d.Aka,
+			Description:       d.Description,
+			Schema:            string(d.Schema),
+			URLs:              d.URLs,
+			FaviconURL:        d.FaviconURL,
+			AuthMethod:        string(d.AuthMethod),
+			HREnabled:         d.HREnabled,
+			Unavailable:       d.Unavailable,
+			UnavailableReason: d.UnavailableReason,
+		})
+	}
+	writeJSON(w, out)
+}

--- a/web/frontend/src/App.vue
+++ b/web/frontend/src/App.vue
@@ -144,6 +144,10 @@ function logout() {
             <el-icon><Connection /></el-icon>
             <template #title>站点与RSS</template>
           </el-menu-item>
+          <el-menu-item index="supported-sites">
+            <el-icon><Collection /></el-icon>
+            <template #title>已支持站点</template>
+          </el-menu-item>
           <el-menu-item index="search">
             <el-icon><Search /></el-icon>
             <template #title>种子搜索</template>

--- a/web/frontend/src/api/index.ts
+++ b/web/frontend/src/api/index.ts
@@ -176,6 +176,20 @@ export const qbitApi = {
   save: (data: QbitSettings) => api.post<void>("/api/qbit", data),
 };
 
+export interface SupportedSiteDefinition {
+  id: string;
+  name: string;
+  aka?: string[];
+  description?: string;
+  schema: string;
+  urls: string[];
+  faviconUrl?: string;
+  authMethod?: string;
+  hrEnabled: boolean;
+  unavailable?: boolean;
+  unavailableReason?: string;
+}
+
 export const sitesApi = {
   list: () => api.get<Record<string, SiteConfig>>("/api/sites"),
   get: (name: string) => api.get<SiteConfig>(`/api/sites/${name}`),
@@ -183,6 +197,7 @@ export const sitesApi = {
   delete: (name: string) => api.delete<void>(`/api/sites?name=${encodeURIComponent(name)}`),
   deleteRss: (name: string, id: number) =>
     api.delete<void>(`/api/sites/${name}?id=${encodeURIComponent(id.toString())}`),
+  listDefinitions: () => api.get<SupportedSiteDefinition[]>("/api/sites/definitions"),
 };
 
 export const tasksApi = {

--- a/web/frontend/src/components/SiteAvatar.vue
+++ b/web/frontend/src/components/SiteAvatar.vue
@@ -7,21 +7,21 @@ const props = withDefaults(
     siteName: string;
     siteId: string;
     size?: number;
+    noFetch?: boolean;
   }>(),
   {
     size: 32,
+    noFetch: false,
   },
 );
 
 const imageError = ref(false);
 
-// 使用后端缓存 API 获取站点图标
-// 后端会自动缓存图标到本地，避免每次都从远程请求
 const faviconUrl = computed(() => {
   if (imageError.value) return null;
   const lower = props.siteId.toLowerCase();
-  // 使用后端 favicon 缓存 API
-  return `/api/favicon/${lower}`;
+  const suffix = props.noFetch ? "?nofetch=1" : "";
+  return `/api/favicon/${lower}${suffix}`;
 });
 
 const avatarColor = computed(() => getAvatarColor(props.siteName));

--- a/web/frontend/src/router/index.ts
+++ b/web/frontend/src/router/index.ts
@@ -46,6 +46,12 @@ const router = createRouter({
       component: () => import("@/views/SiteList.vue"),
     },
     {
+      path: "/supported-sites",
+      name: "supported-sites",
+      component: () => import("@/views/SupportedSites.vue"),
+      meta: { title: "已支持站点" },
+    },
+    {
       path: "/search",
       name: "search",
       component: () => import("@/views/TorrentSearch.vue"),

--- a/web/frontend/src/views/SupportedSites.vue
+++ b/web/frontend/src/views/SupportedSites.vue
@@ -1,0 +1,350 @@
+<script setup lang="ts">
+import { type SupportedSiteDefinition, sitesApi } from "@/api";
+import SiteAvatar from "@/components/SiteAvatar.vue";
+import { ElMessage } from "element-plus";
+import { computed, onMounted, ref } from "vue";
+
+const loading = ref(false);
+const definitions = ref<SupportedSiteDefinition[]>([]);
+const search = ref("");
+const schemaFilter = ref("");
+
+onMounted(async () => {
+  await loadDefinitions();
+});
+
+async function loadDefinitions() {
+  loading.value = true;
+  try {
+    const data = await sitesApi.listDefinitions();
+    definitions.value = (data ?? [])
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name, "zh-Hans-CN"));
+  } catch (e: unknown) {
+    ElMessage.error((e as Error).message || "加载失败");
+  } finally {
+    loading.value = false;
+  }
+}
+
+const schemaOptions = computed(() => {
+  const counts = new Map<string, number>();
+  for (const d of definitions.value) {
+    counts.set(d.schema, (counts.get(d.schema) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([schema, count]) => ({ schema, count }))
+    .sort((a, b) => b.count - a.count);
+});
+
+const filtered = computed(() => {
+  const q = search.value.trim().toLowerCase();
+  return definitions.value.filter((d) => {
+    if (schemaFilter.value && d.schema !== schemaFilter.value) return false;
+    if (!q) return true;
+    if (d.name.toLowerCase().includes(q)) return true;
+    if (d.id.toLowerCase().includes(q)) return true;
+    if (d.description?.toLowerCase().includes(q)) return true;
+    if (d.aka?.some((a) => a.toLowerCase().includes(q))) return true;
+    if (d.urls.some((u) => u.toLowerCase().includes(q))) return true;
+    return false;
+  });
+});
+
+const totalCount = computed(() => definitions.value.length);
+const filteredCount = computed(() => filtered.value.length);
+const unavailableCount = computed(() => definitions.value.filter((d) => d.unavailable).length);
+
+function authMethodLabel(m?: string): string {
+  switch (m) {
+    case "cookie":
+      return "Cookie";
+    case "api_key":
+      return "API Key";
+    case "cookie_and_api_key":
+      return "Cookie + API Key";
+    case "passkey":
+      return "Passkey";
+    default:
+      return m || "-";
+  }
+}
+
+function authMethodTagType(m?: string): "primary" | "success" | "warning" | "info" {
+  switch (m) {
+    case "cookie":
+      return "primary";
+    case "api_key":
+      return "success";
+    case "cookie_and_api_key":
+      return "warning";
+    case "passkey":
+      return "info";
+    default:
+      return "info";
+  }
+}
+
+function clearFilters() {
+  search.value = "";
+  schemaFilter.value = "";
+}
+</script>
+
+<template>
+  <div class="page-container">
+    <div class="page-header">
+      <div>
+        <h1 class="page-title">已支持站点</h1>
+        <p class="page-subtitle">
+          pt-tools 当前已适配
+          <strong>{{ totalCount }}</strong>
+          个站点。点击站点 URL 可前往官方主页注册或登录。
+        </p>
+      </div>
+      <div class="page-actions">
+        <el-button :icon="'Refresh'" :loading="loading" @click="loadDefinitions">刷新</el-button>
+        <el-button type="primary" @click="$router.push('/sites')">前往站点管理</el-button>
+      </div>
+    </div>
+
+    <div class="filter-bar">
+      <el-input
+        v-model="search"
+        placeholder="搜索：名称 / ID / 别名 / 域名"
+        clearable
+        :prefix-icon="'Search'"
+        class="filter-input" />
+      <el-select v-model="schemaFilter" placeholder="按架构筛选" clearable class="filter-select">
+        <el-option
+          v-for="opt in schemaOptions"
+          :key="opt.schema"
+          :label="`${opt.schema} (${opt.count})`"
+          :value="opt.schema" />
+      </el-select>
+      <el-button v-if="search || schemaFilter" :icon="'Close'" @click="clearFilters">
+        清空筛选
+      </el-button>
+      <div class="result-count">
+        显示
+        <strong>{{ filteredCount }}</strong>
+        / {{ totalCount }} 站点
+        <span v-if="unavailableCount > 0" class="unavailable-hint">
+          （其中 {{ unavailableCount }} 个临时不可用）
+        </span>
+      </div>
+    </div>
+
+    <el-skeleton v-if="loading && definitions.length === 0" :rows="6" animated />
+
+    <div v-else class="site-grid">
+      <el-card
+        v-for="def in filtered"
+        :key="def.id"
+        class="site-card"
+        :class="{ 'is-unavailable': def.unavailable }"
+        shadow="hover">
+        <div class="site-card-header">
+          <SiteAvatar :site-id="def.id" :site-name="def.name" :size="40" :no-fetch="true" />
+          <div class="site-name-block">
+            <div class="site-name">
+              {{ def.name }}
+              <el-tag v-if="def.unavailable" type="danger" size="small" class="status-tag">
+                不可用
+              </el-tag>
+            </div>
+            <div v-if="def.aka && def.aka.length > 0" class="site-aka">
+              {{ def.aka.join(" / ") }}
+            </div>
+          </div>
+        </div>
+
+        <div v-if="def.description" class="site-description">
+          {{ def.description }}
+        </div>
+        <div v-if="def.unavailable && def.unavailableReason" class="unavailable-reason">
+          {{ def.unavailableReason }}
+        </div>
+
+        <div class="site-tags">
+          <el-tag size="small" type="primary" effect="plain">{{ def.schema }}</el-tag>
+          <el-tag size="small" :type="authMethodTagType(def.authMethod)" effect="plain">
+            {{ authMethodLabel(def.authMethod) }}
+          </el-tag>
+          <el-tag v-if="def.hrEnabled" size="small" type="warning" effect="plain">H&amp;R</el-tag>
+        </div>
+
+        <div v-if="def.urls.length > 0" class="site-urls">
+          <a
+            v-for="url in def.urls"
+            :key="url"
+            :href="url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="site-url-link">
+            {{ url.replace(/^https?:\/\//, "").replace(/\/$/, "") }}
+          </a>
+        </div>
+      </el-card>
+
+      <el-empty v-if="!loading && filtered.length === 0" description="未找到匹配的站点" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.page-container {
+  padding: 16px 24px 32px;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.page-title {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0 0 4px 0;
+  color: var(--pt-text-primary);
+}
+
+.page-subtitle {
+  margin: 0;
+  color: var(--pt-text-secondary);
+  font-size: 13px;
+}
+
+.page-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.filter-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 20px;
+  padding: 12px 16px;
+  background: var(--pt-bg-elevated, #fafafa);
+  border-radius: 8px;
+}
+
+.filter-input {
+  flex: 1;
+  min-width: 240px;
+  max-width: 360px;
+}
+
+.filter-select {
+  min-width: 200px;
+}
+
+.result-count {
+  margin-left: auto;
+  color: var(--pt-text-secondary);
+  font-size: 13px;
+}
+
+.unavailable-hint {
+  color: var(--el-color-danger);
+}
+
+.site-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.site-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.site-card.is-unavailable {
+  opacity: 0.7;
+}
+
+.site-card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.site-name-block {
+  flex: 1;
+  min-width: 0;
+}
+
+.site-name {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--pt-text-primary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.status-tag {
+  flex-shrink: 0;
+}
+
+.site-aka {
+  font-size: 12px;
+  color: var(--pt-text-secondary);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.site-description {
+  color: var(--pt-text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+  margin-bottom: 12px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.unavailable-reason {
+  font-size: 12px;
+  color: var(--el-color-danger);
+  background: var(--el-color-danger-light-9);
+  padding: 6px 10px;
+  border-radius: 4px;
+  margin-bottom: 12px;
+}
+
+.site-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.site-urls {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.site-url-link {
+  color: var(--el-color-primary);
+  text-decoration: none;
+  word-break: break-all;
+}
+
+.site-url-link:hover {
+  text-decoration: underline;
+}
+</style>

--- a/web/frontend/src/views/UserInfoDashboard.vue
+++ b/web/frontend/src/views/UserInfoDashboard.vue
@@ -290,6 +290,10 @@ onUnmounted(() => {
             <el-icon><Share /></el-icon>
             导出分享
           </el-button>
+          <el-button size="small" @click="$router.push('/supported-sites')">
+            <el-icon><Collection /></el-icon>
+            已支持站点
+          </el-button>
           <el-button type="primary" size="small" :loading="syncing" @click="syncAll">
             <el-icon><Refresh /></el-icon>
             同步全部

--- a/web/server.go
+++ b/web/server.go
@@ -85,6 +85,7 @@ func (s *Server) Serve(addr string) error {
 	// Site management APIs
 	mux.HandleFunc("/api/sites/downloader-summary", s.auth(s.apiSiteDownloaderSummary))
 	mux.HandleFunc("/api/sites/validate", s.auth(s.apiSiteValidate))
+	mux.HandleFunc("/api/sites/definitions", s.auth(s.apiSiteDefinitions))
 	mux.HandleFunc("/api/sites/dynamic", s.auth(s.apiDynamicSites))
 	mux.HandleFunc("/api/sites/templates", s.auth(s.apiSiteTemplates))
 	mux.HandleFunc("/api/sites/templates/import", s.auth(s.apiSiteTemplateImport))


### PR DESCRIPTION
## Summary

修复用户反馈：只配置了 mteam + rousipro 两个站点，日志却显示在刷新所有 40+ 站点的 favicon。

## Bug 根因

`web/api_favicon.go` 的 `refreshExpiredFavicons()` 后台任务（默认每 12 小时跑一次）直接迭代 `v2.GetDefinitionRegistry().GetAll()` —— 即所有 \`init()\` 注册过的站点定义，而 **没有任何启用状态过滤**。

- Loop A 刷新所有过期的 \`FaviconCache\` 行
- Loop B 为每个 \`SiteSetting\` 中**没有**对应 cache 行的站点首次抓取 favicon → 一旦完成，所有定义都拿到 cache 行 → 之后 Loop A 每 12h 全部刷新

完全不查询 \`models.SiteSetting\`，零关联用户实际启用的站点。

## 修复

后端：
- \`refreshExpiredFavicons\` 改为查询 \`SiteSetting WHERE enabled = true\` 得到 enabledIDs，两个 loop 都以此过滤
- 新增 \`loadEnabledSiteIDsLower()\` 辅助函数（避免依赖 \`*Server\` 上下文）
- \`apiFaviconList\` 按启用状态过滤（list endpoint 不应暴露未启用站点的 cache 状态）
- \`apiFavicon\` 单图标 GET 新增 \`?nofetch=1\` query：对未缓存站点直接 404，不触发外部抓取

前端 — 新增"已支持站点"视图：
- \`GET /api/sites/definitions\` 后端暴露完整定义列表（精简 DTO）
- \`views/SupportedSites.vue\` 卡片网格 + 搜索 + Schema 筛选 + 不可用徽章
- \`components/SiteAvatar\` 新增 \`noFetch\` prop，避免 SupportedSites 页面对未启用站点触发抓取
- \`/supported-sites\` 路由 + 侧栏入口 + UserInfoDashboard CTA

## 行为对比

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 配置 2 站点，启动后 12h 内 | 刷新全部 ~40 站点 | 只刷新 2 站点 |
| 启动后首次刷新 | Loop B 为全部站点抓取 favicon | Loop B 仅为已启用 2 站点抓取 |
| 浏览"已支持站点"页面 | (页面不存在) | 41 站点卡片网格，favicon 仅命中已缓存的 |
| favicon 列表 API | 返回所有 ~40 项 | 仅返回已启用站点 |

## Validation

- \`go build ./...\` ✅
- \`go test ./web/\` ✅ 5.7s PASS
- \`go vet ./...\` ✅
- \`golangci-lint run ./web/\` ✅ 0 issues
- \`pnpm vue-tsc --noEmit\` ✅ 0 errors
- \`pnpm oxlint <changed files>\` ✅ 0 warnings 0 errors
- \`pnpm build\` ✅ built in 1.25s

## 兼容性

- 已存在的 \`FaviconCache\` 行不会被删除（保守策略）—— 用户禁用某站点后，cache 行保留但不再刷新
- \`apiFavicon\` 默认行为不变（\`?nofetch\` 是 opt-in）
- 用户启用新站点后，下个 12h tick 才会自动抓取 favicon；如需立即刷新可手动 \`POST /api/favicon/<id>/refresh\`