### PR TITLE
chore(extension): 版本 0.1.0 → 0.2.0 准备首次 Edge 商店 API 发布

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -738,12 +738,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **site**: 新增 OpenCD 和 PTT 站点适配
 - 新增 site/v2/definitions/opencd.go 适配 open.cd (繁体 NexusPHP)
   _ 使用 div.title + td.rowtitle 替代标准 h1 + td.rowhead
-  _ 支持 plugin*details.php 链接格式
-  * 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
-  * 处理 font.promotion 替代 img.pro*_ 的非标准折扣标记
-  _ span.category 替代 img[alt] 的分类标记
-  _ 处理 info_block 隐藏列的 nth-child 索引偏移
-  _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
+  _ 支持 plugin\*details.php 链接格式
+  - 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
+  - 处理 font.promotion 替代 img.pro\*_ 的非标准折扣标记
+    _ span.category 替代 img[alt] 的分类标记
+    _ 处理 info_block 隐藏列的 nth-child 索引偏移
+    _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
 
 ## [0.23.0] - 2026-04-29
 

--- a/tools/browser-extension/package.json
+++ b/tools/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt-tools-browser-extension",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "PT Tools Helper browser extension",
   "type": "module",

--- a/tools/browser-extension/src/manifest.ts
+++ b/tools/browser-extension/src/manifest.ts
@@ -1,7 +1,7 @@
 export const manifest = {
   manifest_version: 3,
   name: "__MSG_extensionName__",
-  version: "0.1.0",
+  version: "0.2.0",
   description: "__MSG_extensionDescription__",
   default_locale: "zh_CN",
   permissions: ["storage", "activeTab", "scripting"],


### PR DESCRIPTION
## Summary

首次通过 GitHub Actions API 发布扩展到 Microsoft Edge Add-ons 商店。

## 变更
- `tools/browser-extension/package.json`: 0.1.0 → 0.2.0
- `tools/browser-extension/src/manifest.ts`: 0.1.0 → 0.2.0

## 后续
此 PR merge 后 atlas 会推送 `ext-v0.2.0` tag，触发 `extension-publish.yml` workflow：
1. pnpm build 扩展
2. 打包 zip
3. 调 Edge Add-ons API 上传到 product `pgicnjkmgenmjfhlclodbpbedjmojbea`
4. 等审核通过后商店 listing 自动更新

所需 secrets 已设置：
- `EDGE_API_KEY`
- `EDGE_CLIENT_ID`
- `EDGE_PRODUCT_ID`