### PR TITLE
chore(extension): 发布 0.2.2 验证 API 发布路径

### DIFF
--- a/tools/browser-extension/package.json
+++ b/tools/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt-tools-browser-extension",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "PT Tools Helper browser extension",
   "type": "module",

--- a/tools/browser-extension/src/manifest.ts
+++ b/tools/browser-extension/src/manifest.ts
@@ -1,7 +1,7 @@
 export const manifest = {
   manifest_version: 3,
   name: "__MSG_extensionName__",
-  version: "0.2.1",
+  version: "0.2.2",
   description: "__MSG_extensionDescription__",
   default_locale: "zh_CN",
   permissions: ["storage", "activeTab", "scripting"],


### PR DESCRIPTION
## Summary

纯版本号 bump（0.2.1 → 0.2.2），作为 stuck-draft hypothesis 的判别实验。

## Background

0.2.1 通过 Partner Center Web UI 手动提交，目前已 InReview。在此之前，从 0.2.0 开始的两次 CI API 上传都收到了 `status: Failed, errorCode: null, errors: null` 这种屏蔽掉真实错误的反馈。

Oracle 分析了三种 hypothesis：
- **(a) Stuck-draft 状态机错配 (~70%)**：Microsoft 服务端 `draftsubmission` 槽位卡在 0.1.0 元数据上，public API 没有清理它的方式
- **(c) 后端流水线差异 (~20%)**：Web UI 比 API 的验证流水线更宽松或会自动归一化 zip 内容
- **(b) 隐私表必填**：已被反证（填完表 API 仍失败）

完整诊断见 [上一轮分析](https://github.com/sunerpy/pt-tools/pull/358)。

## Experiment

0.2.1 Web UI 提交已经把 stuck draft 槽位消费掉了：
- `GET /api/Package/{ID}/lastUploadedPackage` 现在返回 404（之前返回 0.1.0）
- `GET /api/.../overview/submissions` 不再有 `draftsubmission` 条目

如果 hypothesis (a) 正确，0.2.2 通过 API 上传现在应该成功 —— 没有卡住的 draft 可冲突。

## Diff

仅 2 行：
- `tools/browser-extension/package.json`: `0.2.1` → `0.2.2`
- `tools/browser-extension/src/manifest.ts`: `0.2.1` → `0.2.2`

无任何代码 / 行为改动。zip 字节内容与 0.2.1 的差异仅限 manifest 中的 version 字段。

## Predictions

合并并打 `ext-v0.2.2` tag 后：

| 结果 | 含义 | 后续动作 |
|---|---|---|
| publish-edge job 全绿，商店 InReview | hypothesis (a) 验证 | 写入 RELEASE.md：未来全部走 API；首次切换 API 后 stuck draft 不会再出现 |
| 仍报 `status=Failed errorCode=null` | hypothesis (c) 占主导 | 申请 Microsoft 工单引用 OperationID；研究 zip 内容差异（locale 归一化、签名等） |
| 走到 publish 但 publish 阶段 Failed | 中间路径，可能是 publish 端的另一个状态机问题 | 单独排查 |

## Workflow self-test

附带验证今天提交的 [Location-header 解析 + fail-fast 修复](https://github.com/sunerpy/pt-tools/pull/356) 在新流程下仍然工作正确：
- 上传成功 → 应输出 `Upload OperationID: <uuid>`
- 轮询应输出 `status=Succeeded` 而不是 `Unknown` 反复