### PR TITLE
fix(scheduler): 修复部分种子免费期结束后未自动暂停 + 改进发版公告流程

### DIFF
--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -1,0 +1,21 @@
+# Release Announcement Overrides
+
+Files in this directory override the auto-generated GitHub Release body for
+the Telegram release announcement workflow only. The GitHub Release body and
+the project `CHANGELOG.md` are not affected.
+
+## Naming
+
+- `v<X.Y.Z>.md` — matches the git tag exactly (`v0.32.1.md`)
+- `<X.Y.Z>.md` — fallback without the `v` prefix (`0.32.1.md`)
+
+## Workflow
+
+1. Curate a user-facing announcement in Markdown (≤ 600 Chinese characters
+   per `pt-tools-workflow` skill rules).
+2. Commit the file to `dev` alongside the release commits.
+3. Merge the release PR. `telegram-release-announce.yml` reads this file
+   instead of the noisy `release.body` and renders it via
+   `tg_release_announce.py`.
+
+When no override file exists the workflow falls back to `release.body`.

--- a/.github/release-notes/v0.32.1.md
+++ b/.github/release-notes/v0.32.1.md
@@ -1,0 +1,23 @@
+# 🎉 pt-tools v0.32.1 发布
+
+修复用户反馈的「免费期结束没有自动暂停」问题，并改进发版公告流程。
+
+## 🐛 Bug 修复
+
+**自动暂停偶尔不生效**
+
+- **影响**：部分种子在免费期结束后没有被暂停，下载量被记为非免费。
+- **根因**：进度更新模块在 `progress=1.0` 但状态非做种（如 `pausedDL`、`missingFiles`、`checkingResumeData`）时也会标记为已完成，自此该种子被永久排除出免费期暂停监控。
+- **修复**：仅当 `progress=1.0` 且状态为做种/排队中才标记完成；周期巡检（每 5 分钟）现在也会补预约错过的未来过期种子；调度跳过时输出明确日志便于诊断。
+
+## ⚙️ 发版流程改进
+
+- TG 公告现在支持 `.github/release-notes/<tag>.md` 自定义文件，覆盖 release-please 自动生成的脏 body。
+- release-please-config 隐藏 `chore` / `deps` / `ci` / `build` 等非用户可见类型，公告只展示 `feat` / `fix` / `perf` / `revert`。
+
+## ⚙️ 兼容性
+
+- 自动迁移，无需操作
+- 新逻辑在轻微抖动情况下完成判定会延迟一个轮询周期（约 1 分钟），但不会越界
+
+📖 [Release v0.32.1](https://github.com/sunerpy/pt-tools/releases/tag/v0.32.1)

--- a/.github/workflows/telegram-release-announce.yml
+++ b/.github/workflows/telegram-release-announce.yml
@@ -40,6 +40,22 @@ jobs:
             BODY=$(echo "$json" | jq -r '.body // ""')
             URL=$(echo "$json" | jq -r '.html_url')
           fi
+          # Curated announcement override: .github/release-notes/<tag>.md (or
+          # without the leading "v") wins over the release-please-generated
+          # release body, which is prone to dependabot noise + truncated commit
+          # bodies. The override file is committed to the repo before the
+          # release PR is merged so CI can pick it up here.
+          OVERRIDE_PATH=".github/release-notes/${TAG}.md"
+          OVERRIDE_PATH_ALT=".github/release-notes/${TAG#v}.md"
+          if [ -f "$OVERRIDE_PATH" ]; then
+            echo "Using announcement override: $OVERRIDE_PATH"
+            BODY=$(cat "$OVERRIDE_PATH")
+          elif [ -f "$OVERRIDE_PATH_ALT" ]; then
+            echo "Using announcement override: $OVERRIDE_PATH_ALT"
+            BODY=$(cat "$OVERRIDE_PATH_ALT")
+          else
+            echo "No announcement override found; falling back to release body."
+          fi
           {
             echo "tag=$TAG"
             echo "name<<__EOF__"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1045,12 +1045,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **site**: 新增 OpenCD 和 PTT 站点适配
 - 新增 site/v2/definitions/opencd.go 适配 open.cd (繁体 NexusPHP)
   _ 使用 div.title + td.rowtitle 替代标准 h1 + td.rowhead
-  _ 支持 plugin*details.php 链接格式
-  * 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
-  * 处理 font.promotion 替代 img.pro*_ 的非标准折扣标记
-  _ span.category 替代 img[alt] 的分类标记
-  _ 处理 info_block 隐藏列的 nth-child 索引偏移
-  _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
+  _ 支持 plugin\*details.php 链接格式
+  - 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
+  - 处理 font.promotion 替代 img.pro\*_ 的非标准折扣标记
+    _ span.category 替代 img[alt] 的分类标记
+    _ 处理 info_block 隐藏列的 nth-child 索引偏移
+    _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
 
 ## [0.23.0] - 2026-04-29
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,20 @@
   "pull-request-title-pattern": "chore: release ${version}",
   "pull-request-header": "## Release ${version}",
   "separate-pull-requests": false,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+    { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "build", "section": "Build System", "hidden": true },
+    { "type": "ci", "section": "Continuous Integration", "hidden": true },
+    { "type": "deps", "section": "Dependencies", "hidden": true }
+  ],
   "packages": {
     ".": {
       "skip-changelog": true

--- a/scheduler/free_end_monitor.go
+++ b/scheduler/free_end_monitor.go
@@ -135,7 +135,15 @@ func (m *FreeEndMonitor) loadPendingTasksFromDB() error {
 }
 
 func (m *FreeEndMonitor) ScheduleTorrent(torrent models.TorrentInfo) {
-	if !torrent.PauseOnFreeEnd || torrent.FreeEndTime == nil || torrent.DownloaderTaskID == "" {
+	if !torrent.PauseOnFreeEnd {
+		return
+	}
+	if torrent.FreeEndTime == nil {
+		global.GetSlogger().Debugf("[FreeEndMonitor] 跳过调度 (种子:%s, ID:%d): FreeEndTime 为空", torrent.Title, torrent.ID)
+		return
+	}
+	if torrent.DownloaderTaskID == "" {
+		global.GetSlogger().Debugf("[FreeEndMonitor] 跳过调度 (种子:%s, ID:%d): DownloaderTaskID 为空，将由周期巡检兜底", torrent.Title, torrent.ID)
 		return
 	}
 
@@ -147,6 +155,8 @@ func (m *FreeEndMonitor) ScheduleTorrent(torrent models.TorrentInfo) {
 	}
 
 	m.scheduleTaskLocked(torrent)
+	global.GetSlogger().Infof("[FreeEndMonitor] 已调度种子 %s (ID:%d) 的免费结束监控，将在 %v 后检查",
+		torrent.Title, torrent.ID, time.Until(*torrent.FreeEndTime))
 }
 
 func (m *FreeEndMonitor) scheduleTask(torrent models.TorrentInfo) {
@@ -294,11 +304,10 @@ func (m *FreeEndMonitor) updateAllMonitoredProgress() {
 			"check_count":     gorm.Expr("check_count + 1"),
 		}
 
-		if info.Progress >= 1.0 {
+		if isTorrentTrulyCompleted(info) {
 			updates["is_completed"] = true
 			updates["completed_at"] = time.Now()
-			m.CancelTorrent(t.ID)
-			global.GetSlogger().Infof("种子已完成下载: %s (ID:%d)", t.Title, t.ID)
+			global.GetSlogger().Infof("种子已完成下载: %s (ID:%d, state=%s)", t.Title, t.ID, info.State)
 		}
 
 		if err := m.db.Model(&models.TorrentInfo{}).Where("id = ?", t.ID).Updates(updates).Error; err != nil {
@@ -307,6 +316,43 @@ func (m *FreeEndMonitor) updateAllMonitoredProgress() {
 	}
 
 	global.GetSlogger().Debugf("已更新 %d 个种子的下载进度", len(torrents))
+}
+
+// isTorrentTrulyCompleted returns true only when the torrent is *actually*
+// finished from the user's perspective: progress == 1.0 AND the downloader
+// reports a state that means the data is complete (seeding/queued/checking
+// post-download). A 100% progress reading on its own is unreliable because:
+//   - qBit may briefly report progress=1.0 in transient states like
+//     `checkingResumeData` after add, then drop back as files mismatch
+//     (`missingFiles`) — marking complete locks us out of the free-end timer.
+//   - paused/error/missingFiles at 100% means user/downloader interrupted
+//     and we cannot infer "done". Free-end timer must still fire.
+//
+// isTorrentTrulyCompleted returns true only when the torrent is *actually*
+// finished from the user's perspective: progress == 1.0 AND the downloader
+// reports a state that means the data is complete (seeding/queued).
+//
+// Why TorrentChecking is excluded: qBit's mapQbitState collapses
+// checkingDL / checkingUP / checkingResumeData onto a single generic
+// TorrentChecking. checkingResumeData runs *before* downloading on add,
+// so progress=1.0 there is meaningless (it's verifying an unexpectedly
+// pre-existing file, not real completion). Excluding the whole group
+// costs at most one cycle of latency for a torrent in checkingUP, which
+// flips to TorrentSeeding on the next pass anyway.
+//
+// Why TorrentPaused / TorrentError are excluded: a paused-at-100% or
+// missingFiles-at-100% torrent is in a degraded state where we cannot
+// claim completion; the free-end timer must still fire so we can pause
+// it explicitly when the free window closes.
+func isTorrentTrulyCompleted(info downloader.Torrent) bool {
+	if info.Progress < 1.0 {
+		return false
+	}
+	switch info.State {
+	case downloader.TorrentSeeding, downloader.TorrentQueued:
+		return true
+	}
+	return false
 }
 
 func (m *FreeEndMonitor) checkAndProcessExpiredTorrents() {
@@ -332,6 +378,46 @@ func (m *FreeEndMonitor) checkAndProcessExpiredTorrents() {
 			defer m.wg.Done()
 			m.handleFreeEndedTorrent(torrent)
 		}(t)
+	}
+
+	m.rescheduleMissingFutureTorrents(now)
+}
+
+// rescheduleMissingFutureTorrents catches torrents that should have an
+// in-process timer but don't — e.g. when the initial Schedule call was
+// missed because DownloaderTaskID hadn't been written yet, or a process
+// restart dropped the timer for a row whose loadPendingTasksFromDB
+// excluded it (transient is_paused_by_system / is_completed flag, etc.).
+//
+// Without this safety net, a future-expiring torrent missed by the
+// in-memory scheduler would only be picked up after free_end_time has
+// already passed (worst case: 5 minutes of non-free download before
+// pause). Calling ScheduleTorrent is idempotent (it returns early when
+// the torrent is already in pendingTasks), so this is a cheap reconcile.
+func (m *FreeEndMonitor) rescheduleMissingFutureTorrents(now time.Time) {
+	var torrents []models.TorrentInfo
+	err := m.db.Where(
+		"pause_on_free_end = ? AND is_paused_by_system = ? AND is_completed = ? AND free_end_time IS NOT NULL AND free_end_time > ? AND downloader_task_id != ''",
+		true, false, false, now,
+	).Find(&torrents).Error
+	if err != nil {
+		global.GetSlogger().Errorf("查询待补预约种子失败: %v", err)
+		return
+	}
+
+	rescheduled := 0
+	m.mu.Lock()
+	for _, t := range torrents {
+		if _, exists := m.pendingTasks[t.ID]; exists {
+			continue
+		}
+		m.scheduleTaskLocked(t)
+		rescheduled++
+	}
+	m.mu.Unlock()
+
+	if rescheduled > 0 {
+		global.GetSlogger().Infof("[FreeEndMonitor] 周期巡检：补预约了 %d 个未在内存中的未来过期种子", rescheduled)
 	}
 }
 
@@ -449,7 +535,7 @@ func (m *FreeEndMonitor) checkTorrentCompletion(_ context.Context, dl downloader
 	}
 
 	progress := info.Progress * 100
-	return info.Progress >= 1.0, progress, info.TotalSize, nil
+	return isTorrentTrulyCompleted(info), progress, info.TotalSize, nil
 }
 
 func (m *FreeEndMonitor) pauseTorrentWithRetry(ctx context.Context, dl downloader.Downloader, torrent models.TorrentInfo) error {
@@ -768,10 +854,10 @@ func (m *FreeEndMonitor) updateAllPushedTasksProgress() {
 			"check_count":     gorm.Expr("check_count + 1"),
 		}
 
-		if info.Progress >= 1.0 {
+		if isTorrentTrulyCompleted(info) {
 			updates["is_completed"] = true
 			updates["completed_at"] = time.Now()
-			global.GetSlogger().Infof("任务已完成下载 (ID:%d, Title:%s)", t.ID, t.Title)
+			global.GetSlogger().Infof("任务已完成下载 (ID:%d, Title:%s, state=%s)", t.ID, t.Title, info.State)
 		}
 
 		if err := m.db.Model(&models.TorrentInfo{}).Where("id = ?", t.ID).Updates(updates).Error; err != nil {

--- a/scheduler/free_end_monitor_test.go
+++ b/scheduler/free_end_monitor_test.go
@@ -39,9 +39,19 @@ func createMockQBitServer(t *testing.T, progress float64, paused bool) *httptest
 			_, _ = w.Write([]byte(`{"server_state":{"free_space_on_disk":10000000000}}`))
 		case "/api/v2/torrents/info":
 			w.WriteHeader(http.StatusOK)
+			// qBit reports `uploading`/`stalledUP` once a torrent reaches
+			// progress=1.0, never `downloading`. Mirroring that here keeps
+			// the fixtures aligned with isTorrentTrulyCompleted's contract.
 			state := "downloading"
+			if progress >= 1.0 {
+				state = "uploading"
+			}
 			if paused {
-				state = "pausedDL"
+				if progress >= 1.0 {
+					state = "pausedUP"
+				} else {
+					state = "pausedDL"
+				}
 			}
 			_, _ = w.Write([]byte(`[{"hash":"test-hash-123","name":"Test Torrent","progress":` +
 				floatToString(progress) + `,"state":"` + state + `","size":1073741824}]`))
@@ -654,4 +664,180 @@ func TestFreeEndMonitor_CheckTorrentCompletion(t *testing.T) {
 
 func ptrTime(t time.Time) *time.Time {
 	return &t
+}
+
+// createMockQBitServerWithState pins the exact qBit `state` value returned
+// for a given progress, so tests can assert behavior on noise states like
+// `pausedDL` or `missingFiles` at progress=1.0.
+func createMockQBitServerWithState(t *testing.T, progress float64, state string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/sync/maindata":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"server_state":{"free_space_on_disk":10000000000}}`))
+		case "/api/v2/torrents/info":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"hash":"test-hash-123","name":"Test Torrent","progress":` +
+				floatToString(progress) + `,"state":"` + state + `","size":1073741824}]`))
+		case "/api/v2/torrents/pause":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+}
+
+// TestFreeEndMonitor_UpdateProgress_DoesNotMarkCompletedOnNoiseStates asserts
+// that progress=1.0 in non-seeding states must NOT flip is_completed. Marking
+// completed cancels the timer and excludes the row from every later free-end
+// query, so the user reports "种子没有自动暂停".
+func TestFreeEndMonitor_UpdateProgress_DoesNotMarkCompletedOnNoiseStates(t *testing.T) {
+	noiseStates := []string{"pausedDL", "stoppedDL", "error", "missingFiles", "checkingResumeData"}
+	for _, state := range noiseStates {
+		t.Run(state, func(t *testing.T) {
+			db := setupTestDB(t)
+			srv := createMockQBitServerWithState(t, 1.0, state)
+			defer srv.Close()
+			dlMgr := setupTestDownloaderManager(t, srv)
+
+			monitor := NewFreeEndMonitor(db.DB, dlMgr)
+
+			freeEndTime := time.Now().Add(1 * time.Hour)
+			isPushed := true
+			torrent := models.TorrentInfo{
+				SiteName:         "test-site",
+				TorrentID:        "tid-" + state,
+				Title:            "noise-" + state,
+				PauseOnFreeEnd:   true,
+				FreeEndTime:      &freeEndTime,
+				DownloaderTaskID: "test-hash-123",
+				DownloaderName:   "test-qbit",
+				IsPushed:         &isPushed,
+			}
+			require.NoError(t, db.DB.Create(&torrent).Error)
+
+			monitor.updateAllMonitoredProgress()
+
+			var got models.TorrentInfo
+			require.NoError(t, db.DB.First(&got, torrent.ID).Error)
+			assert.False(t, got.IsCompleted,
+				"progress=1.0 in noise state %q must NOT mark is_completed; doing so locks the torrent out of the free-end timer permanently",
+				state)
+		})
+	}
+}
+
+// TestFreeEndMonitor_UpdateProgress_MarksCompletedOnSeedingStates is the
+// positive complement of the noise-state test: a torrent at progress=1.0 in a
+// real seeding state must be marked completed.
+func TestFreeEndMonitor_UpdateProgress_MarksCompletedOnSeedingStates(t *testing.T) {
+	for _, state := range []string{"uploading", "stalledUP", "forcedUP"} {
+		t.Run(state, func(t *testing.T) {
+			db := setupTestDB(t)
+			srv := createMockQBitServerWithState(t, 1.0, state)
+			defer srv.Close()
+			dlMgr := setupTestDownloaderManager(t, srv)
+
+			monitor := NewFreeEndMonitor(db.DB, dlMgr)
+
+			freeEndTime := time.Now().Add(1 * time.Hour)
+			isPushed := true
+			torrent := models.TorrentInfo{
+				SiteName:         "test-site",
+				TorrentID:        "tid-seed-" + state,
+				Title:            "seed-" + state,
+				PauseOnFreeEnd:   true,
+				FreeEndTime:      &freeEndTime,
+				DownloaderTaskID: "test-hash-123",
+				DownloaderName:   "test-qbit",
+				IsPushed:         &isPushed,
+			}
+			require.NoError(t, db.DB.Create(&torrent).Error)
+
+			monitor.updateAllMonitoredProgress()
+
+			var got models.TorrentInfo
+			require.NoError(t, db.DB.First(&got, torrent.ID).Error)
+			assert.True(t, got.IsCompleted,
+				"progress=1.0 in seeding state %q should mark is_completed",
+				state)
+		})
+	}
+}
+
+// TestFreeEndMonitor_PeriodicCheck_RescheduleMissingFutureTorrents asserts the
+// 5-minute periodic sweep also covers torrents whose initial Schedule call
+// never fired (push happened before monitor wired up, restart loss, etc.).
+// Without it, a missed schedule means free-end pause is delayed until the
+// torrent is already past its free window.
+func TestFreeEndMonitor_PeriodicCheck_RescheduleMissingFutureTorrents(t *testing.T) {
+	db := setupTestDB(t)
+	srv := createMockQBitServer(t, 0.5, false)
+	defer srv.Close()
+	dlMgr := setupTestDownloaderManager(t, srv)
+
+	monitor := NewFreeEndMonitor(db.DB, dlMgr)
+
+	freeEndTime := time.Now().Add(2 * time.Hour)
+	isPushed := true
+	torrent := models.TorrentInfo{
+		SiteName:         "test-site",
+		TorrentID:        "future-1",
+		Title:            "future-pending",
+		PauseOnFreeEnd:   true,
+		FreeEndTime:      &freeEndTime,
+		DownloaderTaskID: "test-hash-123",
+		DownloaderName:   "test-qbit",
+		IsPushed:         &isPushed,
+	}
+	require.NoError(t, db.DB.Create(&torrent).Error)
+
+	monitor.mu.Lock()
+	_, alreadyScheduled := monitor.pendingTasks[torrent.ID]
+	monitor.mu.Unlock()
+	require.False(t, alreadyScheduled, "precondition: torrent must NOT be scheduled before periodicCheck runs")
+
+	monitor.checkAndProcessExpiredTorrents()
+
+	monitor.mu.Lock()
+	task, scheduled := monitor.pendingTasks[torrent.ID]
+	monitor.mu.Unlock()
+	require.True(t, scheduled, "periodic check must reschedule a future-expiring torrent that was missed by the initial Schedule")
+	require.NotNil(t, task)
+	require.NotNil(t, task.timer)
+	task.timer.Stop()
+	if task.cancel != nil {
+		task.cancel()
+	}
+}
+
+// TestFreeEndMonitor_ScheduleTorrent_LogsSkipReason guards observability:
+// when ScheduleTorrent no-ops on missing prerequisites the call must not
+// silently return — operators rely on a log line to grep for "跳过调度" when
+// diagnosing "this torrent never got a free-end timer".
+func TestFreeEndMonitor_ScheduleTorrent_LogsSkipReason(t *testing.T) {
+	db := setupTestDB(t)
+	srv := createMockQBitServer(t, 0.5, false)
+	defer srv.Close()
+	dlMgr := setupTestDownloaderManager(t, srv)
+	monitor := NewFreeEndMonitor(db.DB, dlMgr)
+
+	freeEnd := time.Now().Add(1 * time.Hour)
+
+	monitor.ScheduleTorrent(models.TorrentInfo{ID: 100, Title: "missing-task-id", PauseOnFreeEnd: true, FreeEndTime: &freeEnd, DownloaderTaskID: ""})
+	monitor.mu.Lock()
+	_, scheduled := monitor.pendingTasks[100]
+	monitor.mu.Unlock()
+	require.False(t, scheduled, "torrent without DownloaderTaskID must not be scheduled")
+
+	monitor.ScheduleTorrent(models.TorrentInfo{ID: 101, Title: "missing-free-end", PauseOnFreeEnd: true, FreeEndTime: nil, DownloaderTaskID: "x"})
+	monitor.mu.Lock()
+	_, scheduled = monitor.pendingTasks[101]
+	monitor.mu.Unlock()
+	require.False(t, scheduled, "torrent without FreeEndTime must not be scheduled")
 }


### PR DESCRIPTION
## Summary

修复用户反馈的「免费期结束后种子没有自动暂停」问题，并改进 v0.32.0 暴露的发版公告噪音问题。

## fix(scheduler): 自动暂停 3 个真实 bug

### Bug 2 — 进度抖动误标 is_completed（最致命）

旧逻辑只看 `progress >= 1.0` 就标记 `is_completed=true`。但 qBit 在以下状态下也可能短暂出现 `progress=1.0`：

- `pausedDL` / `stoppedDL`：用户主动暂停的下载中种子
- `missingFiles`：文件丢失/路径错误
- `checkingResumeData`：添加种子后预校验，可能短暂报满进度
- `error`：磁盘/网络异常

一旦被误标，该行被永久排除出 `loadPendingTasksFromDB` / `periodicCheck` / `updateAllMonitoredProgress` 的所有查询，定时器也被 `CancelTorrent` 取消，**该种子永久不会被免费期暂停**。

修复：新增 `isTorrentTrulyCompleted` 同时校验 `Progress >= 1.0` AND `State ∈ {Seeding, Queued}`，并移除完成路径上的 `CancelTorrent`。

### Bug 3 — periodicCheck 不预约未来过期种子

旧 `checkAndProcessExpiredTorrents` 只处理 `free_end_time <= now` 的种子。如果初始 `Schedule` 调用因为 `DownloaderTaskID` 写入慢、push 早于 monitor 启动、进程重启等原因丢失，未来过期的种子要等 `free_end_time` 过去后再 5 分钟才会被处理。

修复：新增 `rescheduleMissingFutureTorrents`，每次 periodicCheck 顺手扫描未来过期且不在 `pendingTasks` 的种子并补预约。`ScheduleTorrent` 是幂等的所以重复调用安全。

### Bug 1 — ScheduleTorrent 静默 no-op

调度跳过时静默返回，运维无法定位「这个种子为什么没有定时器」。

修复：跳过时输出 Debug 日志（缺 `FreeEndTime` 或 `DownloaderTaskID` 各自独立提示），成功调度时升级到 Info 级别。

### 测试

- `TestFreeEndMonitor_UpdateProgress_DoesNotMarkCompletedOnNoiseStates`：5 种噪音状态在 progress=1.0 不应标记完成
- `TestFreeEndMonitor_UpdateProgress_MarksCompletedOnSeedingStates`：3 种真实做种状态应标记完成
- `TestFreeEndMonitor_PeriodicCheck_RescheduleMissingFutureTorrents`：补预约逻辑回归
- `TestFreeEndMonitor_ScheduleTorrent_LogsSkipReason`：跳过路径不进入 pendingTasks

`createMockQBitServer` 也修正为 progress=1.0 时返回 `uploading`，与真实 qBit 语义对齐。

## build(release): 公告流程改进

v0.32.0 暴露的两个问题：

1. release-please 把 6 个 dependabot deps PR body 全文塞进 release.body，TG 公告变成一大坨 dependency noise。
2. 我审过的精简公告**根本没有路径**进入 TG 工作流——脚本永远读 `release.body`。

### 修复

- **`release-please-config.json`**：增加 `changelog-sections`，把 `chore` / `docs` / `style` / `refactor` / `test` / `build` / `ci` / `deps` 全部 `hidden=true`，仅保留 `feat` / `fix` / `perf` / `revert` 进入 release body。
- **`.github/workflows/telegram-release-announce.yml`**：在读取 `release.body` 之前先尝试加载 `.github/release-notes/<tag>.md`（或不带 `v` 前缀的 `<tag>.md`）。存在则覆盖，缺失则维持原行为。
- **`.github/release-notes/`**：新增目录 + README，预置 `v0.32.1.md` 作为本次发版公告。

## Verify

- `make fmt` / `make lint` 通过
- `CGO_ENABLED=1 go test -race ./scheduler/... ./internal/... ./web/... ./thirdpart/downloader/...` 通过
- 4 组新增 free-end 测试通过，包含 noise-state 与补预约场景