### PR TITLE
fix(ci): Edge 商店 InReview 阻塞时软失败而非硬失败

### DIFF
--- a/.github/workflows/extension-publish.yml
+++ b/.github/workflows/extension-publish.yml
@@ -150,6 +150,12 @@ jobs:
           EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
           EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
           EDGE_PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
+        # 区分两种 Failed：
+        #   - 快速 Failed (<5s, errorCode/errors 都为 null)：通常是
+        #     Microsoft 拒绝原因为「product 已经有 InReview 的 submission」，
+        #     或其它前置状态机锁。无法通过 Public API 自愈，需等前一次审核完成。
+        #     此时输出 warning 并以 exit code 0 退出（视为软失败），不阻塞后续 release artifact。
+        #   - 慢速或 errorCode 非空：真实包错误，硬失败。
         run: |
           set -euo pipefail
           if [ -z "${UPLOAD_OPERATION_ID:-}" ]; then
@@ -157,6 +163,8 @@ jobs:
             exit 1
           fi
           STATUS=""
+          STATUS_RESPONSE=""
+          STARTED_AT=$(date +%s)
           for i in $(seq 1 30); do
             sleep 10
             STATUS_RESPONSE=$(curl -sS \
@@ -169,20 +177,41 @@ jobs:
 
             if [ "$STATUS" = "Succeeded" ]; then
               echo "Upload processing complete"
+              echo "UPLOAD_SOFT_FAIL=false" >> "$GITHUB_ENV"
               break
             elif [ "$STATUS" = "Failed" ]; then
-              echo "::error::Upload processing failed"
+              ELAPSED=$(( $(date +%s) - STARTED_AT ))
+              ERROR_CODE=$(echo "$STATUS_RESPONSE" | grep -oP '"errorCode"\s*:\s*"\K[^"]+' || echo "")
+              HAS_ERRORS=$(echo "$STATUS_RESPONSE" | grep -oP '"errors"\s*:\s*\[\K[^]]*' || echo "")
+
+              echo "::group::Failure response"
               echo "$STATUS_RESPONSE"
+              echo "::endgroup::"
+              echo "Elapsed: ${ELAPSED}s, errorCode=${ERROR_CODE:-<null>}, errors=[${HAS_ERRORS:-<empty>}]"
+
+              if [ "$ELAPSED" -lt 5 ] && [ -z "$ERROR_CODE" ] && [ -z "$HAS_ERRORS" ]; then
+                echo "::warning::Edge API quickly rejected upload (status=Failed within ${ELAPSED}s, no errorCode/errors)."
+                echo "::warning::Most likely cause: previous submission for this product is still InReview."
+                echo "::warning::Edge enforces serialized submissions: only one in-flight submission per product is allowed."
+                echo "::warning::Action: wait for previous submission to reach InExtensionStore (Live) state, then re-trigger this workflow via:"
+                echo "::warning::  gh workflow run extension-publish.yml --ref main"
+                echo "::warning::Skipping publish for now. Release artifact (zip + GitHub Release) was still created."
+                echo "UPLOAD_SOFT_FAIL=true" >> "$GITHUB_ENV"
+                break
+              fi
+
+              echo "::error::Upload processing failed (real package error: errorCode=${ERROR_CODE:-<null>}, elapsed=${ELAPSED}s)"
               exit 1
             fi
           done
-          if [ "$STATUS" != "Succeeded" ]; then
+          if [ "$STATUS" != "Succeeded" ] && [ "${UPLOAD_SOFT_FAIL:-false}" != "true" ]; then
             echo "::error::Upload processing did not reach Succeeded after 30 polls (last status: ${STATUS:-<empty>})"
             echo "Last response: $STATUS_RESPONSE"
             exit 1
           fi
 
       - name: Publish submission
+        if: env.UPLOAD_SOFT_FAIL != 'true'
         env:
           EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
           EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
@@ -222,6 +251,7 @@ jobs:
           echo "PUBLISH_OPERATION_ID=$PUBLISH_OPERATION_ID" >> "$GITHUB_ENV"
 
       - name: Wait for publish processing
+        if: env.UPLOAD_SOFT_FAIL != 'true'
         env:
           EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
           EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}


### PR DESCRIPTION
## Summary

判别实验 0.2.2 验证了 Oracle 的修正假设：**Edge Public API 不允许 product 同时存在多个 in-flight submission**。Workflow 改为软失败 + 手动 `workflow_dispatch` 重试模式，避免 release pipeline 被 InReview 阻塞误判为 broken。

## Experiment Result

| 时间 | 场景 | 失败时间 | 状态机阶段 |
|---|---|---|---|
| 0.2.0 last week | stuck draft + 隐私表未填 | ~10s (InProgress→Failed) | 异步处理失败 |
| 0.2.1 today | stuck draft + 隐私表已填 | ~10s (InProgress→Failed) | 异步处理失败 |
| 0.2.1 Web UI | NO draft, 0.1.0 InExtensionStore | ✅ 成功 | — |
| **0.2.2 today** | **NO draft, 0.2.1 InReview** | **<1s (Failed 立即)** | **同步前置检查失败** |

签名一致：`status=Failed, errorCode=null, errors=null`，但**1s vs 10s 的时间差**揭示了两个不同的拒绝路径，统一规则是 "product 不在 ready-to-receive 状态"。

## Change

`.github/workflows/extension-publish.yml` 中 `Wait for upload processing` 步骤增加分支判断：

```bash
if [ "$ELAPSED" -lt 5 ] && [ -z "$ERROR_CODE" ] && [ -z "$HAS_ERRORS" ]; then
  # 同步前置条件失败 — 极可能 InReview 阻塞
  echo "::warning::..."
  echo "UPLOAD_SOFT_FAIL=true" >> "$GITHUB_ENV"
  break
fi
echo "::error::Upload processing failed (real package error)"
exit 1
```

并给 Publish + Wait-for-publish 两步加 `if: env.UPLOAD_SOFT_FAIL != 'true'` 跳过保护。

## Behavior Matrix

| 场景 | 旧行为 | 新行为 |
|---|---|---|
| 上传成功，发布成功 | ✅ exit 0 | ✅ exit 0 |
| 上传 Failed，慢速（>5s）或带 errorCode | ❌ exit 1 | ❌ exit 1（不变） |
| 上传 Failed，<5s 且 null errorCode/errors | ❌ exit 1（误以为包错误） | ⚠️ exit 0（warning + 操作指引），跳过 Publish |
| HTTP ≠ 202 | ❌ exit 1 | ❌ exit 1（不变） |
| 30 次轮询都未 Succeeded | ❌ exit 1 | ❌ exit 1（不变） |

## 操作指引（已在 warning 中输出）

前一次 submission 进入 `InExtensionStore` (Live) 后：
```bash
gh workflow run extension-publish.yml --ref main
```
即可手动重新发布当前 main 上的版本，无需重新打 tag。

## Why not precheck?

Oracle 评估了"上传前预检 submission 状态"的方案：
- Public API **没有 `/v1/products/{ID}/submissions` 列出 in-flight 的 endpoint**（doc 仅有 `/draft/package` 和单个 submission/operation 状态查询）
- 内部 Cookie 鉴权 endpoint `/api/.../overview/submissions` 不能用 API key（且 Cookie 会过期，ToS 灰色）
- 因此采用「乐观尝试 + 失败软退」的方案是当前可达的最佳实现

## Confidence

Hypothesis ~85%（Oracle 估计）。完全确认需要等 0.2.1 进入 `InExtensionStore` 后再触发 `workflow_dispatch`：
- 若成功 → 假设确认，未来连续发布需遵守串行规则
- 若仍失败 → 还有别的前置条件，需要进一步排查（可能要发 Microsoft 工单引用 OperationID `78d6ff58-19cd-4a2e-9aec-8f1ff9080ab7`）