### PR TITLE
docs(release-notes): 合并 v0.32.0 公告至 v0.32.1

### DIFF
--- a/.github/release-notes/v0.32.1.md
+++ b/.github/release-notes/v0.32.1.md
@@ -1,23 +1,32 @@
-# 🎉 pt-tools v0.32.1 发布
+# 🎉 pt-tools v0.32.0 + v0.32.1 发布
 
-修复用户反馈的「免费期结束没有自动暂停」问题，并改进发版公告流程。
+批量修复磁盘保护、站点同步、自动暂停等用户反馈问题，并改进发版公告流程。
 
-## 🐛 Bug 修复
+🐛 **磁盘保护并发 race**（Issue #299）
+多 worker 并发推送时可能重复借用空间。推送成功后保留预留，手动添加接口接入保护，magnet/URL 在保护启用时拒绝。
 
-**自动暂停偶尔不生效**
+🐛 **磁盘空间日志不解释**
+日志拆分为 `qBit可用 - 下载中待占用 - 本进程预留 = 有效空间`。
 
-- **影响**：部分种子在免费期结束后没有被暂停，下载量被记为非免费。
-- **根因**：进度更新模块在 `progress=1.0` 但状态非做种（如 `pausedDL`、`missingFiles`、`checkingResumeData`）时也会标记为已完成，自此该种子被永久排除出免费期暂停监控。
-- **修复**：仅当 `progress=1.0` 且状态为做种/排队中才标记完成；周期巡检（每 5 分钟）现在也会补预约错过的未来过期种子；调度跳过时输出明确日志便于诊断。
+🐛 **5 站点用户数据同步缺失**（Issue #332）
+基于真实 DOM 重写选择器，覆盖 NicePT / PTtime / GameGamePT / GTKPW / M-Team。
 
-## ⚙️ 发版流程改进
+🐛 **GTKPW RSS 连接被重置**
+改用浏览器 UA + 30s 超时。
 
-- TG 公告现在支持 `.github/release-notes/<tag>.md` 自定义文件，覆盖 release-please 自动生成的脏 body。
-- release-please-config 隐藏 `chore` / `deps` / `ci` / `build` 等非用户可见类型，公告只展示 `feat` / `fix` / `perf` / `revert`。
+🐛 **种子哈希计算失败提示不清**
+下载后先校验合法再落盘。
 
-## ⚙️ 兼容性
+🐛 **自动暂停偶尔不生效**（v0.32.1 新修）
+`progress=1.0` 但状态非做种（pausedDL / missingFiles / checkingResumeData）会被误标完成而永久排除出监控。现仅做种/排队中才标记完成；周期巡检补预约错过的未来过期种子。
 
-- 自动迁移，无需操作
-- 新逻辑在轻微抖动情况下完成判定会延迟一个轮询周期（约 1 分钟），但不会越界
+✨ 体验改进
 
-📖 [Release v0.32.1](https://github.com/sunerpy/pt-tools/releases/tag/v0.32.1)
+- 侧栏刷新不再闪过「全局设置」
+- 下载器被禁用改为 Warn，不再 Error 刷屏
+- 下载器 URL 自动补 `http://`
+- Transmission 磁盘检查改为 fail-closed
+- 默认启用磁盘保护（保底 50GB），老用户开关保持原值
+- TG 公告支持 `.github/release-notes/<tag>.md` 覆盖，发版噪音
+
+📖 [v0.32.0](https://github.com/sunerpy/pt-tools/releases/tag/v0.32.0) · [v0.32.1](https://github.com/sunerpy/pt-tools/releases/tag/v0.32.1)


### PR DESCRIPTION
v0.32.0 公告被 release-please 自动 body 污染，TG 收到的是带 dependabot 噪音的版本。本次发版改为合并版公告（v0.32.0 + v0.32.1 一起对外），通过新引入的 .github/release-notes/v0.32.1.md 覆盖路径。

- 字数 ≈ 365 中文字符，符合 ≤ 400 字限制
- docs 类型在 release-please-config 中已 hidden=true，不会污染 release notes
- 必须在 Release PR #354 合并前进入 main，否则 v0.32.1 tag 上的文件还是单版本旧内容