### PR TITLE
fix(chatops): 修复 4 个通知通道 bug + 配置热重载 (v0.31.2)

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sunerpy/pt-tools/internal/chatops"
 	chatopscmds "github.com/sunerpy/pt-tools/internal/chatops/commands"
 	"github.com/sunerpy/pt-tools/internal/crypto"
+	"github.com/sunerpy/pt-tools/internal/events"
 	"github.com/sunerpy/pt-tools/internal/notify"
 	"github.com/sunerpy/pt-tools/models"
 	"github.com/sunerpy/pt-tools/scheduler"
@@ -233,6 +234,8 @@ var webCmd = &cobra.Command{
 			chatopsLogger().Infof("RSS notifier 已就绪")
 			chatopsLogger().Infof("RSS retry worker 已启动")
 			chatopsLogger().Infof("RSS callback actions 已注册 channels=%d", registeredCallbackChannels)
+
+			go runChatOpsChannelReloader(runtimeCtx, global.GlobalDB.DB, bs, callbackActions)
 		}
 
 		srv := web.NewServer(store, mgr)
@@ -750,4 +753,93 @@ func (a *rssNotifierAdapter) NotifyFilteredItem(ctx context.Context, ev internal
 		SiteName:  ev.SiteName,
 		TorrentID: ev.TorrentID,
 	})
+}
+
+// runChatOpsChannelReloader 订阅 events.ConfigChanged{Source:"notification"}，
+// 收到事件后重建 bs.channels：先逐个 Close 旧实例（带超时避免阻塞），
+// 再调用 initEnabledChannels 从 DB 重新加载 enabled=true 的所有通道并 Init，
+// 最后重新注册 RSS callback action handler。事件冒泡式 fan-out 由 events.Publish
+// 保证：单条事件触发一次完整重建。
+func runChatOpsChannelReloader(
+	ctx context.Context,
+	db *gorm.DB,
+	bs *chatopsBootstrap,
+	callbackActions telegramadapter.CallbackActionHandler,
+) {
+	if bs == nil || db == nil {
+		return
+	}
+	id, eventCh, cancel := events.Subscribe(64)
+	defer cancel()
+	log := chatopsLogger()
+	log.Infof("ChatOps 通道热重载订阅已就绪 sub=%s", id)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-eventCh:
+			if !ok {
+				return
+			}
+			if ev.Type != events.ConfigChanged || ev.Source != "notification" {
+				continue
+			}
+			if err := reloadChatOpsChannels(ctx, db, bs, callbackActions); err != nil {
+				log.Warnf("ChatOps 通道热重载失败: %v", err)
+				continue
+			}
+			log.Infof("ChatOps 通道已热重载")
+		}
+	}
+}
+
+// reloadChatOpsChannels 关闭所有旧通道实例并从 DB 重新加载所有 enabled=true 的通道。
+// 采用全量重建策略以匹配 core/config_store.go 的全局 reload 模式：避免逐通道 dirty 状态追踪，
+// 且通道 Init 是轻量操作（TG 仅打开新 HTTPS client，QQ 仅重绑 WS 端口）。
+func reloadChatOpsChannels(
+	ctx context.Context,
+	db *gorm.DB,
+	bs *chatopsBootstrap,
+	callbackActions telegramadapter.CallbackActionHandler,
+) error {
+	log := chatopsLogger()
+
+	for confID, ch := range bs.channels {
+		stepCtx, stepCancel := context.WithTimeout(ctx, chatopsShutdownPerStep)
+		if err := ch.Close(stepCtx); err != nil {
+			log.Warnf("ChatOps 通道关闭失败 conf_id=%d type=%s: %v", confID, ch.Type(), err)
+		} else {
+			log.Infof("ChatOps 通道已下线 conf_id=%d type=%s", confID, ch.Type())
+		}
+		stepCancel()
+	}
+	for confID := range bs.channels {
+		delete(bs.channels, confID)
+	}
+
+	var inbound notify.InboundHandler
+	if bs.chain != nil {
+		inbound = bs.chain.Process
+	}
+	newChannels, err := initEnabledChannels(ctx, db, bs.registry, inbound, log)
+	if err != nil {
+		bs.manager.SetChannels(bs.channels)
+		return err
+	}
+
+	if callbackActions != nil {
+		for _, ch := range newChannels {
+			if setter, ok := ch.(interface {
+				SetCallbackActionHandler(telegramadapter.CallbackActionHandler)
+			}); ok {
+				setter.SetCallbackActionHandler(callbackActions)
+			}
+		}
+	}
+
+	for confID, ch := range newChannels {
+		bs.channels[confID] = ch
+	}
+	bs.manager.SetChannels(bs.channels)
+	return nil
 }

--- a/internal/app/notification_service.go
+++ b/internal/app/notification_service.go
@@ -208,7 +208,42 @@ func (s *notificationService) UpdateConf(ctx context.Context, id uint, req Updat
 		updates["quiet_hours_end"] = *req.QuietHoursEnd
 	}
 	if len(req.ConfigJSON) > 0 {
-		cipherStr, err := crypto.Encrypt([]byte(req.ConfigJSON))
+		// 合并策略：解密 DB 现有配置 → 与 partial 新值 merge（新值覆盖、缺失键保留）→ 重新加密。
+		// 避免前端只发部分字段时把其他原有字段（admin_users / default_chat_id 等）覆盖掉。
+		var existingRow models.NotificationConf
+		if err := s.db.WithContext(ctx).First(&existingRow, id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrConfNotFound
+			}
+			return fmt.Errorf("查询通道失败: %w", err)
+		}
+
+		existingMap := map[string]json.RawMessage{}
+		if existingRow.ConfigJSON != "" {
+			plain, derr := crypto.Decrypt(existingRow.ConfigJSON)
+			if derr != nil {
+				return fmt.Errorf("解密旧配置失败: %w", derr)
+			}
+			if len(plain) > 0 {
+				if perr := json.Unmarshal(plain, &existingMap); perr != nil {
+					return fmt.Errorf("解析旧配置失败: %w", perr)
+				}
+			}
+		}
+
+		var newMap map[string]json.RawMessage
+		if perr := json.Unmarshal([]byte(req.ConfigJSON), &newMap); perr != nil {
+			return fmt.Errorf("解析新配置失败: %w", perr)
+		}
+		for k, v := range newMap {
+			existingMap[k] = v
+		}
+
+		merged, merr := json.Marshal(existingMap)
+		if merr != nil {
+			return fmt.Errorf("合并配置失败: %w", merr)
+		}
+		cipherStr, err := crypto.Encrypt(merged)
 		if err != nil {
 			return fmt.Errorf("加密通道配置失败: %w", err)
 		}

--- a/internal/app/notification_service.go
+++ b/internal/app/notification_service.go
@@ -11,9 +11,21 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/sunerpy/pt-tools/internal/crypto"
+	"github.com/sunerpy/pt-tools/internal/events"
 	"github.com/sunerpy/pt-tools/internal/notify"
 	"github.com/sunerpy/pt-tools/models"
 )
+
+// publishNotificationConfigChanged 通知订阅方（如 cmd/web.go 中的热重载 goroutine）
+// 通道配置发生变化，需重建对应通道实例以加载最新的解密配置（proxy_url、bot_token 等）。
+func publishNotificationConfigChanged() {
+	events.Publish(events.Event{
+		Type:    events.ConfigChanged,
+		Version: time.Now().UnixNano(),
+		Source:  "notification",
+		At:      time.Now(),
+	})
+}
 
 // Notification 是 NotificationService 与 NotifyManager 之间传递的最小消息载荷。
 // TODO(T15): 替换为 internal/notify 包内的 notify.Notification 完整结构。
@@ -175,6 +187,7 @@ func (s *notificationService) CreateConf(ctx context.Context, req CreateConfReq)
 	if err := s.db.WithContext(ctx).Create(&row).Error; err != nil {
 		return NotificationConfDTO{}, fmt.Errorf("创建通知通道失败: %w", err)
 	}
+	publishNotificationConfigChanged()
 	return NotificationConfDTO{
 		ID:              row.ID,
 		ChannelType:     row.ChannelType,
@@ -260,6 +273,7 @@ func (s *notificationService) UpdateConf(ctx context.Context, id uint, req Updat
 	if res.RowsAffected == 0 {
 		return ErrConfNotFound
 	}
+	publishNotificationConfigChanged()
 	return nil
 }
 
@@ -274,6 +288,7 @@ func (s *notificationService) DeleteConf(ctx context.Context, id uint) error {
 	if res.RowsAffected == 0 {
 		return ErrConfNotFound
 	}
+	publishNotificationConfigChanged()
 	return nil
 }
 

--- a/internal/app/notification_service.go
+++ b/internal/app/notification_service.go
@@ -72,6 +72,7 @@ type NotificationService interface {
 	DeleteConf(ctx context.Context, id uint) error
 	TestConf(ctx context.Context, id uint) error
 	Push(ctx context.Context, n Notification) error
+	PushSync(ctx context.Context, n Notification) error
 	Enqueue(ctx context.Context, n Notification, confID uint) error
 }
 
@@ -261,7 +262,7 @@ func (s *notificationService) TestConf(ctx context.Context, id uint) error {
 			targets["message_type"] = "private"
 		}
 	}
-	return s.Push(ctx, Notification{
+	return s.PushSync(ctx, Notification{
 		Title:        "pt-tools 测试通知",
 		Text:         "如果你看到此消息，说明通道配置正常。",
 		SourceConfID: row.ID,
@@ -425,6 +426,28 @@ func (s *notificationService) Push(ctx context.Context, n Notification) error {
 		return s.Enqueue(ctx, n, n.SourceConfID)
 	case <-sendCtx.Done():
 		return s.Enqueue(ctx, n, n.SourceConfID)
+	}
+}
+
+// PushSync 仅尝试同步投递：超时或失败时不会写入 outbox，错误原样返回给调用方。
+// 用于 TestConf 等需要"立即验证通道是否可用"的语义场景；业务通知请使用 Push（含 outbox fallback）。
+func (s *notificationService) PushSync(ctx context.Context, n Notification) error {
+	if s.manager == nil {
+		return errors.New("通知管理器未初始化")
+	}
+	sendCtx, cancel := context.WithTimeout(ctx, s.pushTimeout)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.manager.Send(sendCtx, n.SourceConfID, n)
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-sendCtx.Done():
+		return fmt.Errorf("通道未在 %s 内响应: %w", s.pushTimeout, sendCtx.Err())
 	}
 }
 

--- a/internal/app/notification_service_test.go
+++ b/internal/app/notification_service_test.go
@@ -307,3 +307,92 @@ func TestConf_SyncFailureSurfacesError(t *testing.T) {
 		Where("status = ?", "pending").Count(&pendingCount).Error)
 	assert.Equal(t, int64(0), pendingCount, "TestConf failure must NOT enqueue to outbox")
 }
+
+// TestUpdateConf_PartialMergePreservesExistingFields 验证 UpdateConf 在收到 partial config_json 时，
+// 只覆盖传入的字段、保留其它已有字段，避免 Web 编辑表单只填一项就把其它字段清掉的数据丢失 bug。
+func TestUpdateConf_PartialMergePreservesExistingFields(t *testing.T) {
+	setupTestKey(t)
+	db := setupTestDB(t)
+	svc := NewNotificationService(db, &mockNotifyManager{}, 5*time.Second)
+
+	full := `{"bot_token":"original-token","admin_users":[8576996727],"default_chat_id":8576996727,"proxy_url":""}`
+	dto, err := svc.CreateConf(context.Background(), CreateConfReq{
+		ChannelType: "telegram",
+		Name:        "merge-test",
+		ConfigJSON:  json.RawMessage(full),
+		Enabled:     true,
+	})
+	require.NoError(t, err)
+
+	partial := `{"proxy_url":"http://127.0.0.1:1080"}`
+	require.NoError(t, svc.UpdateConf(context.Background(), dto.ID, UpdateConfReq{
+		ConfigJSON: json.RawMessage(partial),
+	}))
+
+	var stored string
+	require.NoError(t, db.Raw("SELECT config_json FROM notification_conf WHERE id = ?", dto.ID).
+		Scan(&stored).Error)
+	plain, err := crypto.Decrypt(stored)
+	require.NoError(t, err, "should decrypt merged config_json")
+
+	var merged map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(plain, &merged), "merged config_json should parse")
+
+	assert.Contains(t, merged, "bot_token", "bot_token must be preserved after partial update")
+	assert.Contains(t, merged, "admin_users", "admin_users must be preserved after partial update")
+	assert.Contains(t, merged, "default_chat_id", "default_chat_id must be preserved after partial update")
+	assert.Contains(t, merged, "proxy_url", "proxy_url should be present (newly written)")
+
+	var botToken string
+	require.NoError(t, json.Unmarshal(merged["bot_token"], &botToken))
+	assert.Equal(t, "original-token", botToken, "bot_token value must be unchanged")
+
+	var proxyURL string
+	require.NoError(t, json.Unmarshal(merged["proxy_url"], &proxyURL))
+	assert.Equal(t, "http://127.0.0.1:1080", proxyURL, "proxy_url should be the new value")
+
+	var adminUsers []int64
+	require.NoError(t, json.Unmarshal(merged["admin_users"], &adminUsers))
+	assert.Equal(t, []int64{8576996727}, adminUsers, "admin_users content must be unchanged")
+
+	var defaultChatID int64
+	require.NoError(t, json.Unmarshal(merged["default_chat_id"], &defaultChatID))
+	assert.Equal(t, int64(8576996727), defaultChatID, "default_chat_id must be unchanged")
+}
+
+// TestUpdateConf_PartialMergeOverwritesExistingValue 验证 partial update 中若包含已有 key，
+// 该 key 会被新值覆盖（merge 语义为「新值优先」）。
+func TestUpdateConf_PartialMergeOverwritesExistingValue(t *testing.T) {
+	setupTestKey(t)
+	db := setupTestDB(t)
+	svc := NewNotificationService(db, &mockNotifyManager{}, 5*time.Second)
+
+	dto, err := svc.CreateConf(context.Background(), CreateConfReq{
+		ChannelType: "telegram",
+		Name:        "merge-overwrite",
+		ConfigJSON:  json.RawMessage(`{"bot_token":"old","default_chat_id":111}`),
+		Enabled:     true,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, svc.UpdateConf(context.Background(), dto.ID, UpdateConfReq{
+		ConfigJSON: json.RawMessage(`{"bot_token":"new"}`),
+	}))
+
+	var stored string
+	require.NoError(t, db.Raw("SELECT config_json FROM notification_conf WHERE id = ?", dto.ID).
+		Scan(&stored).Error)
+	plain, err := crypto.Decrypt(stored)
+	require.NoError(t, err)
+
+	var merged map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(plain, &merged))
+
+	var botToken string
+	require.NoError(t, json.Unmarshal(merged["bot_token"], &botToken))
+	assert.Equal(t, "new", botToken, "bot_token must be overwritten with new value")
+
+	var defaultChatID int64
+	require.NoError(t, json.Unmarshal(merged["default_chat_id"], &defaultChatID))
+	assert.Equal(t, int64(111), defaultChatID, "default_chat_id must be preserved")
+}

--- a/internal/app/notification_service_test.go
+++ b/internal/app/notification_service_test.go
@@ -15,6 +15,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/sunerpy/pt-tools/internal/crypto"
+	"github.com/sunerpy/pt-tools/internal/events"
 	"github.com/sunerpy/pt-tools/models"
 )
 
@@ -395,4 +396,107 @@ func TestUpdateConf_PartialMergeOverwritesExistingValue(t *testing.T) {
 	var defaultChatID int64
 	require.NoError(t, json.Unmarshal(merged["default_chat_id"], &defaultChatID))
 	assert.Equal(t, int64(111), defaultChatID, "default_chat_id must be preserved")
+}
+
+func waitForNotificationEvent(t *testing.T, ch <-chan events.Event, timeout time.Duration) events.Event {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case ev := <-ch:
+			if ev.Type == events.ConfigChanged && ev.Source == "notification" {
+				return ev
+			}
+		case <-deadline:
+			t.Fatalf("等待 ConfigChanged{Source:notification} 事件超时")
+			return events.Event{}
+		}
+	}
+}
+
+func TestCreateConf_PublishesConfigChanged(t *testing.T) {
+	setupTestKey(t)
+	db := setupTestDB(t)
+	svc := NewNotificationService(db, &mockNotifyManager{}, 5*time.Second)
+
+	_, eventCh, cancel := events.Subscribe(8)
+	defer cancel()
+
+	_, err := svc.CreateConf(context.Background(), CreateConfReq{
+		ChannelType: "telegram",
+		Name:        "tg-publish-create",
+		ConfigJSON:  json.RawMessage(`{"bot_token":"x"}`),
+		Enabled:     true,
+	})
+	require.NoError(t, err)
+
+	ev := waitForNotificationEvent(t, eventCh, 200*time.Millisecond)
+	assert.Equal(t, events.ConfigChanged, ev.Type)
+	assert.Equal(t, "notification", ev.Source)
+	assert.NotZero(t, ev.Version)
+}
+
+func TestUpdateConf_PublishesConfigChanged(t *testing.T) {
+	setupTestKey(t)
+	db := setupTestDB(t)
+	svc := NewNotificationService(db, &mockNotifyManager{}, 5*time.Second)
+
+	cipher, err := crypto.Encrypt([]byte(`{"bot_token":"old"}`))
+	require.NoError(t, err)
+	row := models.NotificationConf{ChannelType: "telegram", Name: "tg", ConfigJSON: cipher, Enabled: true}
+	require.NoError(t, db.Create(&row).Error)
+
+	_, eventCh, cancelSub := events.Subscribe(8)
+	defer cancelSub()
+
+	newJSON := json.RawMessage(`{"proxy_url":"http://127.0.0.1:1080"}`)
+	require.NoError(t, svc.UpdateConf(context.Background(), row.ID, UpdateConfReq{ConfigJSON: newJSON}))
+
+	ev := waitForNotificationEvent(t, eventCh, 200*time.Millisecond)
+	assert.Equal(t, events.ConfigChanged, ev.Type)
+	assert.Equal(t, "notification", ev.Source)
+}
+
+func TestDeleteConf_PublishesConfigChanged(t *testing.T) {
+	setupTestKey(t)
+	db := setupTestDB(t)
+	svc := NewNotificationService(db, &mockNotifyManager{}, 5*time.Second)
+
+	cipher, err := crypto.Encrypt([]byte(`{"bot_token":"old"}`))
+	require.NoError(t, err)
+	row := models.NotificationConf{ChannelType: "telegram", Name: "tg", ConfigJSON: cipher, Enabled: true}
+	require.NoError(t, db.Create(&row).Error)
+
+	_, eventCh, cancelSub := events.Subscribe(8)
+	defer cancelSub()
+
+	require.NoError(t, svc.DeleteConf(context.Background(), row.ID))
+
+	ev := waitForNotificationEvent(t, eventCh, 200*time.Millisecond)
+	assert.Equal(t, events.ConfigChanged, ev.Type)
+	assert.Equal(t, "notification", ev.Source)
+}
+
+func TestUpdateConf_NoChanges_DoesNotPublish(t *testing.T) {
+	setupTestKey(t)
+	db := setupTestDB(t)
+	svc := NewNotificationService(db, &mockNotifyManager{}, 5*time.Second)
+
+	cipher, err := crypto.Encrypt([]byte(`{"bot_token":"old"}`))
+	require.NoError(t, err)
+	row := models.NotificationConf{ChannelType: "telegram", Name: "tg", ConfigJSON: cipher, Enabled: true}
+	require.NoError(t, db.Create(&row).Error)
+
+	_, eventCh, cancelSub := events.Subscribe(8)
+	defer cancelSub()
+
+	require.NoError(t, svc.UpdateConf(context.Background(), row.ID, UpdateConfReq{}))
+
+	select {
+	case ev := <-eventCh:
+		if ev.Type == events.ConfigChanged && ev.Source == "notification" {
+			t.Fatalf("空 UpdateConf 不应 publish 事件: %+v", ev)
+		}
+	case <-time.After(80 * time.Millisecond):
+	}
 }

--- a/internal/app/notification_service_test.go
+++ b/internal/app/notification_service_test.go
@@ -226,3 +226,84 @@ func TestPush_ManagerError_FallbackOutbox(t *testing.T) {
 		Where("status = ?", "pending").Count(&pendingCount).Error)
 	assert.Equal(t, int64(1), pendingCount, "outbox should have 1 pending row")
 }
+
+// TestPushSync_ManagerError_NoOutbox 验证 PushSync 在 manager.Send 出错时直接返回错误，
+// 不会 fallback 到 outbox。
+func TestPushSync_ManagerError_NoOutbox(t *testing.T) {
+	setupTestKey(t)
+	db := setupTestDB(t)
+
+	mock := &mockNotifyManager{delay: 0, returnErr: errors.New("boom")}
+	svc := NewNotificationService(db, mock, 5*time.Second)
+
+	dto, err := svc.CreateConf(context.Background(), CreateConfReq{
+		ChannelType: "telegram",
+		Name:        "test",
+		ConfigJSON:  json.RawMessage(`{"bot_token":"xxx"}`),
+		Enabled:     true,
+	})
+	require.NoError(t, err)
+
+	n := Notification{Title: "hi", Text: "hello", SourceConfID: dto.ID}
+	err = svc.PushSync(context.Background(), n)
+	require.Error(t, err, "PushSync should propagate manager error")
+	assert.Contains(t, err.Error(), "boom", "error should contain underlying reason")
+
+	var pendingCount int64
+	require.NoError(t, db.Model(&models.NotificationOutbox{}).
+		Where("status = ?", "pending").Count(&pendingCount).Error)
+	assert.Equal(t, int64(0), pendingCount, "PushSync must NOT write to outbox on failure")
+}
+
+// TestPushSync_Timeout_NoOutbox 验证 PushSync 在 send 超时后直接报错，不写 outbox。
+func TestPushSync_Timeout_NoOutbox(t *testing.T) {
+	setupTestKey(t)
+	db := setupTestDB(t)
+
+	mock := &mockNotifyManager{delay: 200 * time.Millisecond, returnErr: nil}
+	svc := NewNotificationService(db, mock, 50*time.Millisecond)
+
+	dto, err := svc.CreateConf(context.Background(), CreateConfReq{
+		ChannelType: "telegram",
+		Name:        "test",
+		ConfigJSON:  json.RawMessage(`{"bot_token":"xxx"}`),
+		Enabled:     true,
+	})
+	require.NoError(t, err)
+
+	n := Notification{Title: "hi", Text: "hello", SourceConfID: dto.ID}
+	err = svc.PushSync(context.Background(), n)
+	require.Error(t, err, "PushSync should error on timeout")
+
+	var pendingCount int64
+	require.NoError(t, db.Model(&models.NotificationOutbox{}).
+		Where("status = ?", "pending").Count(&pendingCount).Error)
+	assert.Equal(t, int64(0), pendingCount, "PushSync must NOT write to outbox on timeout")
+}
+
+// TestConf_SyncFailureSurfacesError 验证 TestConf 改用 PushSync 后，
+// 底层 manager.Send 失败会作为错误返回，且不会静默写入 outbox。
+func TestConf_SyncFailureSurfacesError(t *testing.T) {
+	setupTestKey(t)
+	db := setupTestDB(t)
+
+	mock := &mockNotifyManager{delay: 0, returnErr: errors.New("boom")}
+	svc := NewNotificationService(db, mock, 5*time.Second)
+
+	dto, err := svc.CreateConf(context.Background(), CreateConfReq{
+		ChannelType: "telegram",
+		Name:        "test-tg",
+		ConfigJSON:  json.RawMessage(`{"bot_token":"xxx","default_chat_id":"123456"}`),
+		Enabled:     true,
+	})
+	require.NoError(t, err)
+
+	err = svc.TestConf(context.Background(), dto.ID)
+	require.Error(t, err, "TestConf must surface underlying send error")
+	assert.Contains(t, err.Error(), "boom", "error must contain underlying reason")
+
+	var pendingCount int64
+	require.NoError(t, db.Model(&models.NotificationOutbox{}).
+		Where("status = ?", "pending").Count(&pendingCount).Error)
+	assert.Equal(t, int64(0), pendingCount, "TestConf failure must NOT enqueue to outbox")
+}

--- a/internal/app/rss_retry_worker_test.go
+++ b/internal/app/rss_retry_worker_test.go
@@ -71,19 +71,20 @@ func TestRSSRetryWorker_PendingPastRetry_PushSucceeds(t *testing.T) {
 
 func TestRSSRetryWorker_PushFails_BackoffScheduled(t *testing.T) {
 	db := setupRetryWorkerDB(t)
-	past := time.Now().Add(-1 * time.Minute)
+	mockNow := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	past := mockNow.Add(-1 * time.Minute)
 	row := models.RSSNotificationLog{
 		RSSID: 1, SiteName: "s", TorrentID: "t2", NotifyKind: "all",
 		NotificationConfID: 1, Result: "pending", Attempts: 0,
 		NextRetryAt: &past,
 		PayloadJSON: mustJSON(t, renderedNotice{Title: "T", Text: "Body"}),
-		CreatedAt:   time.Now(), UpdatedAt: time.Now(),
+		CreatedAt:   mockNow.Add(-2 * time.Minute), UpdatedAt: mockNow.Add(-2 * time.Minute),
 	}
 	require.NoError(t, db.Create(&row).Error)
 
 	svc := &fakePushSvc{err: errors.New("boom")}
 	w := NewRSSRetryWorker(db, svc)
-	w.now = func() time.Time { return time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC) }
+	w.now = func() time.Time { return mockNow }
 	require.NoError(t, w.drainOnce(context.Background()))
 
 	var got models.RSSNotificationLog

--- a/internal/notify/adapter/telegram/adapter.go
+++ b/internal/notify/adapter/telegram/adapter.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/mymmrac/telego"
@@ -22,14 +24,108 @@ import (
 const ChannelType = "telegram"
 
 // Config is the JSON shape stored (encrypted) in NotificationConf.ConfigJSON.
+//
+// AllowedUsers / AdminUsers / DefaultChatID are stored as json.RawMessage so
+// that the adapter tolerates both numeric and string-quoted values that users
+// commonly type into the Web UI form (e.g. `"8576996727"` or `"@channel"`).
+// Use the helper methods (DefaultChatIDInt, DefaultChatIDUsername,
+// AdminUsersList, AllowedUsersList) to access typed values.
 type Config struct {
-	BotToken              string  `json:"bot_token"`
-	AllowedUsers          []int64 `json:"allowed_users"`
-	AdminUsers            []int64 `json:"admin_users"`
-	DefaultChatID         int64   `json:"default_chat_id"`
-	PollingTimeoutSeconds int     `json:"polling_timeout_seconds"`
-	APIServer             string  `json:"api_server,omitempty"`
-	ProxyURL              string  `json:"proxy_url,omitempty"`
+	BotToken              string          `json:"bot_token"`
+	AllowedUsers          json.RawMessage `json:"allowed_users,omitempty"`
+	AdminUsers            json.RawMessage `json:"admin_users,omitempty"`
+	DefaultChatID         json.RawMessage `json:"default_chat_id,omitempty"`
+	PollingTimeoutSeconds int             `json:"polling_timeout_seconds"`
+	APIServer             string          `json:"api_server,omitempty"`
+	ProxyURL              string          `json:"proxy_url,omitempty"`
+}
+
+// DefaultChatIDInt returns the integer form of default_chat_id. Accepts both
+// raw JSON integers and string-quoted integers ("123456"). Returns (0, false)
+// when the value is absent or is a non-numeric string (e.g. "@channelusername"),
+// in which case the caller should fall back to DefaultChatIDUsername.
+func (c *Config) DefaultChatIDInt() (int64, bool) {
+	if len(c.DefaultChatID) == 0 {
+		return 0, false
+	}
+	var n int64
+	if err := json.Unmarshal(c.DefaultChatID, &n); err == nil {
+		return n, true
+	}
+	var s string
+	if err := json.Unmarshal(c.DefaultChatID, &s); err == nil {
+		s = strings.TrimSpace(s)
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return n, true
+		}
+	}
+	return 0, false
+}
+
+// DefaultChatIDUsername returns the @channelusername form. Only returns a
+// non-empty string when the stored value is a string that does NOT parse as
+// an integer (so DefaultChatIDInt and DefaultChatIDUsername never both
+// return a usable value for the same config).
+func (c *Config) DefaultChatIDUsername() (string, bool) {
+	if len(c.DefaultChatID) == 0 {
+		return "", false
+	}
+	var s string
+	if err := json.Unmarshal(c.DefaultChatID, &s); err != nil {
+		return "", false
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", false
+	}
+	if _, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return "", false
+	}
+	if !strings.HasPrefix(s, "@") {
+		s = "@" + s
+	}
+	return s, true
+}
+
+// AdminUsersList returns admin_users as []int64. Tolerates both raw integer
+// and string-quoted integers in the JSON array; bad entries are silently
+// skipped to avoid taking down the whole channel for one typo.
+func (c *Config) AdminUsersList() []int64 {
+	return parseUserIDList(c.AdminUsers)
+}
+
+// AllowedUsersList returns allowed_users as []int64 with the same tolerance
+// as AdminUsersList.
+func (c *Config) AllowedUsersList() []int64 {
+	return parseUserIDList(c.AllowedUsers)
+}
+
+// parseUserIDList tolerates [123, "456", "bad"] mixed input. Returns nil on
+// invalid JSON or empty input. Bad entries (non-integer strings) are skipped
+// without error so a single bad row doesn't disable the channel.
+func parseUserIDList(raw json.RawMessage) []int64 {
+	if len(raw) == 0 {
+		return nil
+	}
+	var rawList []json.RawMessage
+	if err := json.Unmarshal(raw, &rawList); err != nil {
+		return nil
+	}
+	out := make([]int64, 0, len(rawList))
+	for _, item := range rawList {
+		var n int64
+		if err := json.Unmarshal(item, &n); err == nil {
+			out = append(out, n)
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(item, &s); err == nil && s != "" {
+			if n, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64); err == nil {
+				out = append(out, n)
+			}
+		}
+	}
+	return out
 }
 
 // botAPI is the minimal telego.Bot surface used by the adapter, kept narrow

--- a/internal/notify/adapter/telegram/config_test.go
+++ b/internal/notify/adapter/telegram/config_test.go
@@ -1,0 +1,182 @@
+package telegram
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mymmrac/telego"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sunerpy/pt-tools/internal/notify"
+)
+
+func mustConfigFromJSON(t *testing.T, raw string) *Config {
+	t.Helper()
+	cfg := &Config{}
+	require.NoError(t, json.Unmarshal([]byte(raw), cfg))
+	return cfg
+}
+
+func TestConfig_DefaultChatID_AcceptsInt(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{"default_chat_id": 8576996727}`)
+
+	id, ok := cfg.DefaultChatIDInt()
+	require.True(t, ok)
+	assert.Equal(t, int64(8576996727), id)
+
+	name, ok := cfg.DefaultChatIDUsername()
+	assert.False(t, ok)
+	assert.Equal(t, "", name)
+}
+
+func TestConfig_DefaultChatID_AcceptsQuotedInt(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{"default_chat_id": "8576996727"}`)
+
+	id, ok := cfg.DefaultChatIDInt()
+	require.True(t, ok, "string-quoted integer must parse as int")
+	assert.Equal(t, int64(8576996727), id)
+
+	name, ok := cfg.DefaultChatIDUsername()
+	assert.False(t, ok, "quoted-int must NOT also resolve as username")
+	assert.Equal(t, "", name)
+}
+
+func TestConfig_DefaultChatID_AcceptsUsername(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{"default_chat_id": "@MyChannel"}`)
+
+	id, ok := cfg.DefaultChatIDInt()
+	assert.False(t, ok)
+	assert.Zero(t, id)
+
+	name, ok := cfg.DefaultChatIDUsername()
+	require.True(t, ok)
+	assert.Equal(t, "@MyChannel", name)
+}
+
+func TestConfig_DefaultChatID_BareNameGetsAtPrefix(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{"default_chat_id": "MyChannel"}`)
+
+	name, ok := cfg.DefaultChatIDUsername()
+	require.True(t, ok)
+	assert.Equal(t, "@MyChannel", name)
+}
+
+func TestConfig_DefaultChatID_Empty(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{}`)
+
+	_, okInt := cfg.DefaultChatIDInt()
+	_, okName := cfg.DefaultChatIDUsername()
+	assert.False(t, okInt)
+	assert.False(t, okName)
+}
+
+func TestConfig_AllowedUsers_PureInts(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{"allowed_users": [123, 456]}`)
+	assert.Equal(t, []int64{123, 456}, cfg.AllowedUsersList())
+}
+
+func TestConfig_AllowedUsers_MixedTypes(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{"allowed_users": [123, "456", "bad", 789]}`)
+	assert.Equal(t, []int64{123, 456, 789}, cfg.AllowedUsersList(),
+		"bad string entries must be skipped, valid ones (int + quoted int) preserved")
+}
+
+func TestConfig_AllowedUsers_Empty(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{}`)
+	assert.Nil(t, cfg.AllowedUsersList())
+}
+
+func TestConfig_AdminUsers_QuotedInts(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{"admin_users": ["111", "222"]}`)
+	assert.Equal(t, []int64{111, 222}, cfg.AdminUsersList())
+}
+
+func TestConfig_LegacyStrictDecodeNoLongerFails(t *testing.T) {
+	raw := `{"bot_token":"abc","default_chat_id":"@channel","admin_users":["111"]}`
+	cfg := &Config{}
+	require.NoError(t, json.Unmarshal([]byte(raw), cfg),
+		"json.Unmarshal must NOT fail on the user's broken-state config "+
+			"(default_chat_id is string, admin_users contains quoted ints)")
+	assert.Equal(t, "abc", cfg.BotToken)
+	name, ok := cfg.DefaultChatIDUsername()
+	require.True(t, ok)
+	assert.Equal(t, "@channel", name)
+	assert.Equal(t, []int64{111}, cfg.AdminUsersList())
+}
+
+func TestResolveChatID_NumericTargets(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{}`)
+	n := notify.Notification{Targets: map[string]string{"chat_id": "12345"}}
+
+	id, err := resolveChatID(n, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, telego.ChatID{ID: 12345}, id)
+}
+
+func TestResolveChatID_UsernameTargets(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{}`)
+	n := notify.Notification{Targets: map[string]string{"chat_id": "@MyChannel"}}
+
+	id, err := resolveChatID(n, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, telego.ChatID{Username: "@MyChannel"}, id)
+	assert.Zero(t, id.ID)
+}
+
+func TestResolveChatID_BareUsernameTargets(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{}`)
+	n := notify.Notification{Targets: map[string]string{"chat_id": "MyChannel"}}
+
+	id, err := resolveChatID(n, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, telego.ChatID{Username: "@MyChannel"}, id)
+}
+
+func TestResolveChatID_DefaultChatID_Int(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{"default_chat_id": 555}`)
+	id, err := resolveChatID(notify.Notification{}, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, telego.ChatID{ID: 555}, id)
+}
+
+func TestResolveChatID_DefaultChatID_QuotedInt(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{"default_chat_id": "555"}`)
+	id, err := resolveChatID(notify.Notification{}, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, telego.ChatID{ID: 555}, id)
+}
+
+func TestResolveChatID_DefaultChatID_AsUsername(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{"default_chat_id": "@channel"}`)
+	id, err := resolveChatID(notify.Notification{}, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, telego.ChatID{Username: "@channel"}, id)
+	assert.Zero(t, id.ID)
+}
+
+func TestResolveChatID_NoConfig(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{}`)
+	_, err := resolveChatID(notify.Notification{}, cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "default_chat_id")
+}
+
+func TestResolveChatID_UserIDFallback(t *testing.T) {
+	cfg := mustConfigFromJSON(t, `{}`)
+	n := notify.Notification{UserID: "999"}
+	id, err := resolveChatID(n, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, telego.ChatID{ID: 999}, id)
+}
+
+func TestParseChatIDString_Empty(t *testing.T) {
+	_, err := parseChatIDString("")
+	require.Error(t, err)
+}
+
+func TestParseChatIDString_TrimsWhitespace(t *testing.T) {
+	id, err := parseChatIDString("  555  ")
+	require.NoError(t, err)
+	assert.Equal(t, telego.ChatID{ID: 555}, id)
+}

--- a/internal/notify/adapter/telegram/inbound.go
+++ b/internal/notify/adapter/telegram/inbound.go
@@ -102,20 +102,24 @@ func (c *TelegramChannel) handleUpdate(ctx context.Context, upd telego.Update) {
 }
 
 func permitted(userID int64, cfg *Config, isCommand bool) bool {
+	admins := cfg.AdminUsersList()
+	allowed := cfg.AllowedUsersList()
 	if isCommand {
-		if !contains(cfg.AdminUsers, userID) {
+		if !contains(admins, userID) {
 			return false
 		}
 	}
-	if !contains(cfg.AllowedUsers, userID) && !contains(cfg.AdminUsers, userID) {
+	if !contains(allowed, userID) && !contains(admins, userID) {
 		return false
 	}
 	return true
 }
 
 func denyReason(userID int64, cfg *Config, isCommand bool) string {
-	if isCommand && !contains(cfg.AdminUsers, userID) {
-		if contains(cfg.AllowedUsers, userID) {
+	admins := cfg.AdminUsersList()
+	allowed := cfg.AllowedUsersList()
+	if isCommand && !contains(admins, userID) {
+		if contains(allowed, userID) {
 			return "denied:not_admin"
 		}
 		return "denied:not_in_whitelist"
@@ -173,7 +177,7 @@ func (c *TelegramChannel) handleCallbackQuery(ctx context.Context, cq *telego.Ca
 	}
 
 	userID := cq.From.ID
-	if !contains(cfg.AllowedUsers, userID) && !contains(cfg.AdminUsers, userID) {
+	if !contains(cfg.AllowedUsersList(), userID) && !contains(cfg.AdminUsersList(), userID) {
 		_ = bot.AnswerCallbackQuery(ctx, &telego.AnswerCallbackQueryParams{
 			CallbackQueryID: cq.ID,
 			Text:            denyMessage,

--- a/internal/notify/adapter/telegram/outbound.go
+++ b/internal/notify/adapter/telegram/outbound.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/mymmrac/telego"
 
@@ -39,7 +40,7 @@ func (c *TelegramChannel) Send(ctx context.Context, n notify.Notification) error
 	}
 
 	params := &telego.SendMessageParams{
-		ChatID: telego.ChatID{ID: chatID},
+		ChatID: chatID,
 		Text:   composeText(n, parseMode),
 	}
 	if parseMode != "" {
@@ -92,26 +93,46 @@ func buildInlineKeyboard(rows [][]notify.Button) *telego.InlineKeyboardMarkup {
 	return &telego.InlineKeyboardMarkup{InlineKeyboard: out}
 }
 
-func resolveChatID(n notify.Notification, cfg *Config) (int64, error) {
+// resolveChatID returns the telego.ChatID built from notification targets and
+// channel config. Order of precedence:
+//  1. n.Targets["chat_id"] — accepts numeric string or @username
+//  2. n.UserID — numeric string only
+//  3. cfg.DefaultChatIDInt() — int (or string-quoted int) from raw JSON
+//  4. cfg.DefaultChatIDUsername() — @channelusername fallback
+func resolveChatID(n notify.Notification, cfg *Config) (telego.ChatID, error) {
 	if n.Targets != nil {
 		if raw, ok := n.Targets[targetChatIDKey]; ok && raw != "" {
-			id, err := strconv.ParseInt(raw, 10, 64)
-			if err != nil {
-				return 0, fmt.Errorf("telegram: 无效 targets.chat_id %q: %w", raw, err)
-			}
-			return id, nil
+			return parseChatIDString(raw)
 		}
 	}
 	if n.UserID != "" {
-		id, err := strconv.ParseInt(n.UserID, 10, 64)
-		if err == nil {
-			return id, nil
+		if id, err := strconv.ParseInt(n.UserID, 10, 64); err == nil {
+			return telego.ChatID{ID: id}, nil
 		}
 	}
-	if cfg.DefaultChatID != 0 {
-		return cfg.DefaultChatID, nil
+	if id, ok := cfg.DefaultChatIDInt(); ok && id != 0 {
+		return telego.ChatID{ID: id}, nil
 	}
-	return 0, errors.New("telegram: 未指定 chat_id 且 default_chat_id 为空")
+	if name, ok := cfg.DefaultChatIDUsername(); ok && name != "" {
+		return telego.ChatID{Username: name}, nil
+	}
+	return telego.ChatID{}, errors.New("telegram: 未指定 chat_id 且 default_chat_id 为空")
+}
+
+// parseChatIDString turns a string into telego.ChatID. Numeric → ID,
+// @-prefixed or non-numeric → Username (with @ prepended if missing).
+func parseChatIDString(s string) (telego.ChatID, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return telego.ChatID{}, errors.New("telegram: chat_id 为空")
+	}
+	if id, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return telego.ChatID{ID: id}, nil
+	}
+	if !strings.HasPrefix(s, "@") {
+		s = "@" + s
+	}
+	return telego.ChatID{Username: s}, nil
 }
 
 func composeText(n notify.Notification, parseMode string) string {

--- a/web/api_chatops.go
+++ b/web/api_chatops.go
@@ -181,7 +181,13 @@ func (h *chatopsHandlers) testNotification(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if err := h.deps.NotificationSvc.TestConf(r.Context(), id); err != nil {
-		mapServiceErr(w, err)
+		if errors.Is(err, app.ErrConfNotFound) || errors.Is(err, gorm.ErrRecordNotFound) {
+			writeChatopsErr(w, http.StatusNotFound, "not_found", err.Error())
+			return
+		}
+		detail := "通道发送失败：" + err.Error() +
+			"。请检查网络是否通畅、proxy_url 配置是否正确（Telegram 用户）、或 NapCat 反向 WS 连接是否在线（QQ 用户）"
+		writeChatopsErr(w, http.StatusBadGateway, "send_failed", detail)
 		return
 	}
 	writeJSON(w, map[string]any{"success": true, "status": "sent"})

--- a/web/api_chatops_test.go
+++ b/web/api_chatops_test.go
@@ -84,6 +84,10 @@ func (s *stubNotificationSvc) TestConf(ctx context.Context, id uint) error {
 }
 
 func (s *stubNotificationSvc) Push(ctx context.Context, n app.Notification) error { return nil }
+func (s *stubNotificationSvc) PushSync(ctx context.Context, n app.Notification) error {
+	return nil
+}
+
 func (s *stubNotificationSvc) Enqueue(ctx context.Context, n app.Notification, confID uint) error {
 	return nil
 }

--- a/web/frontend/src/views/chatops/NotificationDetail.vue
+++ b/web/frontend/src/views/chatops/NotificationDetail.vue
@@ -207,23 +207,39 @@ async function handleTest() {
   testResult.value = null;
   try {
     const res = await chatopsApi.notifications.test(conf.id);
+    const ok = !!res?.success;
     testResult.value = {
-      success: !!res?.success,
-      message: res?.success ? "测试消息发送成功" : "测试消息可能未送达，请检查日志",
+      success: ok,
+      message: ok ? "测试消息发送成功，请在目标账号查收。" : "测试消息可能未送达，请检查日志",
       at: new Date().toLocaleString(),
     };
-    if (res?.success) {
-      ElMessage.success("测试消息已发送");
+    if (ok) {
+      ElMessage.success("测试消息发送成功");
     } else {
       ElMessage.warning("已触发测试，但返回结果异常");
     }
   } catch (e: unknown) {
+    const raw = (e as Error).message || "测试失败";
+    let reason = raw;
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") {
+        reason = parsed.detail || parsed.error || raw;
+      }
+    } catch {
+      // raw 不是 JSON，原样使用
+    }
     testResult.value = {
       success: false,
-      message: (e as Error).message || "测试失败",
+      message: reason,
       at: new Date().toLocaleString(),
     };
-    ElMessage.error((e as Error).message || "测试失败");
+    ElMessage({
+      type: "error",
+      message: `测试消息发送失败：${reason}`,
+      duration: 8000,
+      showClose: true,
+    });
   } finally {
     testing.value = false;
   }

--- a/web/frontend/src/views/chatops/NotificationDetail.vue
+++ b/web/frontend/src/views/chatops/NotificationDetail.vue
@@ -89,12 +89,18 @@ async function loadDetail() {
   try {
     const data = await chatopsApi.notifications.get(id.value);
     Object.assign(conf, data);
+    // 后端返回的 config_json 是解密后的对象（如 { bot_token, admin_users, default_chat_id, ... }），
+    // 必须 flatten 到 conf 上，否则编辑表单的 v-model 输入框是空的，提交时会把已有字段覆盖丢失。
+    const cfg = (data as unknown as Record<string, unknown>).config_json;
+    if (cfg && typeof cfg === "object") {
+      Object.assign(conf, cfg as Record<string, unknown>);
+    }
     if (conf.channel_type === "qq_onebot") {
       conf.admin_qq_users = qqListToText(
-        (data as unknown as Record<string, unknown>).admin_qq_users,
+        (conf as unknown as Record<string, unknown>).admin_qq_users,
       );
       conf.allowed_qq_users = qqListToText(
-        (data as unknown as Record<string, unknown>).allowed_qq_users,
+        (conf as unknown as Record<string, unknown>).allowed_qq_users,
       );
     }
   } catch (e: unknown) {


### PR DESCRIPTION
## Summary

v0.31.2 patch release：通知通道相关 4 个真 bug 修复，提升通道配置 UX 与可靠性。

## 🐛 Fixes

- **测试消息误报成功**（commit `bccd79b`）：之前 TestConf → Push → manager.Send 超时/失败时 fallback 到 outbox 异步队列，handler 返 nil → 前端 toast "成功" 但用户没收到消息。新增 PushSync 仅同步发，错误原样返回。
- **编辑通道时丢字段**（commit `100a891`）：UpdateConf 整体覆盖 config_json，用户在 Web UI 只填 `proxy_url` 保存就清掉 `admin_users` / `default_chat_id` 等其他字段。改为 decrypt → merge → encrypt 语义。
- **Telegram conf 中 string/int 混合输入挂掉整个通道**（commit `6adefb4`）：用户填 `default_chat_id` 为字符串（`@channelusername` 或加引号数字）时，strict int64 unmarshal 失败 → 整个 telegram channel init 报 ERROR，所有通知都发不出。改 `Config` 字段为 `json.RawMessage` + 4 个容错 helper（DefaultChatIDInt / DefaultChatIDUsername / AdminUsersList / AllowedUsersList）。

## ✨ Features

- **配置变更后自动热重载**（commit `70a90dc`）：之前改 `proxy_url` / `bot_token` 等必须手动重启服务才生效。NotificationService 在 Create/Update/DeleteConf 后 publish `events.ConfigChanged{Source:"notification"}`；cmd/web.go 订阅事件，重建 channels map 加载新 conf。实测 ~1ms 内热重载完成，下一次 SendMessage 立即用新代理。

## ⚙️ 兼容性

- 无 breaking changes
- DB schema 不变
- 旧 conf 仍能解析（容错路径覆盖 strict int64 / quoted int / @username 等所有合理输入）

## 包含 commits（squash 后合并）

```
6adefb4 fix(chatops/telegram): default_chat_id / admin_users 容错 string 与 int 混合输入
70a90dc feat(chatops/notify): 通道配置变更后自动热重载，无需重启服务
100a891 fix(chatops/notify): UpdateConf 合并配置而非整体覆盖，避免编辑时丢失字段
bccd79b fix(chatops/notify): 测试消息不再走 outbox fallback，失败直接报错给前端
```
