### PR TITLE
fix(core): 修复磁盘保护 race、站点字段同步、RSS Cloudflare 与下载器 URL 等用户反馈问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -932,12 +932,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **site**: 新增 OpenCD 和 PTT 站点适配
 - 新增 site/v2/definitions/opencd.go 适配 open.cd (繁体 NexusPHP)
   _ 使用 div.title + td.rowtitle 替代标准 h1 + td.rowhead
-  _ 支持 plugin*details.php 链接格式
-  * 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
-  * 处理 font.promotion 替代 img.pro*_ 的非标准折扣标记
-  _ span.category 替代 img[alt] 的分类标记
-  _ 处理 info_block 隐藏列的 nth-child 索引偏移
-  _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
+  _ 支持 plugin\*details.php 链接格式
+  - 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
+  - 处理 font.promotion 替代 img.pro\*_ 的非标准折扣标记
+    _ span.category 替代 img[alt] 的分类标记
+    _ 处理 info_block 隐藏列的 nth-child 索引偏移
+    _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
 
 ## [0.23.0] - 2026-04-29
 

--- a/core/config_store.go
+++ b/core/config_store.go
@@ -135,6 +135,8 @@ func (s *ConfigStore) GetGlobalOnly() (models.SettingsGlobal, error) {
 	out.DownloadSpeedLimit = 20
 	out.TorrentSizeGB = 200
 	out.AutoStart = false
+	out.CleanupDiskProtect = true
+	out.CleanupMinDiskSpaceGB = 50
 	return out, nil
 }
 
@@ -150,6 +152,8 @@ func (s *ConfigStore) GetGlobalSettings() (models.SettingsGlobal, error) {
 		gs.DownloadSpeedLimit = 20
 		gs.TorrentSizeGB = 200
 		gs.AutoStart = false
+		gs.CleanupDiskProtect = true
+		gs.CleanupMinDiskSpaceGB = 50
 		return gs, nil
 	}
 	return gs, nil

--- a/internal/common.go
+++ b/internal/common.go
@@ -338,6 +338,7 @@ func processSingleTorrentWithDownloader(
 	// 修复策略 = 三层减法 + 全局互斥锁串行化：
 	//   effective_free = client_free - in_flight_pending - pre_reserved
 	//   gate           = effective_free - thisTorrentSize >= threshold
+	var reservedTorrentSize int64
 	if glOnly.CleanupDiskProtect && glOnly.CleanupMinDiskSpaceGB > 0 {
 		mu := PushMutex()
 		mu.Lock()
@@ -365,12 +366,22 @@ func processSingleTorrentWithDownloader(
 		if torrent != nil {
 			torrentSize = torrent.TorrentSize
 		}
+		if torrentSize <= 0 {
+			if torrentData, readErr := os.ReadFile(filePath); readErr == nil {
+				if parsedSize, sizeErr := qbit.ComputeTorrentSize(torrentData); sizeErr == nil {
+					torrentSize = parsedSize
+				}
+			}
+		}
 		minBytes := int64(glOnly.CleanupMinDiskSpaceGB * 1024 * 1024 * 1024)
 		if effectiveFreeBytes-torrentSize < minBytes {
 			effGB := float64(effectiveFreeBytes) / (1024 * 1024 * 1024)
 			tGB := float64(torrentSize) / (1024 * 1024 * 1024)
-			sLogger().Warnf("[磁盘保护] %s: 空间不足 (有效 %.1f GB - 种子 %.1f GB < 保底 %.1f GB)，跳过推送: %s",
-				dl.GetName(), effGB, tGB, glOnly.CleanupMinDiskSpaceGB, filePath)
+			freeGB := float64(freeSpace) / (1024 * 1024 * 1024)
+			pendingGB := float64(pendingBytes) / (1024 * 1024 * 1024)
+			reservedGB := float64(budget.Reserved()) / (1024 * 1024 * 1024)
+			sLogger().Warnf("[磁盘保护] %s: 空间不足 (qBit可用 %.1f GB - 下载中待占用 %.1f GB - 本进程预留 %.1f GB = 有效 %.1f GB；有效 - 种子 %.1f GB < 保底 %.1f GB)，跳过推送: %s",
+				dl.GetName(), freeGB, pendingGB, reservedGB, effGB, tGB, glOnly.CleanupMinDiskSpaceGB, filePath)
 			if glOnly.CleanupEnabled {
 				events.Publish(events.Event{Type: events.DiskSpaceLow, Source: "rss", At: time.Now()})
 			}
@@ -380,6 +391,7 @@ func processSingleTorrentWithDownloader(
 		// 推送失败会在下方失败分支 Release 归还。
 		if torrentSize > 0 {
 			budget.Reserve(torrentSize)
+			reservedTorrentSize = torrentSize
 		}
 	}
 
@@ -402,8 +414,8 @@ func processSingleTorrentWithDownloader(
 		// 推送失败：归还预留配额，避免 budget 被永久占用。
 		// 注：torrent 可能为 nil（极少数情况下 GetTorrentBySiteAndHash 失败但仍走到这）；
 		// 由 Reserve 的零值守卫保证 Release(0) no-op。
-		if torrent != nil && glOnly.CleanupDiskProtect && torrent.TorrentSize > 0 {
-			GetDiskBudget().Release(torrent.TorrentSize)
+		if reservedTorrentSize > 0 {
+			GetDiskBudget().Release(reservedTorrentSize)
 		}
 		errMsg := ""
 		if pushErr != nil {
@@ -426,6 +438,13 @@ func processSingleTorrentWithDownloader(
 		}
 		return fmt.Errorf("推送种子失败: %s", errMsg)
 	}
+	// 推送成功的预留**不**在此处归还。
+	// 原因：AddTorrentFileEx 返回成功后，qBit 通常仍需 1~2 秒才会把新种子计入
+	// torrents/info 的 amount_left（in-flight pending）。如果此处立刻 Release，
+	// 这段窗口内并发 worker 看到 pre_reserved=0 且 pending 也不含本种子，会
+	// 把同一份磁盘空间重复借给两个推送 —— 即 Issue #299 的原始 race。
+	// 预留由 scheduler/cleanup_monitor.runOnce 的周期 Reset 归还（默认 30 分钟），
+	// 期间 effective_free 略偏保守但不会越界。详见 disk_budget.go 顶部注释。
 
 	pushed2 := true
 	now := time.Now()
@@ -478,6 +497,14 @@ func attemptDownloadWithContext(ctx context.Context, url, title, downloadDir str
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("HTTP 状态码错误: %d", resp.StatusCode)
 	}
+	// 获取响应体字节
+	bodyBytes := resp.Bytes()
+	// 先计算种子的 torrentHash，确认响应体确实是合法 .torrent 后再落盘。
+	// 旧逻辑先写文件再算 hash，站点返回 HTML/JSON 错误页时会留下无效 .torrent，后续推送扫描反复报错。
+	torrentHash, err := qbit.ComputeTorrentHash(bodyBytes)
+	if err != nil {
+		return "", fmt.Errorf("下载到的内容不是有效种子文件，无法解析 info hash: status=%d, size=%d, preview=%q, err=%w", resp.StatusCode, len(bodyBytes), invalidTorrentPreview(bodyBytes), err)
+	}
 	// 创建下载目录
 	if err = os.MkdirAll(downloadDir, os.ModePerm); err != nil {
 		return "", fmt.Errorf("创建下载目录失败: %v", err)
@@ -489,20 +516,30 @@ func attemptDownloadWithContext(ctx context.Context, url, title, downloadDir str
 		return "", fmt.Errorf("创建种子文件失败: %v", err)
 	}
 	defer file.Close()
-	// 获取响应体字节
-	bodyBytes := resp.Bytes()
 	// 写入文件
 	_, err = file.Write(bodyBytes)
 	if err != nil {
 		return "", fmt.Errorf("写入种子文件失败: %v", err)
 	}
-	// 计算种子的 torrentHash
-	torrentHash, err := qbit.ComputeTorrentHash(bodyBytes)
-	if err != nil {
-		return "", fmt.Errorf("计算种子哈希失败: %v", err)
-	}
 	// 下载成功
 	return torrentHash, nil
+}
+
+func invalidTorrentPreview(data []byte) string {
+	preview := strings.ToValidUTF8(string(data), "")
+	preview = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return ' '
+		}
+		return r
+	}, preview)
+	preview = strings.TrimSpace(preview)
+	preview = regexp.MustCompile(`\s+`).ReplaceAllString(preview, " ")
+	runes := []rune(preview)
+	if len(runes) > 160 {
+		preview = string(runes[:160])
+	}
+	return preview
 }
 
 // 下载种子文件，包含重试机制
@@ -1091,13 +1128,44 @@ func FetchAndDownloadFreeRSSUnified(ctx context.Context, m UnifiedPTSite, rssCfg
 }
 
 func fetchRSSFeed(url string) (*gofeed.Feed, error) {
-	parser := gofeed.NewParser()
-	feed, err := parser.ParseURL(url)
+	return fetchRSSFeedWithContext(context.Background(), url)
+}
+
+// fetchRSSFeedWithContext fetches an RSS feed with a real browser User-Agent so
+// Cloudflare-fronted PT trackers (e.g. gtkpw, agsvpt) don't drop the TLS handshake.
+// gofeed's default ParseURL sets a generic UA that is regularly RST'd by these CDNs.
+func fetchRSSFeedWithContext(ctx context.Context, url string) (*gofeed.Feed, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("解析 RSS 失败: %v", err)
+		return nil, fmt.Errorf("构造 RSS 请求失败: %w", err)
+	}
+	req.Header.Set("User-Agent", rssUserAgent)
+	req.Header.Set("Accept", "application/rss+xml, application/xml;q=0.9, text/xml;q=0.8, */*;q=0.5")
+	req.Header.Set("Accept-Language", "zh-CN,zh;q=0.9,en;q=0.8")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("解析 RSS 失败: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("解析 RSS 失败: HTTP %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+
+	parser := gofeed.NewParser()
+	feed, err := parser.Parse(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("解析 RSS 失败: %w", err)
 	}
 	return feed, nil
 }
+
+const rssUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
 
 // FetchAndDownloadFreeRSS 旧的泛型版本（已废弃，请使用 FetchAndDownloadFreeRSSUnified）
 // Deprecated: Use FetchAndDownloadFreeRSSUnified instead for new implementations

--- a/internal/common_test.go
+++ b/internal/common_test.go
@@ -759,6 +759,23 @@ func TestFetchRSSFeed(t *testing.T) {
 	require.Len(t, result.Items, 1)
 }
 
+// TestFetchRSSFeed_BrowserUserAgent 验证 RSS 请求会携带浏览器 User-Agent，
+// 否则 Cloudflare-fronted PT 站点（如 gtkpw）会直接 RST 连接（issue #332）。
+func TestFetchRSSFeed_BrowserUserAgent(t *testing.T) {
+	feed := `<?xml version="1.0"?><rss version="2.0"><channel><title>UA</title></channel></rss>`
+	var gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(feed))
+	}))
+	defer srv.Close()
+
+	_, err := fetchRSSFeed(srv.URL)
+	require.NoError(t, err)
+	require.Contains(t, gotUA, "Mozilla/5.0", "RSS fetcher must send a browser-like UA")
+}
+
 // TestFetchRSSFeed_InvalidURL 测试无效 URL
 func TestFetchRSSFeed_InvalidURL(t *testing.T) {
 	_, err := fetchRSSFeed("://invalid")

--- a/internal/disk_protect_test.go
+++ b/internal/disk_protect_test.go
@@ -8,8 +8,12 @@
 package internal
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -18,12 +22,14 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zeebo/bencode"
 
 	"github.com/sunerpy/pt-tools/core"
 	"github.com/sunerpy/pt-tools/global"
 	sm "github.com/sunerpy/pt-tools/mocks"
 	"github.com/sunerpy/pt-tools/models"
 	"github.com/sunerpy/pt-tools/thirdpart/downloader"
+	"github.com/sunerpy/pt-tools/thirdpart/downloader/qbit"
 )
 
 // setUpDiskProtectTest 为磁盘保护测试初始化全局 DB + 写入 SettingsGlobal 行。
@@ -127,7 +133,9 @@ func TestDiskProtect_AllowsWhenSizeFits(t *testing.T) {
 		path, "cat", "tag", "", models.SiteGroup("springsunday"), false)
 	require.NoError(t, err)
 	assert.Equal(t, 30*gb, GetDiskBudget().Reserved(),
-		"推送成功后应保留预算 30GB（由 cleanup_monitor Reset 或上层回收）")
+		"推送成功后预留必须保留：qBit torrents/info 在 1~2 秒内还看不到本种子，"+
+			"立即 Release 会让并发 worker 重复借用同一份磁盘空间（Issue #299 race）。"+
+			"预留由 cleanup_monitor 周期 Reset 归还。")
 }
 
 // TestDiskProtect_PendingDownloadsSubtracted 验证 in-flight pending 被扣除：
@@ -288,4 +296,117 @@ func TestDiskProtect_ConcurrentPushesSerializeAndReject(t *testing.T) {
 		"剩余 3 个 worker 应被磁盘保护拦截")
 	assert.Equal(t, 2*torrentSize, budget.Reserved(),
 		"通过的 2 个 worker 共预留 60GB")
+}
+
+// makeUniqueTorrentFile 创建一个内容唯一（基于 nameSuffix）的 .torrent 文件，
+// 用于让并发测试里多个 worker 拿到不同的 hash + 不同的 DB 行。
+func makeUniqueTorrentFile(t *testing.T, dir, nameSuffix string) (string, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	torrent := map[string]any{"info": map[string]any{"name": "abc-" + nameSuffix}}
+	require.NoError(t, bencode.NewEncoder(&buf).Encode(torrent))
+	path := filepath.Join(dir, "x-"+nameSuffix+".torrent")
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o644))
+	h, err := qbit.ComputeTorrentHashWithPath(path)
+	require.NoError(t, err)
+	return path, h
+}
+
+// TestDiskProtect_RealRSSPath_SuccessKeepsReservation 是 P0 race 的真实路径回归。
+//
+// 旧版（推送成功立即 Release）会让此测试失败：
+//
+//	worker A 推送成功 → 立即 Release(30GB) → Reserved=0
+//	worker B 此时进入临界区 → 看到 effective_free = 100-0-0 = 100，30GB 通过
+//	worker C 同样通过 → 三个 worker 同时占用 100GB 中的 90GB
+//	最终 Reserved = 30GB（只有最后一个未 Release），但实际已超借
+//
+// 新版预期：成功后保留预留，cleanup_monitor 周期 Reset 归还。
+//
+// 100GB free, 0 pending, 30GB 种子, 阈值 20GB。
+// 第 1 个：effective=100, 100-30=70 ≥ 20，通过，Reserved=30
+// 第 2 个：effective=70, 70-30=40 ≥ 20，通过，Reserved=60
+// 第 3 个：effective=40, 40-30=10 < 20，拒绝
+// 第 4/5 个：同样拒绝
+// 期望 success=2 / fail=3 / final reserved = 60GB。
+func TestDiskProtect_RealRSSPath_SuccessKeepsReservation(t *testing.T) {
+	setUpDiskProtectTest(t)
+	dir := t.TempDir()
+
+	const workers = 5
+	const torrentSize int64 = 30 * gb
+	const free int64 = 100 * gb
+
+	type job struct {
+		path string
+		hash string
+	}
+	jobs := make([]job, workers)
+	for i := 0; i < workers; i++ {
+		path, hash := makeUniqueTorrentFile(t, dir, fmt.Sprintf("w%d", i))
+		pushed := false
+		future := time.Now().Add(1 * time.Hour)
+		ti := &models.TorrentInfo{
+			SiteName:     string(models.SiteGroup("springsunday")),
+			TorrentID:    fmt.Sprintf("race-w%d", i),
+			TorrentHash:  &hash,
+			IsPushed:     &pushed,
+			FreeEndTime:  &future,
+			TorrentSize:  torrentSize,
+			IsDownloaded: true,
+		}
+		require.NoError(t, global.GlobalDB.UpsertTorrent(ti))
+		jobs[i] = job{path: path, hash: hash}
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDl := sm.NewMockDownloader(ctrl)
+	mockDl.EXPECT().GetName().Return("test-dl").AnyTimes()
+	mockDl.EXPECT().GetType().Return(downloader.DownloaderQBittorrent).AnyTimes()
+	for _, j := range jobs {
+		mockDl.EXPECT().CheckTorrentExists(j.hash).Return(false, nil).AnyTimes()
+	}
+	mockDl.EXPECT().GetClientFreeSpace(gomock.Any()).Return(free, nil).AnyTimes()
+	mockDl.EXPECT().GetIncompletePendingBytes(gomock.Any()).Return(int64(0), nil).AnyTimes()
+	mockDl.EXPECT().AddTorrentFileEx(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(data []byte, _ downloader.AddTorrentOptions) (downloader.AddTorrentResult, error) {
+			h, err := qbit.ComputeTorrentHash(data)
+			require.NoError(t, err)
+			return downloader.AddTorrentResult{Success: true, Hash: h}, nil
+		}).AnyTimes()
+
+	dlInfo := &DownloaderInfo{ID: 1, Name: "test-dl", AutoStart: true}
+
+	var success, fail atomic.Int32
+	var wg sync.WaitGroup
+	for _, j := range jobs {
+		wg.Add(1)
+		go func(j job) {
+			defer wg.Done()
+			err := processSingleTorrentWithDownloader(context.Background(), mockDl, dlInfo,
+				j.path, "cat", "tag", "", models.SiteGroup("springsunday"), false)
+			if err != nil {
+				if errors.Is(err, downloader.ErrInsufficientSpace) {
+					fail.Add(1)
+				} else {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			success.Add(1)
+		}(j)
+	}
+	wg.Wait()
+
+	t.Logf("成功 %d, 失败 %d, 最终预留 %d GB",
+		success.Load(), fail.Load(), GetDiskBudget().Reserved()/gb)
+
+	assert.Equal(t, int32(2), success.Load(),
+		"100GB free / 30GB 种子 / 20GB 阈值 → 仅前 2 个 worker 应该成功推送")
+	assert.Equal(t, int32(3), fail.Load(),
+		"后 3 个 worker 应被磁盘保护拦截")
+	assert.Equal(t, 2*torrentSize, GetDiskBudget().Reserved(),
+		"两次成功推送的预留必须保留，等待 cleanup_monitor 周期 Reset；"+
+			"如果此处显示 0 表示 P0 race 被复活：成功路径仍在立即 Release。")
 }

--- a/internal/push.go
+++ b/internal/push.go
@@ -160,8 +160,11 @@ func PushTorrentToDownloader(ctx context.Context, req PushTorrentRequest) (*Push
 		if effectiveFreeBytes-pushTorrentSize < minBytes {
 			effGB := float64(effectiveFreeBytes) / (1024 * 1024 * 1024)
 			tGB := float64(pushTorrentSize) / (1024 * 1024 * 1024)
-			sLogger().Warnf("[磁盘保护] %s: 空间不足 (有效 %.1f GB - 种子 %.1f GB < 保底 %.1f GB)，跳过推送: site=%s, id=%s",
-				dlSetting.Name, effGB, tGB, glOnly.CleanupMinDiskSpaceGB, req.SiteID, req.TorrentID)
+			freeGB := float64(freeSpace) / (1024 * 1024 * 1024)
+			pendingGB := float64(pendingBytes) / (1024 * 1024 * 1024)
+			reservedGB := float64(budget.Reserved()) / (1024 * 1024 * 1024)
+			sLogger().Warnf("[磁盘保护] %s: 空间不足 (qBit可用 %.1f GB - 下载中待占用 %.1f GB - 本进程预留 %.1f GB = 有效 %.1f GB；有效 - 种子 %.1f GB < 保底 %.1f GB)，跳过推送: site=%s, id=%s",
+				dlSetting.Name, freeGB, pendingGB, reservedGB, effGB, tGB, glOnly.CleanupMinDiskSpaceGB, req.SiteID, req.TorrentID)
 			if glOnly.CleanupEnabled {
 				events.Publish(events.Event{Type: events.DiskSpaceLow, Source: "push", At: time.Now()})
 			}
@@ -211,6 +214,9 @@ func PushTorrentToDownloader(ctx context.Context, req PushTorrentRequest) (*Push
 			Message:     errMsg,
 		}, nil
 	}
+	// 推送成功的预留由 scheduler/cleanup_monitor 周期 Reset 归还，避免与
+	// downloader.GetIncompletePendingBytes 在 qBit 可见性窗口内双重计数
+	// （Issue #299 race，详见 disk_budget.go 顶部注释）。
 
 	// 推送成功，更新数据库状态
 	pushed := true

--- a/internal/torrent_detail.go
+++ b/internal/torrent_detail.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/mmcdole/gofeed"
@@ -25,6 +26,11 @@ type TorrentDetailForTest struct {
 	Tag    string // 种子标签/副标题
 	IsFree bool   // 是否免费
 }
+
+var mtorrentDetailLimiter = struct {
+	sync.Mutex
+	next map[models.SiteGroup]time.Time
+}{next: make(map[models.SiteGroup]time.Time)}
 
 // GetTorrentDetailForTest 获取种子详情用于过滤规则测试
 // 根据站点类型调用对应的 API 获取完整的种子信息
@@ -102,6 +108,9 @@ func fetchMTorrentDetail(ctx context.Context, siteName models.SiteGroup, item *g
 	}
 	req.AddHeader("Content-Type", "application/x-www-form-urlencoded")
 	req.AddHeader("x-api-key", sc.APIKey)
+	if rateErr := waitMTorrentDetailRateLimit(ctx, siteName); rateErr != nil {
+		return nil, rateErr
+	}
 
 	resp, err := session.DoWithContext(ctx, req)
 	if err != nil {
@@ -116,8 +125,33 @@ func fetchMTorrentDetail(ctx context.Context, siteName models.SiteGroup, item *g
 	if err := json.NewDecoder(bytes.NewReader(resp.Bytes())).Decode(&responseData); err != nil {
 		return nil, fmt.Errorf("解析 JSON 失败: %v", err)
 	}
+	if code := strings.TrimSpace(fmt.Sprint(responseData.Code)); code != "" && code != "0" {
+		return nil, fmt.Errorf("API error: %s - %s", code, responseData.Message)
+	}
 
 	return &responseData.Data, nil
+}
+
+func waitMTorrentDetailRateLimit(ctx context.Context, siteName models.SiteGroup) error {
+	mtorrentDetailLimiter.Lock()
+	now := time.Now()
+	waitUntil := mtorrentDetailLimiter.next[siteName]
+	if now.After(waitUntil) {
+		waitUntil = now
+	}
+	mtorrentDetailLimiter.next[siteName] = waitUntil.Add(1200 * time.Millisecond)
+	mtorrentDetailLimiter.Unlock()
+
+	if delay := time.Until(waitUntil); delay > 0 {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return nil
 }
 
 // fetchNexusPHPDetail 获取 NexusPHP 架构站点的种子详情

--- a/internal/unified_site.go
+++ b/internal/unified_site.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/mmcdole/gofeed"
@@ -228,6 +229,11 @@ func (u *UnifiedSiteImpl) SendTorrentToDownloader(ctx context.Context, rssCfg mo
 
 	err = ProcessTorrentsWithDownloaderByRSS(ctx, rssCfg, dirPath, rssCfg.Category, rssCfg.Tag, u.siteGroup)
 	if err != nil {
+		if strings.Contains(err.Error(), "未启用") {
+			u.logger.Warnf("[推送跳过] 站点=%s, 配置的下载器未启用：%v；请在站点设置中切换下载器或在下载器管理中启用",
+				u.siteGroup, err)
+			return err
+		}
 		u.logger.Errorf("[推送失败] 站点=%s, 错误=%v", u.siteGroup, err)
 		return err
 	}

--- a/scheduler/cleanup_monitor.go
+++ b/scheduler/cleanup_monitor.go
@@ -12,6 +12,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/sunerpy/pt-tools/global"
+	ptinternal "github.com/sunerpy/pt-tools/internal"
 	"github.com/sunerpy/pt-tools/internal/events"
 	"github.com/sunerpy/pt-tools/models"
 	v2 "github.com/sunerpy/pt-tools/site/v2"
@@ -145,6 +146,14 @@ func (c *CleanupMonitor) loadConfig() *models.SettingsGlobal {
 }
 
 func (c *CleanupMonitor) runOnce(cfg *models.SettingsGlobal) {
+	// Reset 必须在 PushMutex 内执行：否则可能在某个 worker 的「Reserve → push」
+	// 中间清零，让下一个 worker 看到 pre_reserved=0 而重复借用同一份磁盘空间
+	// （Issue #299 race 的另一形态）。
+	mu := ptinternal.PushMutex()
+	mu.Lock()
+	ptinternal.GetDiskBudget().Reset()
+	mu.Unlock()
+
 	dlNames := c.downloaderMgr.ListDownloaders()
 	if len(dlNames) == 0 {
 		return

--- a/site/v2/definitions/gamegamept.go
+++ b/site/v2/definitions/gamegamept.go
@@ -26,7 +26,14 @@ var GameGamePTDefinition = &v2.SiteDefinition{
 			{
 				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
 				Assertion:     map[string]string{"id": "params.id"},
-				Fields:        []string{"name", "uploaded", "downloaded", "ratio", "levelName", "joinTime"},
+				Fields: []string{
+					"name", "uploaded", "downloaded", "ratio", "levelName", "joinTime",
+					"trueUploaded", "trueDownloaded",
+				},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/mybonus.php", ResponseType: "document"},
+				Fields:        []string{"bonusPerHour"},
 			},
 		},
 		Selectors: map[string]v2.FieldSelector{
@@ -75,6 +82,41 @@ var GameGamePTDefinition = &v2.SiteDefinition{
 				Selector: []string{"#info_block"},
 				Attr:     "html",
 				Filters:  []v2.Filter{{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}}, {Name: "parseNumber"}},
+			},
+			"trueUploaded": {
+				Selector: []string{
+					"td.rowhead:contains('传输') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('傳送') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:实际上传量|實際上傳量|實際上傳|实际上传)</strong>[\s:：]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"trueDownloaded": {
+				Selector: []string{
+					"td.rowhead:contains('传输') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('傳送') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:实际下载量|實際下載量|實際下載|实际下载)</strong>[\s:：]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"bonusPerHour": {
+				Selector: []string{
+					"#outer",
+					"body",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:你當前每小時能獲取|你当前每小时能获取|您當前每小時能獲取|您当前每小时能获取)[^\d-]{0,20}([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
 			},
 		},
 	},

--- a/site/v2/definitions/gamegamept_fixture_test.go
+++ b/site/v2/definitions/gamegamept_fixture_test.go
@@ -65,11 +65,17 @@ const gamegameptIndexFixture = `<html><body>
 
 const gamegameptUserdetailsFixture = `<html><body>
 <table>
-  <tr><td class="rowhead">用户ID/UID</td><td class="rowfollow">44933</td></tr>
-  <tr><td class="rowhead">加入日期</td><td class="rowfollow">2026-03-20 08:30:00 (<span title="2026-03-20 08:30:00">7天前</span>)</td></tr>
-  <tr><td class="rowhead">传输</td><td class="rowfollow"><table><tr><td class="embedded"><strong>分享率</strong>: <font color="">4.000</font></td></tr><tr><td class="embedded"><strong>上传量</strong>: 1.00 TB</td><td class="embedded"><strong>下载量</strong>: 256.00 GB</td></tr></table></td></tr>
-  <tr><td class="rowhead">等级</td><td class="rowfollow"><img title="User" src="pic/user.gif" /></td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">用户ID/UID</td><td class="rowfollow">44933</td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">加入日期</td><td class="rowfollow">2026-03-20 08:30:00 (<span title="2026-03-20 08:30:00">7天前</span>)</td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">传输</td><td class="rowfollow"><table><tr><td class="embedded"><strong>分享率</strong>: <font color="">4.000</font></td></tr><tr><td class="embedded"><strong>上传量</strong>: 1.00 TB</td><td class="embedded"><strong>下载量</strong>: 256.00 GB</td></tr><tr><td class="embedded"><strong>实际上传量</strong>: 50.00 TB</td><td class="embedded"><strong>实际下载量</strong>: 1.00 TB</td></tr></table></td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">等级</td><td class="rowfollow"><img title="User" src="pic/user.gif" /></td></tr>
 </table>
+</body></html>`
+
+const gamegameptMyBonusFixture = `<html><body>
+<div id="outer">
+您当前每小时能获取 56.78 个魔力值
+</div>
 </body></html>`
 
 const gamegameptDetailFixture = `<html><body>
@@ -147,6 +153,11 @@ func testGameGamePTUserInfo(t *testing.T) {
 	assert.Equal(t, "4", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["ratio"]))
 	assert.Equal(t, "User", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["levelName"]))
 	assert.Equal(t, "1773995400", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["joinTime"]))
+	assert.Equal(t, "54975581388800", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["trueUploaded"]))
+	assert.Equal(t, "1099511627776", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["trueDownloaded"]))
+
+	bonusDoc := FixtureDoc(t, "gamegamept_mybonus", gamegameptMyBonusFixture)
+	assert.Equal(t, "56.78", driver.ExtractFieldValuePublic(bonusDoc, def.UserInfo.Selectors["bonusPerHour"]))
 }
 
 func TestGameGamePT_Fixtures_NoSecrets(t *testing.T) {
@@ -154,6 +165,7 @@ func TestGameGamePT_Fixtures_NoSecrets(t *testing.T) {
 		"search":      gamegameptSearchFixture,
 		"index":       gamegameptIndexFixture,
 		"userdetails": gamegameptUserdetailsFixture,
+		"mybonus":     gamegameptMyBonusFixture,
 		"detail":      gamegameptDetailFixture,
 	}
 	for name, data := range fixtures {

--- a/site/v2/definitions/gtkpw.go
+++ b/site/v2/definitions/gtkpw.go
@@ -26,7 +26,14 @@ var GTKPWDefinition = &v2.SiteDefinition{
 			{
 				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
 				Assertion:     map[string]string{"id": "params.id"},
-				Fields:        []string{"name", "uploaded", "downloaded", "ratio", "levelName", "joinTime"},
+				Fields: []string{
+					"name", "uploaded", "downloaded", "ratio", "levelName", "joinTime",
+					"trueUploaded", "trueDownloaded",
+				},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/mybonus.php", ResponseType: "document"},
+				Fields:        []string{"bonusPerHour"},
 			},
 		},
 		Selectors: map[string]v2.FieldSelector{
@@ -75,6 +82,41 @@ var GTKPWDefinition = &v2.SiteDefinition{
 				Selector: []string{"#info_block"},
 				Attr:     "html",
 				Filters:  []v2.Filter{{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}}, {Name: "parseNumber"}},
+			},
+			"trueUploaded": {
+				Selector: []string{
+					"td.rowhead:contains('传输') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('傳送') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:实际上传量|實際上傳量|實際上傳|实际上传)</strong>[\s:：]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"trueDownloaded": {
+				Selector: []string{
+					"td.rowhead:contains('传输') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('傳送') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:实际下载量|實際下載量|實際下載|实际下载)</strong>[\s:：]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"bonusPerHour": {
+				Selector: []string{
+					"#outer",
+					"body",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:你當前每小時能獲取|你当前每小时能获取|您當前每小時能獲取|您当前每小时能获取)[^\d-]{0,20}([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
 			},
 		},
 	},

--- a/site/v2/definitions/gtkpw_fixture_test.go
+++ b/site/v2/definitions/gtkpw_fixture_test.go
@@ -64,11 +64,17 @@ const gtkpwIndexFixture = `<html><body>
 
 const gtkpwUserdetailsFixture = `<html><body>
 <table>
-  <tr><td class="rowhead">用户ID/UID</td><td class="rowfollow">7283</td></tr>
-  <tr><td class="rowhead">加入日期</td><td class="rowfollow">2025-08-20 09:00:00 (<span title="2025-08-20 09:00:00">8月前</span>)</td></tr>
-  <tr><td class="rowhead">传输</td><td class="rowfollow"><table><tr><td class="embedded"><strong>分享率</strong>: <font color="">6.789</font></td></tr><tr><td class="embedded"><strong>上传量</strong>: 3.50 TB</td><td class="embedded"><strong>下载量</strong>: 600.00 GB</td></tr></table></td></tr>
-  <tr><td class="rowhead">等级</td><td class="rowfollow"><img title="Crazy User" src="pic/crazyuser.gif" /></td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">用户ID/UID</td><td class="rowfollow">7283</td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">加入日期</td><td class="rowfollow">2025-08-20 09:00:00 (<span title="2025-08-20 09:00:00">8月前</span>)</td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">传输</td><td class="rowfollow"><table><tr><td class="embedded"><strong>分享率</strong>: <font color="">6.789</font></td></tr><tr><td class="embedded"><strong>上传量</strong>: 3.50 TB</td><td class="embedded"><strong>下载量</strong>: 600.00 GB</td></tr><tr><td class="embedded"><strong>实际上传量</strong>: 4.00 TB</td><td class="embedded"><strong>实际下载量</strong>: 2.00 TB</td></tr></table></td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">等级</td><td class="rowfollow"><img title="Crazy User" src="pic/crazyuser.gif" /></td></tr>
 </table>
+</body></html>`
+
+const gtkpwMyBonusFixture = `<html><body>
+<div id="outer">
+您当前每小时能获取 23.45 个魔力值
+</div>
 </body></html>`
 
 const gtkpwDetailFixture = `<html><body>
@@ -146,6 +152,11 @@ func testGTKPWUserInfo(t *testing.T) {
 	assert.Equal(t, "644245094400", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["downloaded"]))
 	assert.Equal(t, "6.789", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["ratio"]))
 	assert.Equal(t, "Crazy User", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["levelName"]))
+	assert.Equal(t, "4398046511104", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["trueUploaded"]))
+	assert.Equal(t, "2199023255552", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["trueDownloaded"]))
+
+	bonusDoc := FixtureDoc(t, "gtkpw_mybonus", gtkpwMyBonusFixture)
+	assert.Equal(t, "23.45", driver.ExtractFieldValuePublic(bonusDoc, def.UserInfo.Selectors["bonusPerHour"]))
 }
 
 func TestGTKPW_Fixtures_NoSecrets(t *testing.T) {
@@ -153,6 +164,7 @@ func TestGTKPW_Fixtures_NoSecrets(t *testing.T) {
 		"search":      gtkpwSearchFixture,
 		"index":       gtkpwIndexFixture,
 		"userdetails": gtkpwUserdetailsFixture,
+		"mybonus":     gtkpwMyBonusFixture,
 		"detail":      gtkpwDetailFixture,
 	}
 	for name, data := range fixtures {

--- a/site/v2/definitions/mteam.go
+++ b/site/v2/definitions/mteam.go
@@ -37,6 +37,7 @@ var MTeamDefinition = &v2.SiteDefinition{
 				},
 				Fields: []string{
 					"id", "name", "joinTime", "uploaded", "downloaded",
+					"trueUploaded", "trueDownloaded",
 					"levelName", "levelId", "bonus", "lastAccessAt",
 				},
 			},
@@ -83,6 +84,14 @@ var MTeamDefinition = &v2.SiteDefinition{
 			},
 			"downloaded": {
 				Selector: []string{"data.memberCount.downloaded"},
+				Filters:  []v2.Filter{{Name: "parseNumber"}},
+			},
+			"trueUploaded": {
+				Selector: []string{"data.memberCount.trueUploaded"},
+				Filters:  []v2.Filter{{Name: "parseNumber"}},
+			},
+			"trueDownloaded": {
+				Selector: []string{"data.memberCount.trueDownloaded"},
 				Filters:  []v2.Filter{{Name: "parseNumber"}},
 			},
 			"levelName": {

--- a/site/v2/definitions/nicept.go
+++ b/site/v2/definitions/nicept.go
@@ -26,7 +26,14 @@ var NicePTDefinition = &v2.SiteDefinition{
 			{
 				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
 				Assertion:     map[string]string{"id": "params.id"},
-				Fields:        []string{"name", "uploaded", "downloaded", "ratio", "levelName", "joinTime"},
+				Fields: []string{
+					"name", "uploaded", "downloaded", "ratio", "levelName", "joinTime",
+					"trueUploaded", "trueDownloaded",
+				},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/mybonus.php", ResponseType: "document"},
+				Fields:        []string{"bonusPerHour"},
 			},
 		},
 		Selectors: map[string]v2.FieldSelector{
@@ -75,6 +82,41 @@ var NicePTDefinition = &v2.SiteDefinition{
 				Selector: []string{"#info_block"},
 				Attr:     "html",
 				Filters:  []v2.Filter{{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}}, {Name: "parseNumber"}},
+			},
+			"trueUploaded": {
+				Selector: []string{
+					"td.rowhead:contains('傳送') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('传输') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:實際上傳量|实际上传量|實際上傳|实际上传)</strong>[\s:：]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"trueDownloaded": {
+				Selector: []string{
+					"td.rowhead:contains('傳送') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('传输') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:實際下載量|实际下载量|實際下載|实际下载)</strong>[\s:：]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"bonusPerHour": {
+				Selector: []string{
+					"#outer",
+					"body",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:你當前每小時能獲取|你当前每小时能获取|您當前每小時能獲取|您当前每小时能获取)[^\d-]{0,20}([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
 			},
 		},
 	},

--- a/site/v2/definitions/nicept_fixture_test.go
+++ b/site/v2/definitions/nicept_fixture_test.go
@@ -65,11 +65,17 @@ const niceptIndexFixture = `<html><body>
 
 const niceptUserdetailsFixture = `<html><body>
 <table>
-  <tr><td class="rowhead">用戶ID/UID</td><td class="rowfollow">1188761</td></tr>
-  <tr><td class="rowhead">加入日期</td><td class="rowfollow">2025-06-15 10:00:00 (<span title="2025-06-15 10:00:00">11月前</span>)</td></tr>
-  <tr><td class="rowhead">傳送</td><td class="rowfollow"><table><tr><td class="embedded"><strong>分享率</strong>: <font color="">7.890</font></td></tr><tr><td class="embedded"><strong>上傳量</strong>: 5.00 TB</td><td class="embedded"><strong>下載量</strong>: 650.00 GB</td></tr></table></td></tr>
-  <tr><td class="rowhead">等級</td><td class="rowfollow"><img title="Veteran User" src="pic/veteran.gif" /></td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">用戶ID/UID</td><td class="rowfollow">1188761</td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">加入日期</td><td class="rowfollow">2025-06-15 10:00:00 (<span title="2025-06-15 10:00:00">11月前</span>)</td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">傳送</td><td class="rowfollow"><table><tr><td class="embedded"><strong>分享率</strong>: <font color="">7.890</font></td></tr><tr><td class="embedded"><strong>上傳量</strong>: 5.00 TB</td><td class="embedded"><strong>下載量</strong>: 650.00 GB</td></tr><tr><td class="embedded"><strong>實際上傳量</strong>: 14.00 TB</td><td class="embedded"><strong>實際下載量</strong>: 2.00 TB</td></tr></table></td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">等級</td><td class="rowfollow"><img title="Veteran User" src="pic/veteran.gif" /></td></tr>
 </table>
+</body></html>`
+
+const niceptMyBonusFixture = `<html><body>
+<div id="outer">
+您當前每小時能獲取 12.34 個魔力值
+</div>
 </body></html>`
 
 const niceptDetailFixture = `<html><body>
@@ -148,6 +154,11 @@ func testNicePTUserInfo(t *testing.T) {
 	assert.Equal(t, "697932185600", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["downloaded"]))
 	assert.Equal(t, "7.89", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["ratio"]))
 	assert.Equal(t, "Veteran User", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["levelName"]))
+	assert.Equal(t, "15393162788864", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["trueUploaded"]))
+	assert.Equal(t, "2199023255552", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["trueDownloaded"]))
+
+	bonusDoc := FixtureDoc(t, "nicept_mybonus", niceptMyBonusFixture)
+	assert.Equal(t, "12.34", driver.ExtractFieldValuePublic(bonusDoc, def.UserInfo.Selectors["bonusPerHour"]))
 }
 
 func TestNicePT_Fixtures_NoSecrets(t *testing.T) {
@@ -155,6 +166,7 @@ func TestNicePT_Fixtures_NoSecrets(t *testing.T) {
 		"search":      niceptSearchFixture,
 		"index":       niceptIndexFixture,
 		"userdetails": niceptUserdetailsFixture,
+		"mybonus":     niceptMyBonusFixture,
 		"detail":      niceptDetailFixture,
 	}
 	for name, data := range fixtures {

--- a/site/v2/definitions/pttime.go
+++ b/site/v2/definitions/pttime.go
@@ -33,7 +33,7 @@ var PTTimeDefinition = &v2.SiteDefinition{
 			{
 				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
 				Assertion:     map[string]string{"id": "params.id"},
-				Fields:        []string{"joinTime"},
+				Fields:        []string{"joinTime", "bonusPerHour"},
 			},
 		},
 		Selectors: map[string]v2.FieldSelector{
@@ -121,6 +121,17 @@ var PTTimeDefinition = &v2.SiteDefinition{
 				Filters: []v2.Filter{
 					{Name: "split", Args: []any{" (", 0}},
 					{Name: "parseTime"},
+				},
+			},
+			"bonusPerHour": {
+				Selector: []string{
+					"#info_block",
+					"body",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`\(([\d.,]+)\s*魔力/小[時时]\)`}},
+					{Name: "parseNumber"},
 				},
 			},
 		},

--- a/site/v2/definitions/pttime_fixture_test.go
+++ b/site/v2/definitions/pttime_fixture_test.go
@@ -88,12 +88,15 @@ const pttimeIndexFixture = `<html><body>
 </body></html>`
 
 const pttimeUserdetailsFixture = `<html><body>
-<table>
-  <tr>
-    <td class="rowhead">加入日期</td>
-    <td class="rowfollow">2023-01-15 10:00:00 (<span title="2023-01-15 10:00:00">3年前</span>)</td>
-  </tr>
-</table>
+<div id="outer">
+  魔力值(84.36魔力/小时) [<a href="mybonus.php">使用</a>]: 1889134.7
+  <table>
+    <tr>
+      <td class="rowhead">加入日期</td>
+      <td class="rowfollow">2023-01-15 10:00:00 (<span title="2023-01-15 10:00:00">3年前</span>)</td>
+    </tr>
+  </table>
+</div>
 </body></html>`
 
 const pttimeDetailFixture = `<html><body>
@@ -219,6 +222,10 @@ func testPTTimeUserInfo(t *testing.T) {
 		require.True(t, ok)
 		got := driver.ExtractFieldValuePublic(doc, sel)
 		assert.NotEmpty(t, got, "joinTime should be parsed")
+
+		bonusSel, ok := def.UserInfo.Selectors["bonusPerHour"]
+		require.True(t, ok, "bonusPerHour selector not found")
+		assert.Equal(t, "84.36", driver.ExtractFieldValuePublic(doc, bonusSel))
 	})
 }
 

--- a/site/v2/mtorrent_driver.go
+++ b/site/v2/mtorrent_driver.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -223,12 +224,14 @@ type MTorrentUserInfo struct {
 
 // MTorrentMemberCount contains upload/download stats
 type MTorrentMemberCount struct {
-	Uploaded   string `json:"uploaded"`
-	Downloaded string `json:"downloaded"`
-	Bonus      string `json:"bonus"`
-	ShareRate  string `json:"shareRate"`
-	Seedtime   string `json:"seedtime"`
-	Leechtime  string `json:"leechtime"`
+	Uploaded       string `json:"uploaded"`
+	Downloaded     string `json:"downloaded"`
+	TrueUploaded   string `json:"trueUploaded"`
+	TrueDownloaded string `json:"trueDownloaded"`
+	Bonus          string `json:"bonus"`
+	ShareRate      string `json:"shareRate"`
+	Seedtime       string `json:"seedtime"`
+	Leechtime      string `json:"leechtime"`
 }
 
 // MTorrentMemberStatus contains user status info
@@ -553,16 +556,18 @@ func (d *MTorrentDriver) ParseUserInfo(res MTorrentResponse) (UserInfo, error) {
 	levelID, _ := strconv.Atoi(userData.Role)
 
 	info := UserInfo{
-		UserID:     userData.ID,
-		Username:   userData.Username,
-		Uploaded:   parseSize(userData.MemberCount.Uploaded),
-		Downloaded: parseSize(userData.MemberCount.Downloaded),
-		Ratio:      ratio,
-		Bonus:      bonus,
-		Rank:       rank,
-		LevelName:  rank,
-		LevelID:    levelID,
-		LastUpdate: time.Now().Unix(),
+		UserID:         userData.ID,
+		Username:       userData.Username,
+		Uploaded:       parseSize(userData.MemberCount.Uploaded),
+		Downloaded:     parseSize(userData.MemberCount.Downloaded),
+		TrueUploaded:   parseSize(userData.MemberCount.TrueUploaded),
+		TrueDownloaded: parseSize(userData.MemberCount.TrueDownloaded),
+		Ratio:          ratio,
+		Bonus:          bonus,
+		Rank:           rank,
+		LevelName:      rank,
+		LevelID:        levelID,
+		LastUpdate:     time.Now().Unix(),
 	}
 
 	// Parse join date
@@ -656,7 +661,29 @@ func (d *MTorrentDriver) ParseDownload(res MTorrentResponse) ([]byte, error) {
 		return nil, fmt.Errorf("HTTP %d fetching torrent from %s", resp.StatusCode, downloadURL)
 	}
 
-	return resp.Bytes(), nil
+	data := resp.Bytes()
+	if err := ValidateTorrentFile(data); err != nil {
+		return nil, fmt.Errorf("invalid torrent response from %s: size=%d, preview=%q, err=%w", downloadURL, len(data), torrentResponsePreview(data), err)
+	}
+
+	return data, nil
+}
+
+func torrentResponsePreview(data []byte) string {
+	preview := strings.ToValidUTF8(string(data), "")
+	preview = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return ' '
+		}
+		return r
+	}, preview)
+	preview = strings.TrimSpace(preview)
+	preview = regexp.MustCompile(`\s+`).ReplaceAllString(preview, " ")
+	runes := []rune(preview)
+	if len(runes) > 160 {
+		preview = string(runes[:160])
+	}
+	return preview
 }
 
 // parseMTorrentDiscount parses M-Team discount string to DiscountLevel

--- a/site/v2/userinfo_service.go
+++ b/site/v2/userinfo_service.go
@@ -3,6 +3,7 @@ package v2
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -118,9 +119,14 @@ func (s *UserInfoService) FetchAndSave(ctx context.Context, siteID string) (User
 		)
 		return UserInfo{}, fmt.Errorf("fetch user info from %s: %w", siteID, err)
 	}
+	if strings.TrimSpace(info.Username) == "" {
+		return UserInfo{}, fmt.Errorf("fetch user info from %s: parsed empty username", siteID)
+	}
 
 	// Save to repository
-	if err := s.repo.Save(ctx, info); err != nil {
+	saveCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+	if err := s.repo.Save(saveCtx, info); err != nil {
 		s.logger.Error(
 			"Failed to save user info",
 			zap.String("site", siteID),

--- a/thirdpart/downloader/qbit/config.go
+++ b/thirdpart/downloader/qbit/config.go
@@ -2,6 +2,7 @@ package qbit
 
 import (
 	"errors"
+	"net/url"
 	"strings"
 
 	"github.com/sunerpy/pt-tools/thirdpart/downloader"
@@ -22,7 +23,11 @@ func (c *QBitConfig) GetType() downloader.DownloaderType {
 
 // GetURL 获取下载器 URL（自动去除尾斜杠）
 func (c *QBitConfig) GetURL() string {
-	return strings.TrimSuffix(c.URL, "/")
+	value := strings.TrimSpace(c.URL)
+	if value != "" && !strings.Contains(value, "://") {
+		value = "http://" + value
+	}
+	return strings.TrimSuffix(value, "/")
 }
 
 // GetUsername 获取用户名
@@ -44,6 +49,19 @@ func (c *QBitConfig) GetAutoStart() bool {
 func (c *QBitConfig) Validate() error {
 	if c.URL == "" {
 		return errors.New("qBittorrent URL is required")
+	}
+	parsed, err := url.Parse(c.GetURL())
+	if err != nil || parsed.Scheme == "" || parsed.Hostname() == "" {
+		return errors.New("qBittorrent URL is invalid")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return errors.New("qBittorrent URL must use http or https")
+	}
+	if parsed.User != nil {
+		return errors.New("qBittorrent URL must not include username or password")
+	}
+	if parsed.Fragment != "" {
+		return errors.New("qBittorrent URL must not include fragment")
 	}
 	return nil
 }

--- a/thirdpart/downloader/transmission/config.go
+++ b/thirdpart/downloader/transmission/config.go
@@ -2,6 +2,7 @@ package transmission
 
 import (
 	"errors"
+	"net/url"
 	"strings"
 
 	"github.com/sunerpy/pt-tools/thirdpart/downloader"
@@ -23,7 +24,11 @@ func (c *TransmissionConfig) GetType() downloader.DownloaderType {
 
 // GetURL 获取下载器 URL（自动去除尾斜杠）
 func (c *TransmissionConfig) GetURL() string {
-	return strings.TrimSuffix(c.URL, "/")
+	value := strings.TrimSpace(c.URL)
+	if value != "" && !strings.Contains(value, "://") {
+		value = "http://" + value
+	}
+	return strings.TrimSuffix(value, "/")
 }
 
 // GetUsername 获取用户名
@@ -45,6 +50,19 @@ func (c *TransmissionConfig) GetAutoStart() bool {
 func (c *TransmissionConfig) Validate() error {
 	if c.URL == "" {
 		return errors.New("Transmission URL is required")
+	}
+	parsed, err := url.Parse(c.GetURL())
+	if err != nil || parsed.Scheme == "" || parsed.Hostname() == "" {
+		return errors.New("Transmission URL is invalid")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return errors.New("Transmission URL must use http or https")
+	}
+	if parsed.User != nil {
+		return errors.New("Transmission URL must not include username or password")
+	}
+	if parsed.Fragment != "" {
+		return errors.New("Transmission URL must not include fragment")
 	}
 	return nil
 }

--- a/thirdpart/downloader/transmission/transmission_impl.go
+++ b/thirdpart/downloader/transmission/transmission_impl.go
@@ -363,11 +363,7 @@ func (t *TransmissionClient) GetDiskSpace(ctx context.Context) (int64, error) {
 	// 获取下载目录的可用空间
 	freeSpaceResp, err := t.doRequest("free-space", freeSpaceArgs{Path: downloadDir})
 	if err != nil {
-		// 如果获取磁盘空间失败，记录警告但返回一个大值以允许继续
-		// 这样可以避免因为路径问题导致无法添加种子
-		sLogger().Warnf("Failed to get free space for path %s: %v, assuming sufficient space", downloadDir, err)
-		// 返回 100GB 作为默认值，让种子可以继续添加
-		return 100 * 1024 * 1024 * 1024, nil
+		return 0, fmt.Errorf("failed to get free space for path %s: %w", downloadDir, err)
 	}
 
 	var freeSpace freeSpaceResponse
@@ -377,8 +373,7 @@ func (t *TransmissionClient) GetDiskSpace(ctx context.Context) (int64, error) {
 
 	// 如果返回的空间为 0 或负数，可能是路径问题
 	if freeSpace.SizeBytes <= 0 {
-		sLogger().Warnf("Free space returned %d bytes for path %s, assuming sufficient space", freeSpace.SizeBytes, downloadDir)
-		return 100 * 1024 * 1024 * 1024, nil
+		return 0, fmt.Errorf("free space returned %d bytes for path %s", freeSpace.SizeBytes, downloadDir)
 	}
 
 	return freeSpace.SizeBytes, nil

--- a/thirdpart/downloader/transmission/transmission_impl_test.go
+++ b/thirdpart/downloader/transmission/transmission_impl_test.go
@@ -427,18 +427,15 @@ func TestTransmissionClientGetDiskSpaceWithError(t *testing.T) {
 
 	ctx := context.Background()
 	space, err := client.GetDiskSpace(ctx)
-	// 应该不返回错误，而是返回默认的 100GB
-	if err != nil {
-		t.Fatalf("expected no error when free-space fails, got: %v", err)
+	if err == nil {
+		t.Fatal("expected error when free-space fails")
 	}
-
-	expectedSpace := int64(100 * 1024 * 1024 * 1024) // 100 GB default
-	if space != expectedSpace {
-		t.Errorf("expected default space %d (100GB), got %d", expectedSpace, space)
+	if space != 0 {
+		t.Errorf("expected zero space when free-space fails, got %d", space)
 	}
 }
 
-// TestTransmissionClientCanAddTorrentWithDiskSpaceError 测试磁盘空间检查失败时仍能添加种子
+// TestTransmissionClientCanAddTorrentWithDiskSpaceError 测试磁盘空间检查失败时 fail-closed
 func TestTransmissionClientCanAddTorrentWithDiskSpaceError(t *testing.T) {
 	server := createMockServerWithFreeSpaceError()
 	defer server.Close()
@@ -452,13 +449,12 @@ func TestTransmissionClientCanAddTorrentWithDiskSpaceError(t *testing.T) {
 
 	ctx := context.Background()
 
-	// 即使 free-space 失败，也应该允许添加合理大小的种子
 	canAdd, err := client.CanAddTorrent(ctx, 1024*1024*100) // 100 MB
-	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
+	if err == nil {
+		t.Fatal("expected error when disk space check fails")
 	}
-	if !canAdd {
-		t.Error("expected to be able to add torrent when disk space check fails with default value")
+	if canAdd {
+		t.Error("expected cannot add torrent when disk space check fails")
 	}
 }
 
@@ -686,14 +682,11 @@ func TestTransmissionClientGetDiskSpaceZero(t *testing.T) {
 
 	ctx := context.Background()
 	space, err := client.GetDiskSpace(ctx)
-	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
+	if err == nil {
+		t.Fatal("expected error when free-space returns zero")
 	}
-
-	// 当返回零空间时，应该返回默认的 100GB
-	expectedSpace := int64(100 * 1024 * 1024 * 1024)
-	if space != expectedSpace {
-		t.Errorf("expected default space %d (100GB), got %d", expectedSpace, space)
+	if space != 0 {
+		t.Errorf("expected zero space when free-space returns zero, got %d", space)
 	}
 }
 

--- a/web/api_downloader.go
+++ b/web/api_downloader.go
@@ -2,7 +2,9 @@ package web
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -181,6 +183,11 @@ func (s *Server) createDownloader(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "URL不能为空", http.StatusBadRequest)
 		return
 	}
+	downloaderURL, err := normalizeDownloaderURL(req.URL)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	db := global.GlobalDB.DB
 
@@ -207,7 +214,7 @@ func (s *Server) createDownloader(w http.ResponseWriter, r *http.Request) {
 	downloader := models.DownloaderSetting{
 		Name:        req.Name,
 		Type:        req.Type,
-		URL:         req.URL,
+		URL:         downloaderURL,
 		Username:    req.Username,
 		Password:    req.Password,
 		IsDefault:   req.IsDefault,
@@ -303,7 +310,12 @@ func (s *Server) updateDownloader(w http.ResponseWriter, r *http.Request, id uin
 		downloader.Type = req.Type
 	}
 	if req.URL != "" {
-		downloader.URL = req.URL
+		downloaderURL, err := normalizeDownloaderURL(req.URL)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		downloader.URL = downloaderURL
 	}
 	downloader.Username = req.Username
 	if req.Password != "" {
@@ -334,6 +346,30 @@ func (s *Server) updateDownloader(w http.ResponseWriter, r *http.Request, id uin
 		AutoStart:   downloader.AutoStart,
 		ExtraConfig: downloader.ExtraConfig,
 	})
+}
+
+func normalizeDownloaderURL(rawURL string) (string, error) {
+	value := strings.TrimSpace(rawURL)
+	if value == "" {
+		return "", fmt.Errorf("URL不能为空")
+	}
+	if !strings.Contains(value, "://") {
+		value = "http://" + value
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Scheme == "" || parsed.Hostname() == "" {
+		return "", fmt.Errorf("URL格式无效")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("URL仅支持 http 或 https")
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("URL中请勿包含用户名或密码")
+	}
+	if parsed.Fragment != "" {
+		return "", fmt.Errorf("URL中请勿包含片段标识")
+	}
+	return strings.TrimRight(value, "/"), nil
 }
 
 // deleteDownloader 删除下载器

--- a/web/api_downloader_torrents.go
+++ b/web/api_downloader_torrents.go
@@ -1,16 +1,23 @@
 package web
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/sunerpy/pt-tools/core"
 	"github.com/sunerpy/pt-tools/global"
+	ptinternal "github.com/sunerpy/pt-tools/internal"
+	"github.com/sunerpy/pt-tools/internal/events"
 	"github.com/sunerpy/pt-tools/models"
 	"github.com/sunerpy/pt-tools/thirdpart/downloader"
+	"github.com/sunerpy/pt-tools/thirdpart/downloader/qbit"
 )
 
 type DownloaderTorrentItem struct {
@@ -713,12 +720,28 @@ func (s *Server) apiAddDownloaderTorrent(w http.ResponseWriter, r *http.Request)
 			})
 			continue
 		}
+		reservedSize, guardErr := reserveDownloaderAddDiskBudget(r.Context(), dl, torrentBytes, source)
+		if guardErr != nil {
+			resp.FailedCount++
+			resp.Results = append(resp.Results, AddDownloaderTorrentResult{
+				DownloaderID:   rec.ID,
+				DownloaderName: rec.Name,
+				Success:        false,
+				Message:        guardErr.Error(),
+			})
+			continue
+		}
 
 		var result downloader.AddTorrentResult
 		if len(torrentBytes) > 0 {
 			result, err = dl.AddTorrentFileEx(torrentBytes, opt)
 		} else {
 			result, err = dl.AddTorrentEx(source, opt)
+		}
+		if err != nil || !result.Success {
+			if reservedSize > 0 {
+				ptinternal.GetDiskBudget().Release(reservedSize)
+			}
 		}
 
 		if err != nil {
@@ -732,17 +755,82 @@ func (s *Server) apiAddDownloaderTorrent(w http.ResponseWriter, r *http.Request)
 			continue
 		}
 
-		resp.SuccessCount++
+		if result.Success {
+			resp.SuccessCount++
+		} else {
+			resp.FailedCount++
+		}
 		resp.Results = append(resp.Results, AddDownloaderTorrentResult{
 			DownloaderID:   rec.ID,
 			DownloaderName: rec.Name,
 			Success:        result.Success,
 			TaskID:         result.ID,
 			Hash:           result.Hash,
+			Message:        fmt.Sprint(result.Message),
 		})
 	}
 
 	writeJSON(w, resp)
+}
+
+// reserveDownloaderAddDiskBudget executes the disk-protect gate for the manual
+// "add torrent" endpoint. Returns the reserved torrent size on success (caller
+// is responsible for Releasing it on failure paths). When disk protection is
+// disabled, returns (0, nil) and the caller must NOT call Release.
+//
+// Magnet / URL sources cannot be sized before the metadata is fetched, so they
+// are rejected when disk protection is on. This closes a bypass where a user
+// could submit a magnet and skip the gate entirely.
+func reserveDownloaderAddDiskBudget(ctx context.Context, dl downloader.Downloader, torrentBytes []byte, source string) (int64, error) {
+	glOnly, err := core.NewConfigStore(global.GlobalDB).GetGlobalOnly()
+	if err != nil || !glOnly.CleanupDiskProtect || glOnly.CleanupMinDiskSpaceGB <= 0 {
+		return 0, nil
+	}
+
+	if len(torrentBytes) == 0 {
+		return 0, fmt.Errorf("[磁盘保护] 已启用，无法在添加前确定 magnet/URL 种子大小: %s。请改用 .torrent 文件上传，或在全局设置中关闭磁盘保护。", source)
+	}
+
+	torrentSize, sizeErr := qbit.ComputeTorrentSize(torrentBytes)
+	if sizeErr != nil {
+		return 0, fmt.Errorf("种子文件无效，无法解析大小: %w", sizeErr)
+	}
+
+	mu := ptinternal.PushMutex()
+	mu.Lock()
+	defer mu.Unlock()
+
+	freeSpace, spaceErr := dl.GetClientFreeSpace(ctx)
+	if spaceErr != nil {
+		return 0, fmt.Errorf("[磁盘保护] %s: 获取磁盘空间失败，拒绝添加: %w", dl.GetName(), spaceErr)
+	}
+	pendingBytes, pendingErr := dl.GetIncompletePendingBytes(ctx)
+	if pendingErr != nil {
+		pendingBytes = 0
+	}
+	budget := ptinternal.GetDiskBudget()
+	effectiveFreeBytes := freeSpace - pendingBytes - budget.Reserved()
+	if effectiveFreeBytes < 0 {
+		effectiveFreeBytes = 0
+	}
+	minBytes := int64(glOnly.CleanupMinDiskSpaceGB * 1024 * 1024 * 1024)
+	if effectiveFreeBytes-torrentSize < minBytes {
+		effGB := float64(effectiveFreeBytes) / (1024 * 1024 * 1024)
+		tGB := float64(torrentSize) / (1024 * 1024 * 1024)
+		freeGB := float64(freeSpace) / (1024 * 1024 * 1024)
+		pendingGB := float64(pendingBytes) / (1024 * 1024 * 1024)
+		reservedGB := float64(budget.Reserved()) / (1024 * 1024 * 1024)
+		global.GetSlogger().Warnf("[磁盘保护] %s: 空间不足 (qBit可用 %.1f GB - 下载中待占用 %.1f GB - 本进程预留 %.1f GB = 有效 %.1f GB；有效 - 种子 %.1f GB < 保底 %.1f GB)，跳过手动添加",
+			dl.GetName(), freeGB, pendingGB, reservedGB, effGB, tGB, glOnly.CleanupMinDiskSpaceGB)
+		if glOnly.CleanupEnabled {
+			events.Publish(events.Event{Type: events.DiskSpaceLow, Source: "downloader-add", At: time.Now()})
+		}
+		return 0, fmt.Errorf("磁盘空间不足 (有效 %.1f GB - 种子 %.1f GB < %.1f GB)", effGB, tGB, glOnly.CleanupMinDiskSpaceGB)
+	}
+	if torrentSize > 0 {
+		budget.Reserve(torrentSize)
+	}
+	return torrentSize, nil
 }
 
 func (s *Server) getDownloaderRecordMap() (map[uint]downloaderRecord, error) {

--- a/web/frontend/src/App.vue
+++ b/web/frontend/src/App.vue
@@ -26,10 +26,23 @@ const themeStyleOptions = [
   { label: "翡翠配色", value: "emerald" },
 ];
 
+// 路由 name -> 侧栏菜单 index 的映射。
+// 当路由 name 与菜单 index 不一致（例如详情页、ChatOps 子路由）时在此显式映射。
+const routeNameToMenuIndex: Record<string, string> = {
+  "userinfo-export": "userinfo",
+  "site-detail": "sites",
+  notifications: "chatops/notifications",
+  "notification-detail": "chatops/notifications",
+  bindings: "chatops/bindings",
+  "audit-log": "chatops/audit",
+  "rss-notifications": "chatops/rss-notifications",
+};
+
 const activeMenu = computed(() => {
-  const name = route.name as string;
-  if (name === "site-detail") return "sites";
-  return name || "global";
+  const name = route.name as string | undefined;
+  // 路由尚未就绪（首屏挂载第一帧）时返回空串，避免错误地高亮「全局设置」造成闪烁。
+  if (!name) return "";
+  return routeNameToMenuIndex[name] ?? name;
 });
 const isImmersive = computed(() => route.name === "downloader-hub");
 


### PR DESCRIPTION
## Summary

针对 Issue #299（磁盘保护 race）与 Issue #332（多站点字段同步缺失）的批量修复，并附带若干用户反馈的 RSS / 下载器 / 推送日志类问题。

## Changes

### 磁盘保护 (Issue #299 race 收敛)

- 推送成功后**保留**预留，由 cleanup_monitor 周期 Reset 归还，避免 qBit `torrents/info` 可见性窗口（1~2s）内并发 worker 重复借用同一份磁盘空间
- `cleanup_monitor.runOnce` 的 `Reset` 包入 `internal.PushMutex`，避免与 worker 临界区交错
- DB 缺失 `TorrentSize` 时回退到 `qbit.ComputeTorrentSize` 解析种子文件
- 磁盘保护日志拆分输出 `qBit可用 / 下载中待占用 / 本进程预留 / 有效空间`，解释「为什么 qBit 显示 145GB 但有效只有 29.4GB」
- 手动添加种子 API 加入磁盘保护，magnet/URL 在保护启用时拒绝（无法预先确定大小）
- 默认全局配置启用 `CleanupDiskProtect=true / CleanupMinDiskSpaceGB=50`
- Transmission `GetDiskSpace` 改为 fail-closed（不再假返回 100GB）
- 新增 `TestDiskProtect_RealRSSPath_SuccessKeepsReservation`：5 worker 并发推送的端到端 race 回归

### 站点字段同步 (Issue #332)

基于 issue #321/#323/#301/#250 用户上传的真实 `userdetails.php` DOM 重写选择器：

- nicept / gtkpw / gamegamept：`trueUploaded / trueDownloaded` 从 `传输/傳送` row 内 `<strong>实际上传量/實際上傳量</strong>` 抽取（旧版 `td.rowhead:contains('真实上传量')` 永远命中不到）
- pttime：从 `userdetails.php` 内联 `(xx魔力/小时)` 解析时魔，无需额外 mybonus.php 请求
- mteam：增加 `data.memberCount.trueUploaded / trueDownloaded` JSON 字段映射
- 撤回所有 `seedingSize` 显式选择器，恢复 driver 自动 `FetchSeedingStatus` ajax 兜底（真实 DOM 上做种体积是 ajax 占位符而非静态 HTML）
- `bonusPerHour` 改用 `#outer / #info_block` 容器 + 紧凑正则避免误匹配
- 各站 fixture 测试更新为真实 DOM 形态

### 种子下载与同步稳定性

- 下载响应先用 `qbit.ComputeTorrentHash` 校验为合法 torrent 再落盘；错误信息附带 `status / size / preview`，避免 HTML 错误页被写成 `.torrent` 后续反复触发「计算种子哈希失败」
- mTorrent 详情接口增加按站点 1.2s 本地频控 + 业务错误码识别（HTTP 200 但 `code != 0` 现在会返回错误）
- `UserInfoService` 拒绝空用户名，保存使用 `context.WithoutCancel + 10s` 独立超时避免请求取消污染缓存

### RSS 抓取

- `fetchRSSFeed` 改用浏览器 UA + 30s 超时，修复 Cloudflare-fronted 站点（gtkpw 等）TLS reset
- 新增 `TestFetchRSSFeed_BrowserUserAgent` 断言

### 下载器配置

- qbit / transmission URL 自动补全 `http://` 前缀，拒绝非 http(s) / 含 userinfo / 含 fragment 的输入

### 推送日志降噪

- 推送目标下载器未启用时改为 `Warn`，提示用户切换或启用，避免 `Error` 刷屏

## Verify

- `make fmt` / `make lint` 通过
- `CGO_ENABLED=1 go test -race ./internal/... ./scheduler/... ./web/... ./thirdpart/downloader/...` 通过
- 真实 DOM 选择器验证已离线确认（gamegamept/nicept/gtkpw 真实上传/下载，pttime 时魔）