### PR TITLE
fix(qbit): 检测到 HTML 响应时拒绝认证，避免错误 URL 静默通过

### DIFF
--- a/.github/workflows/extension-publish.yml
+++ b/.github/workflows/extension-publish.yml
@@ -151,11 +151,12 @@ jobs:
           EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
           EDGE_PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
         # 区分两种 Failed：
-        #   - 快速 Failed (<5s, errorCode/errors 都为 null)：通常是
+        #   - Edge 返回通用失败 message，且 errorCode/errors 都为 null：通常是
         #     Microsoft 拒绝原因为「product 已经有 InReview 的 submission」，
-        #     或其它前置状态机锁。无法通过 Public API 自愈，需等前一次审核完成。
+        #     或其它前置状态机锁。实测该失败可能在 1s 内返回，也可能在 30s 左右返回；
+        #     无法通过 Public API 自愈，需等前一次审核完成。
         #     此时输出 warning 并以 exit code 0 退出（视为软失败），不阻塞后续 release artifact。
-        #   - 慢速或 errorCode 非空：真实包错误，硬失败。
+        #   - errorCode 或 errors 非空：真实包错误，硬失败。
         run: |
           set -euo pipefail
           if [ -z "${UPLOAD_OPERATION_ID:-}" ]; then
@@ -181,16 +182,17 @@ jobs:
               break
             elif [ "$STATUS" = "Failed" ]; then
               ELAPSED=$(( $(date +%s) - STARTED_AT ))
+              MESSAGE=$(echo "$STATUS_RESPONSE" | grep -oP '"message"\s*:\s*"\K[^"]+' || echo "")
               ERROR_CODE=$(echo "$STATUS_RESPONSE" | grep -oP '"errorCode"\s*:\s*"\K[^"]+' || echo "")
               HAS_ERRORS=$(echo "$STATUS_RESPONSE" | grep -oP '"errors"\s*:\s*\[\K[^]]*' || echo "")
 
               echo "::group::Failure response"
               echo "$STATUS_RESPONSE"
               echo "::endgroup::"
-              echo "Elapsed: ${ELAPSED}s, errorCode=${ERROR_CODE:-<null>}, errors=[${HAS_ERRORS:-<empty>}]"
+              echo "Elapsed: ${ELAPSED}s, message=${MESSAGE:-<empty>}, errorCode=${ERROR_CODE:-<null>}, errors=[${HAS_ERRORS:-<empty>}]"
 
-              if [ "$ELAPSED" -lt 5 ] && [ -z "$ERROR_CODE" ] && [ -z "$HAS_ERRORS" ]; then
-                echo "::warning::Edge API quickly rejected upload (status=Failed within ${ELAPSED}s, no errorCode/errors)."
+              if [ -z "$ERROR_CODE" ] && [ -z "$HAS_ERRORS" ] && [ "$MESSAGE" = "An error occurred while performing the operation" ]; then
+                echo "::warning::Edge API rejected upload with opaque failure (elapsed ${ELAPSED}s, no errorCode/errors)."
                 echo "::warning::Most likely cause: previous submission for this product is still InReview."
                 echo "::warning::Edge enforces serialized submissions: only one in-flight submission per product is allowed."
                 echo "::warning::Action: wait for previous submission to reach InExtensionStore (Live) state, then re-trigger this workflow via:"

--- a/thirdpart/downloader/qbit/qbit_impl.go
+++ b/thirdpart/downloader/qbit/qbit_impl.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -51,6 +52,40 @@ type QbitTorrentProperties struct {
 
 // 确保 QbitClient 实现 Downloader 接口
 var _ downloader.Downloader = (*QbitClient)(nil)
+
+// errWrongServer indicates the WebAPI response was HTML, meaning the URL
+// almost certainly points at a non-qBit server. Callers should propagate
+// this rather than falling back to legacy mode.
+var errWrongServer = fmt.Errorf("downloader URL does not point to qBittorrent")
+
+// looksLikeHTML reports whether the given body is HTML rather than a qBit
+// WebAPI response. qBit's API responses are plain text (`Ok.`, `Fails.`,
+// version strings) or JSON. Receiving HTML means the request hit a non-qBit
+// endpoint — typically because the configured URL points at a different web
+// server (e.g. pt-tools' own Web UI), or a reverse proxy intercepted an
+// auth failure with a custom error page.
+func looksLikeHTML(body []byte) bool {
+	trimmed := bytes.TrimLeft(body, " \t\r\n\xef\xbb\xbf")
+	if len(trimmed) == 0 {
+		return false
+	}
+	// Match `<` followed by `!doctype`, `html`, `body`, or any tag-name char.
+	if trimmed[0] != '<' {
+		return false
+	}
+	if len(trimmed) < 2 {
+		return false
+	}
+	// Reject XML processing instructions (`<?xml ...`).
+	if trimmed[1] == '?' {
+		return false
+	}
+	lower := bytes.ToLower(trimmed)
+	return bytes.HasPrefix(lower, []byte("<!doctype")) ||
+		bytes.HasPrefix(lower, []byte("<html")) ||
+		bytes.HasPrefix(lower, []byte("<head")) ||
+		bytes.HasPrefix(lower, []byte("<body"))
+}
 
 // parseQBitVersion extracts semver major.minor.patch from a qBit version string.
 func parseQBitVersion(raw string) (major, minor, patch int, ok bool) {
@@ -163,6 +198,9 @@ func (q *QbitClient) AuthenticateWithContext(ctx context.Context) error {
 		q.lastActivity = time.Now()
 		sLogger().Info("Successfully logged in to qBittorrent (204 No Content)")
 		if detectErr := q.detectVersion(ctx); detectErr != nil {
+			if errors.Is(detectErr, errWrongServer) {
+				return fmt.Errorf("疑似检测到非 qBittorrent 响应：登录看似成功但后续 API 返回 HTML 页面（可能是 pt-tools 自身或反向代理的登录页），请检查下载器 WebUI 地址是否正确")
+			}
 			sLogger().Debugf("qBit 版本探测返回错误: %v", detectErr)
 		}
 		return nil
@@ -179,10 +217,18 @@ func (q *QbitClient) AuthenticateWithContext(ctx context.Context) error {
 		return fmt.Errorf("用户名或密码错误")
 	}
 
+	if looksLikeHTML(body) {
+		q.healthy = false
+		return fmt.Errorf("疑似检测到非 qBittorrent 响应：登录返回了 HTML 页面，请检查下载器 WebUI 地址是否正确（例如错误指向了 pt-tools 自身或反向代理的登录页）")
+	}
+
 	q.healthy = true
 	q.lastActivity = time.Now()
 	sLogger().Info("Successfully logged in to qBittorrent")
 	if detectErr := q.detectVersion(ctx); detectErr != nil {
+		if errors.Is(detectErr, errWrongServer) {
+			return fmt.Errorf("疑似检测到非 qBittorrent 响应：登录看似成功但后续 API 返回 HTML 页面（可能是 pt-tools 自身或反向代理的登录页），请检查下载器 WebUI 地址是否正确")
+		}
 		sLogger().Debugf("qBit 版本探测返回错误: %v", detectErr)
 	}
 	return nil
@@ -212,6 +258,13 @@ func (q *QbitClient) detectVersion(ctx context.Context) error {
 	if err != nil {
 		sLogger().Warnf("qBit 版本探测失败，使用 legacy 模式（旧版兼容）: %v", err)
 		return nil
+	}
+
+	if looksLikeHTML(body) {
+		q.mu.Lock()
+		q.healthy = false
+		q.mu.Unlock()
+		return fmt.Errorf("%w: 版本探测返回 HTML 页面", errWrongServer)
 	}
 
 	version := strings.TrimSpace(string(body))

--- a/thirdpart/downloader/qbit/qbit_wrong_url_test.go
+++ b/thirdpart/downloader/qbit/qbit_wrong_url_test.go
@@ -1,0 +1,180 @@
+package qbit
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const ptToolsLoginHTML = `<!doctype html><html><head><meta charset="utf-8"><title>登录</title>
+<link rel="stylesheet" href="/static/style.css"></head>
+<body class="login-page">
+<main class="login-layout">
+  <div class="login-card">
+    <p class="login-eyebrow">PT TOOLS</p>
+    <h1 class="login-title">欢迎登录</h1>
+    <p class="login-subtitle">集中管理站点、RSS 与下载任务</p>
+  </div>
+</main>
+</body></html>`
+
+func TestLooksLikeHTML(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"empty", "", false},
+		{"qbit_ok", "Ok.", false},
+		{"qbit_fails", "Fails.", false},
+		{"qbit_version", "v5.2.0", false},
+		{"qbit_json", `{"hash":"abc"}`, false},
+		{"json_array", "[]", false},
+		{"xml_processing_instruction", `<?xml version="1.0"?><root/>`, false},
+		{"random_lt", "<not-html-just-stray-bracket", false},
+		{"doctype_lower", `<!doctype html>`, true},
+		{"doctype_upper", `<!DOCTYPE html>`, true},
+		{"doctype_with_bom", "\xef\xbb\xbf<!doctype html>", true},
+		{"html_tag", `<html><body></body></html>`, true},
+		{"head_tag", `<head><title>x</title></head>`, true},
+		{"body_tag", `<body>foo</body>`, true},
+		{"leading_whitespace", "  \n\t<!doctype html>", true},
+		{"pttools_login_page", ptToolsLoginHTML, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := looksLikeHTML([]byte(tc.body))
+			if got != tc.want {
+				t.Fatalf("looksLikeHTML(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func wrongServerMock(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(ptToolsLoginHTML))
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestAuthenticate_RejectsHTMLBody(t *testing.T) {
+	ts := wrongServerMock(t)
+	defer ts.Close()
+
+	client := newVersionTestClient(ts.URL)
+	err := client.Authenticate()
+	if err == nil {
+		t.Fatal("expected error when WebUI URL points at non-qBit server returning HTML, got nil")
+	}
+	if !strings.Contains(err.Error(), "HTML") && !strings.Contains(err.Error(), "qBit") {
+		t.Fatalf("expected error message to mention HTML / qBit / URL config, got: %v", err)
+	}
+	if client.IsHealthy() {
+		t.Fatal("client must not be marked healthy after HTML response")
+	}
+}
+
+func TestAuthenticate_204ThenHTMLVersionFails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/api/v2/app/version", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(ptToolsLoginHTML))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := newVersionTestClient(ts.URL)
+	err := client.Authenticate()
+	if err == nil {
+		t.Fatal("expected error when version probe returns HTML after 204 login, got nil")
+	}
+	if client.IsHealthy() {
+		t.Fatal("client must not be marked healthy when version probe returned HTML")
+	}
+}
+
+func TestDetectVersion_HTMLReturnsWrongServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/app/version", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(ptToolsLoginHTML))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := newVersionTestClient(ts.URL)
+	client.healthy = true
+	err := client.detectVersion(context.Background())
+	if err == nil {
+		t.Fatal("expected detectVersion to error on HTML body, got nil")
+	}
+	if !errors.Is(err, errWrongServer) {
+		t.Fatalf("expected errors.Is(err, errWrongServer), got: %v", err)
+	}
+	if client.IsHealthy() {
+		t.Fatal("detectVersion HTML failure must flip healthy=false")
+	}
+}
+
+func TestRequestsHTTPDoer_PersistsCookiesAcrossRequests(t *testing.T) {
+	const sidName = "QBT_SID_8080"
+	const sidValue = "test-session-id"
+
+	var versionSawCookie string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{
+			Name:     sidName,
+			Value:    sidValue,
+			Path:     "/",
+			HttpOnly: true,
+		})
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/api/v2/app/version", func(w http.ResponseWriter, r *http.Request) {
+		if c, err := r.Cookie(sidName); err == nil {
+			versionSawCookie = c.Value
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("v5.2.0"))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	httpClient := &http.Client{Jar: jar}
+
+	client := &QbitClient{
+		name:     "test-qbit",
+		baseURL:  ts.URL,
+		username: "admin",
+		password: "password",
+		client:   &standardHTTPDoer{client: httpClient},
+	}
+
+	if err := client.Authenticate(); err != nil {
+		t.Fatalf("Authenticate failed: %v", err)
+	}
+	if versionSawCookie != sidValue {
+		t.Fatalf("version probe did not receive %s cookie: got %q want %q", sidName, versionSawCookie, sidValue)
+	}
+	if !client.isV520Plus {
+		t.Fatal("expected isV520Plus=true after detecting v5.2.0")
+	}
+}


### PR DESCRIPTION
## Summary

修复 #362。两个独立小变更打在一起：

- **fix(qbit)**: 当下载器 URL 错误指向非 qBit 服务时，pt-tools 不再静默吞掉 HTML 响应，而是在登录阶段直接报错给出可操作的诊断
- **ci(extension-publish)**: Edge Add-ons API InReview 软失败判定改为基于响应 message 字面匹配，去掉不稳健的时间窗口

## Changes

### fix(qbit)（issue #362）

PR #294 为兼容 qBit 5.2.0 的空 body / 非 \`Ok.\` 响应，把登录成功判定从 \`body == "Ok."\` 放宽为 \`body != "Fails."\`。这导致当下载器 URL 错误指向非 qBit 服务（例如 pt-tools 自身、反向代理登录页）时，会收到 200 OK + HTML，被误判为登录成功，后续版本探测继续吃 HTML 后 silent fallback 到 legacy 模式，最终在种子列表 JSON 解析时炸出 \`invalid character '<'\`，错误信息无法定位根因。

修复：
- 新增 \`looksLikeHTML\` helper：识别 \`<!doctype/<html/<head/<body\` 前缀，容忍 BOM/前导空白，跳过 \`<?xml\` processing instruction
- \`Authenticate\` 200 OK 分支：HTML body 直接报错「**疑似检测到非 qBittorrent 响应：登录返回了 HTML 页面，请检查下载器 WebUI 地址是否正确**」
- \`detectVersion\`：HTML body 不再 silent legacy fallback，置 \`healthy=false\` 并返回包装 \`errWrongServer\` 哨兵的错误
- \`Authenticate\` 200/204 两条成功路径：用 \`errors.Is(detectErr, errWrongServer)\` 把整个登录拉黑

新增 5 个回归测试（\`qbit_wrong_url_test.go\`）：
- \`TestLooksLikeHTML\` — 16 个 table-driven case
- \`TestAuthenticate_RejectsHTMLBody\` — 直接复现 #362 错配场景
- \`TestAuthenticate_204ThenHTMLVersionFails\` — 5.2.0 的 204 登录成功 + HTML 探测
- \`TestDetectVersion_HTMLReturnsWrongServerError\` — \`errors.Is\` 哨兵传播
- \`TestRequestsHTTPDoer_PersistsCookiesAcrossRequests\` — 用真实 \`net/http/cookiejar\` 断言 \`QBT_SID_8080\` cookie 跨 login → version 持久化

### ci(extension-publish)

Edge API 在已有 InReview 的提交时，返回 \`status=Failed\` + \`message="An error occurred while performing the operation"\` + \`errorCode/errors\` 都为 null。原本 \`elapsed < 5s\` 的时间窗口判定不够稳健（实测有 31s 才返回 Failed 的情况），会被误判为硬失败。改为基于响应 message 字面识别。

## Verification

E2E 验证：用真实 qBit 5.2.0 容器（linuxserver.io 5.2.0_v2.0.12-ls458）部署到 EKS，触发真实 \`[自动删种]\` scheduler 路径。

**Before-fix**（PR #294 的代码）逐字符复现 #362 全部 5 行日志：
\`\`\`
[INFO]  [自动删种] 开始检查 (间隔=1分钟, 范围=database, 磁盘保护=true)
[INFO]  Successfully logged in to qBittorrent
[WARN]  qBit 版本探测失败，使用 legacy 模式（旧版兼容）: invalid version "<!doctype html>...PT TOOLS...集中管理站点、RSS 与下载任务..."
[INFO]  Created downloader instance: wrong-url-qbit
[ERROR] [自动删种] wrong-url-qbit: 获取种子列表失败: failed to parse torrents response: invalid character '<' looking for beginning of value
\`\`\`

**After-fix**（本 PR 的代码）退化为单一明确诊断：
\`\`\`
[INFO]  [自动删种] 开始检查 (间隔=1分钟, 范围=database, 磁盘保护=true)
[WARN]  Failed to create downloader wrong-url-qbit (attempt 1): 疑似检测到非 qBittorrent 响应：登录返回了 HTML 页面，请检查下载器 WebUI 地址是否正确（例如错误指向了 pt-tools 自身或反向代理的登录页）
... (5 retries with exponential backoff)
\`\`\`

正确 URL（真实 qBit 5.2.0）下行为不变：\`Successfully logged in (204 No Content)\` → \`qBit 版本探测: v5.2.0 (5.2.0+ 模式)\` → \`Created downloader instance\`。

## Test Coverage

- \`go test -race\` 全部通过（21 个 qbit 包测试，含 5 个新增 + 16 个 \`looksLikeHTML\` 子测试）
- \`golangci-lint\` 0 issues
- \`go vet\` 无输出

Closes #362