### PR TITLE
feat(sites): 新增 OurBits / Mua + 修复 RSS 站点绑定与磁盘预留累积

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1231,12 +1231,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **site**: 新增 OpenCD 和 PTT 站点适配
 - 新增 site/v2/definitions/opencd.go 适配 open.cd (繁体 NexusPHP)
   _ 使用 div.title + td.rowtitle 替代标准 h1 + td.rowhead
-  _ 支持 plugin*details.php 链接格式
-  * 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
-  * 处理 font.promotion 替代 img.pro*_ 的非标准折扣标记
-  _ span.category 替代 img[alt] 的分类标记
-  _ 处理 info_block 隐藏列的 nth-child 索引偏移
-  _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
+  _ 支持 plugin\*details.php 链接格式
+  - 完整 UserInfo / Search / DetailParser 配置 + fixture 测试 - 新增 site/v2/definitions/pttime.go 适配 www.pttime.org (PTT-NP 分支)
+  - 处理 font.promotion 替代 img.pro\*_ 的非标准折扣标记
+    _ span.category 替代 img[alt] 的分类标记
+    _ 处理 info_block 隐藏列的 nth-child 索引偏移
+    _ 处理 "上传:" / "下载:" 无 "量" 后缀的 userinfo 标签 \* 完整 fixture 测试覆盖 Search/Detail/UserInfo - 浏览器扩展 constants.ts 注册 opencd 和 pttime 至 KNOWN_SITES - docs/sites.md 更新适配站点列表至 30 个 - Closes #233 #250
 
 ## [0.23.0] - 2026-04-29
 

--- a/docs/sites.md
+++ b/docs/sites.md
@@ -1,8 +1,8 @@
 ## 支持站点
 
-当前已适配 **41** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
+当前已适配 **43** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
 
-### NexusPHP 系列（37）
+### NexusPHP 系列（39）
 
 | 站点                  | 认证方式 | 支持功能                      | 适配情况 | 备注                                                             |
 | --------------------- | -------- | ----------------------------- | -------- | ---------------------------------------------------------------- |
@@ -41,6 +41,8 @@
 | **HDVideo**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | HD视频（hdvideo.top）                                            |
 | **GTKPW**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 多镜像（pt.gtkpw.xyz / pt.gtk.pw / pt.gtk.xyz / t.myaltbox.com） |
 | **NicePT**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 好趣（www.nicept.net，繁体）                                     |
+| **OurBits**           | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（ourbits.club，issue #329）                               |
+| **Mua**               | Cookie   | RSS、搜索、用户信息           | ✅       | 二次元站点（mua.xloli.cc，userdetails 走 uuid，issue #339）      |
 | **1PTBar**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
 | **lajidui**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
 

--- a/internal/common.go
+++ b/internal/common.go
@@ -69,25 +69,66 @@ func GetDownloaderForRSS(rssCfg models.RSSConfig) (downloader.Downloader, error)
 	return dl, err
 }
 
-// GetDownloaderForRSSWithInfo 根据 RSS 配置获取下载器及其信息
-// 优先使用全局 DownloaderManager（连接池复用），回退到直接创建实例
+// GetDownloaderForRSSWithInfo 根据 RSS 配置获取下载器及其信息（无站点上下文）。
+// 优先级：RSS.DownloaderID > is_default。**不查站点绑定** —— 仅用于无站点
+// 信息可用的旧调用点（CLI、cmd/rss 等）。新代码请用
+// GetDownloaderForRSSAndSiteWithInfo。
 func GetDownloaderForRSSWithInfo(rssCfg models.RSSConfig) (downloader.Downloader, *DownloaderInfo, error) {
+	return getDownloaderForRSSImpl(rssCfg, "")
+}
+
+// GetDownloaderForRSSAndSiteWithInfo 根据 RSS 配置 + 站点名解析下载器。
+//
+// 优先级（新）：
+//  1. rssCfg.DownloaderID（RSS 行级覆盖）
+//  2. SiteSetting.DownloaderID（站点绑定，issue #373 修复点）
+//  3. is_default=true（兜底）
+//
+// siteName 为空时退化为 GetDownloaderForRSSWithInfo 的旧行为。
+func GetDownloaderForRSSAndSiteWithInfo(rssCfg models.RSSConfig, siteName string) (downloader.Downloader, *DownloaderInfo, error) {
+	return getDownloaderForRSSImpl(rssCfg, strings.TrimSpace(siteName))
+}
+
+func getDownloaderForRSSImpl(rssCfg models.RSSConfig, siteName string) (downloader.Downloader, *DownloaderInfo, error) {
 	if global.GlobalDB == nil {
 		return nil, nil, errors.New("数据库未初始化")
 	}
 
 	var dlSetting models.DownloaderSetting
 
-	if rssCfg.DownloaderID != nil {
+	switch {
+	case rssCfg.DownloaderID != nil:
+		// 优先级 1: RSS 行自己指定了下载器
 		if err := global.GlobalDB.DB.First(&dlSetting, *rssCfg.DownloaderID).Error; err != nil {
 			return nil, nil, fmt.Errorf("获取指定下载器失败: %w", err)
 		}
 		if !dlSetting.Enabled {
 			return nil, nil, fmt.Errorf("指定的下载器 %s 未启用", dlSetting.Name)
 		}
-	} else {
-		if err := global.GlobalDB.DB.Where("is_default = ?", true).First(&dlSetting).Error; err != nil {
-			return nil, nil, fmt.Errorf("获取默认下载器失败: %w", err)
+	case siteName != "":
+		// 优先级 2: 站点绑定（issue #373）
+		// 直接查 SiteSetting 而非 DownloaderManager.siteDownloaders 以避免内存
+		// 状态过时（manager 仅在 scheduler init / Reload 时同步一次）。
+		var site models.SiteSetting
+		siteErr := global.GlobalDB.DB.Where("name = ?", siteName).First(&site).Error
+		if siteErr == nil && site.DownloaderID != nil {
+			if err := global.GlobalDB.DB.First(&dlSetting, *site.DownloaderID).Error; err == nil {
+				if !dlSetting.Enabled {
+					return nil, nil, fmt.Errorf("站点 %s 绑定的下载器 %s 未启用", siteName, dlSetting.Name)
+				}
+				break
+			}
+			// 站点 DownloaderID 指向已删除的下载器：fallthrough 到 is_default
+			sLogger().Warnf("站点 %s 绑定的下载器 ID=%d 不存在，回退到 is_default", siteName, *site.DownloaderID)
+		}
+		// 站点未绑定 / 站点行不存在：fallthrough 到 is_default
+		fallthrough
+	default:
+		// 优先级 3: is_default=true 兜底
+		if dlSetting.ID == 0 {
+			if err := global.GlobalDB.DB.Where("is_default = ?", true).First(&dlSetting).Error; err != nil {
+				return nil, nil, fmt.Errorf("获取默认下载器失败: %w", err)
+			}
 		}
 		if !dlSetting.Enabled {
 			return nil, nil, fmt.Errorf("默认下载器 %s 未启用", dlSetting.Name)
@@ -136,7 +177,7 @@ func ProcessTorrentsWithDownloaderByRSS(
 	dirPath, category, tags string,
 	siteName models.SiteGroup,
 ) error {
-	dl, dlInfo, err := GetDownloaderForRSSWithInfo(rssCfg)
+	dl, dlInfo, err := GetDownloaderForRSSAndSiteWithInfo(rssCfg, string(siteName))
 	if err != nil {
 		return fmt.Errorf("获取下载器失败: %w", err)
 	}

--- a/internal/regression_issue373_site_binding_test.go
+++ b/internal/regression_issue373_site_binding_test.go
@@ -1,0 +1,253 @@
+// MIT License
+// Copyright (c) 2025 pt-tools
+
+// Issue #373 regression tests: 多下载器场景下，绑定到站点的下载器必须生效。
+//
+// 修复后的优先级（GetDownloaderForRSSAndSiteWithInfo）：
+//  1. rssCfg.DownloaderID（RSS 行级覆盖）
+//  2. SiteSetting.DownloaderID（站点绑定，本 issue 修复点）
+//  3. is_default=true（兜底）
+//
+// 旧 API GetDownloaderForRSSWithInfo（无站点上下文）保留向后兼容，仅 1+3 路径。
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sunerpy/pt-tools/global"
+	sm "github.com/sunerpy/pt-tools/mocks"
+	"github.com/sunerpy/pt-tools/models"
+	"github.com/sunerpy/pt-tools/thirdpart/downloader"
+)
+
+// installFakeDMWithMocks 安装一个 manager，把"创建下载器"路径短路掉。
+// 工厂总是返回一个全部 AnyTimes 的 MockDownloader —— 我们不关心 dm.GetDownloader
+// 之后能不能跑，只关心 resolver 的"我选谁"决策。
+func installFakeDMWithMocks(t *testing.T) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	dm := downloader.NewDownloaderManager()
+	factory := func(_ downloader.DownloaderConfig, name string) (downloader.Downloader, error) {
+		md := sm.NewMockDownloader(ctrl)
+		md.EXPECT().GetName().Return(name).AnyTimes()
+		md.EXPECT().GetType().Return(downloader.DownloaderQBittorrent).AnyTimes()
+		md.EXPECT().IsHealthy().Return(true).AnyTimes()
+		md.EXPECT().Ping().Return(true, nil).AnyTimes()
+		md.EXPECT().Close().Return(nil).AnyTimes()
+		return md, nil
+	}
+	dm.RegisterFactory(downloader.DownloaderQBittorrent, factory)
+	SetGlobalDownloaderManager(dm)
+	t.Cleanup(func() { SetGlobalDownloaderManager(nil) })
+}
+
+// seedTwoDownloadersAndSiteBinding 在 DB 内写入一份「典型多下载器」状态：
+//   - qbit-default:  is_default=true,  enabled=true
+//   - qbit-mteam:    is_default=false, enabled=true
+//   - SiteSetting{ Name: "mteam", DownloaderID: qbit-mteam.id }
+//
+// 返回两个下载器行的主键，便于断言。
+func seedTwoDownloadersAndSiteBinding(t *testing.T) (defaultID, mteamID uint) {
+	t.Helper()
+	db := global.GlobalDB
+	require.NotNil(t, db, "调用前先 setupDB(t)")
+
+	dlDefault := models.DownloaderSetting{
+		Name:      "qbit-default",
+		Type:      "qbittorrent",
+		URL:       "http://127.0.0.1:8080",
+		Username:  "admin",
+		Password:  "x",
+		IsDefault: true,
+		Enabled:   true,
+	}
+	require.NoError(t, db.DB.Create(&dlDefault).Error)
+
+	dlMteam := models.DownloaderSetting{
+		Name:      "qbit-mteam",
+		Type:      "qbittorrent",
+		URL:       "http://127.0.0.1:8081",
+		Username:  "admin",
+		Password:  "y",
+		IsDefault: false,
+		Enabled:   true,
+	}
+	require.NoError(t, db.DB.Create(&dlMteam).Error)
+
+	site := models.SiteSetting{
+		Name:         "mteam",
+		BaseURL:      "https://example.invalid",
+		Enabled:      true,
+		AuthMethod:   "cookie",
+		DownloaderID: &dlMteam.ID,
+	}
+	require.NoError(t, db.DB.Create(&site).Error)
+
+	return dlDefault.ID, dlMteam.ID
+}
+
+// TestIssue373_NewResolver_HonorsSiteBinding 修复后的核心契约：
+// 站点绑定必须被 resolver 读取。RSS 行 DownloaderID=nil 时，
+// 走 SiteSetting.DownloaderID 路径，选中 qbit-mteam（不是 qbit-default）。
+func TestIssue373_NewResolver_HonorsSiteBinding(t *testing.T) {
+	_ = setupDB(t)
+	t.Cleanup(func() { global.GlobalDB = nil })
+	installFakeDMWithMocks(t)
+
+	defaultID, mteamID := seedTwoDownloadersAndSiteBinding(t)
+	require.NotEqual(t, defaultID, mteamID)
+
+	rssCfg := models.RSSConfig{
+		ID:           42,
+		Name:         "mteam-free",
+		URL:          "https://example.invalid/torrentrss.php?xxx",
+		DownloaderID: nil,
+	}
+
+	_, info, err := GetDownloaderForRSSAndSiteWithInfo(rssCfg, "mteam")
+	require.NoError(t, err)
+	require.NotNil(t, info)
+
+	assert.Equal(t, "qbit-mteam", info.Name,
+		"修复 #373：RSS resolver 必须读取 SiteSetting.DownloaderID，选 qbit-mteam")
+	assert.Equal(t, mteamID, info.ID)
+}
+
+// TestIssue373_NewResolver_RSSOverrideWinsOverSiteBinding 优先级 1 > 2：
+// RSS 行自己指定了 DownloaderID 时，必须忽略站点绑定，走 RSS 自己的下载器。
+func TestIssue373_NewResolver_RSSOverrideWinsOverSiteBinding(t *testing.T) {
+	_ = setupDB(t)
+	t.Cleanup(func() { global.GlobalDB = nil })
+	installFakeDMWithMocks(t)
+
+	defaultID, mteamID := seedTwoDownloadersAndSiteBinding(t)
+	_ = mteamID
+
+	rssCfg := models.RSSConfig{
+		ID:           1,
+		Name:         "rss-override",
+		URL:          "https://x.invalid/",
+		DownloaderID: &defaultID, // RSS 行明确指定 qbit-default
+	}
+
+	_, info, err := GetDownloaderForRSSAndSiteWithInfo(rssCfg, "mteam")
+	require.NoError(t, err)
+	require.NotNil(t, info)
+
+	assert.Equal(t, "qbit-default", info.Name,
+		"优先级 1 (RSS.DownloaderID) 必须高于优先级 2 (SiteSetting.DownloaderID)")
+	assert.Equal(t, defaultID, info.ID)
+}
+
+// TestIssue373_NewResolver_FallsBackToDefaultWhenSiteHasNoBinding 优先级 3：
+// 站点存在但未绑定下载器（DownloaderID=NULL）时，回落 is_default。
+func TestIssue373_NewResolver_FallsBackToDefaultWhenSiteHasNoBinding(t *testing.T) {
+	_ = setupDB(t)
+	t.Cleanup(func() { global.GlobalDB = nil })
+	installFakeDMWithMocks(t)
+
+	defaultID, _ := seedTwoDownloadersAndSiteBinding(t)
+	// 把 mteam 的绑定清掉，模拟"站点存在但没绑下载器"
+	require.NoError(t, global.GlobalDB.DB.
+		Model(&models.SiteSetting{}).
+		Where("name = ?", "mteam").
+		Update("downloader_id", nil).Error)
+
+	rssCfg := models.RSSConfig{ID: 1, Name: "x", URL: "https://x.invalid/", DownloaderID: nil}
+	_, info, err := GetDownloaderForRSSAndSiteWithInfo(rssCfg, "mteam")
+	require.NoError(t, err)
+	require.NotNil(t, info)
+
+	assert.Equal(t, "qbit-default", info.Name, "站点未绑定 → fallback is_default")
+	assert.Equal(t, defaultID, info.ID)
+}
+
+// TestIssue373_NewResolver_FallsBackWhenSiteRowMissing 优先级 3 边界：
+// 站点行根本不存在（site_settings 里没这一行）时也安全 fallback。
+func TestIssue373_NewResolver_FallsBackWhenSiteRowMissing(t *testing.T) {
+	_ = setupDB(t)
+	t.Cleanup(func() { global.GlobalDB = nil })
+	installFakeDMWithMocks(t)
+
+	defaultID, _ := seedTwoDownloadersAndSiteBinding(t)
+
+	rssCfg := models.RSSConfig{ID: 1, Name: "x", URL: "https://x.invalid/", DownloaderID: nil}
+	_, info, err := GetDownloaderForRSSAndSiteWithInfo(rssCfg, "this-site-does-not-exist")
+	require.NoError(t, err)
+	require.NotNil(t, info)
+
+	assert.Equal(t, "qbit-default", info.Name, "未知站点 → fallback is_default")
+	assert.Equal(t, defaultID, info.ID)
+}
+
+// TestIssue373_NewResolver_FallsBackWhenBoundDownloaderDeleted 优先级 3 边界：
+// 站点绑定的下载器被删除（外键悬挂）时也安全 fallback，不报错。
+func TestIssue373_NewResolver_FallsBackWhenBoundDownloaderDeleted(t *testing.T) {
+	_ = setupDB(t)
+	t.Cleanup(func() { global.GlobalDB = nil })
+	installFakeDMWithMocks(t)
+
+	defaultID, mteamID := seedTwoDownloadersAndSiteBinding(t)
+	// 删掉 qbit-mteam（站点绑定指向悬挂 ID）
+	require.NoError(t, global.GlobalDB.DB.Delete(&models.DownloaderSetting{}, mteamID).Error)
+
+	rssCfg := models.RSSConfig{ID: 1, Name: "x", URL: "https://x.invalid/", DownloaderID: nil}
+	_, info, err := GetDownloaderForRSSAndSiteWithInfo(rssCfg, "mteam")
+	require.NoError(t, err)
+	require.NotNil(t, info)
+
+	assert.Equal(t, "qbit-default", info.Name,
+		"站点绑定指向已删除的下载器 → 不应报错，应安全 fallback is_default")
+	assert.Equal(t, defaultID, info.ID)
+}
+
+// TestIssue373_NewResolver_RejectsDisabledBoundDownloader 反向：
+// 站点绑定的下载器被禁用（Enabled=false）时必须明确报错，不能静默 fallback —
+// 否则用户配置意图被悄悄改写。
+func TestIssue373_NewResolver_RejectsDisabledBoundDownloader(t *testing.T) {
+	_ = setupDB(t)
+	t.Cleanup(func() { global.GlobalDB = nil })
+	installFakeDMWithMocks(t)
+
+	_, mteamID := seedTwoDownloadersAndSiteBinding(t)
+	require.NoError(t, global.GlobalDB.DB.
+		Model(&models.DownloaderSetting{}).
+		Where("id = ?", mteamID).
+		Update("enabled", false).Error)
+
+	rssCfg := models.RSSConfig{ID: 1, Name: "x", URL: "https://x.invalid/", DownloaderID: nil}
+	_, _, err := GetDownloaderForRSSAndSiteWithInfo(rssCfg, "mteam")
+	require.Error(t, err, "绑定的下载器被禁用必须报错而非 fallback")
+	assert.Contains(t, err.Error(), "qbit-mteam")
+	assert.Contains(t, err.Error(), "未启用")
+}
+
+// TestIssue373_LegacyResolver_NoSiteContextStillWorks 向后兼容：
+// 旧 API GetDownloaderForRSSWithInfo（无站点上下文）保持原有行为，
+// 仍然走 RSS.DownloaderID > is_default 两路径，不查 SiteSetting。
+//
+// 这条测试存在的意义：保证现有 cmd/rss、CLI 等无站点上下文的调用点不被修复破坏。
+func TestIssue373_LegacyResolver_NoSiteContextStillWorks(t *testing.T) {
+	_ = setupDB(t)
+	t.Cleanup(func() { global.GlobalDB = nil })
+	installFakeDMWithMocks(t)
+
+	defaultID, mteamID := seedTwoDownloadersAndSiteBinding(t)
+	_ = mteamID
+
+	rssCfg := models.RSSConfig{ID: 99, Name: "no-site-ctx", URL: "https://x.invalid/", DownloaderID: nil}
+	_, info, err := GetDownloaderForRSSWithInfo(rssCfg)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+
+	assert.Equal(t, "qbit-default", info.Name,
+		"无站点上下文 → 不查 SiteSetting，直接 fallback is_default（向后兼容）")
+	assert.Equal(t, defaultID, info.ID)
+}

--- a/scheduler/cleanup_monitor.go
+++ b/scheduler/cleanup_monitor.go
@@ -25,6 +25,9 @@ const (
 	emergencyBufferMinGB   = 10.0
 	emergencyBufferPercent = 0.2
 	diskEventDebounce      = 3 * time.Second
+	// diskBudgetResetInterval 控制 CleanupEnabled=false 但 CleanupDiskProtect=true 时
+	// 的 DiskBudget Reset 节奏。Issue #374 修复：原本这条路径下 Reset 永不触发。
+	diskBudgetResetInterval = 5 * time.Minute
 )
 
 type CleanupMonitor struct {
@@ -83,12 +86,14 @@ func (c *CleanupMonitor) runLoop() {
 
 	for {
 		cfg := c.loadConfig()
+		c.maybeResetDiskBudget(cfg)
+
 		if cfg == nil || !cfg.CleanupEnabled {
 			c.logger.Debug("[自动删种] 功能未启用，等待下次检查")
 			select {
 			case <-c.ctx.Done():
 				return
-			case <-time.After(5 * time.Minute):
+			case <-time.After(diskBudgetResetInterval):
 				continue
 			case ev := <-eventCh:
 				if ev.Type == events.DiskSpaceLow {
@@ -120,6 +125,21 @@ func (c *CleanupMonitor) runLoop() {
 	}
 }
 
+// maybeResetDiskBudget 在每次 runLoop 迭代顶部决定是否归还 DiskBudget。
+// Issue #374 修复点：原本 Reset 仅在 runOnce 内被调用，而 runOnce 又被
+// CleanupEnabled gate 拦下，导致 CleanupDiskProtect=true + CleanupEnabled=false
+// 配置组合下预留永不归零。这里改为只要 CleanupDiskProtect=true 就 Reset，
+// 与 CleanupEnabled 解耦。
+//
+// 抽成独立方法以便单测可在不进入完整 runLoop（含 10 秒 Sleep）的前提下
+// 验证 fix 的契约。
+func (c *CleanupMonitor) maybeResetDiskBudget(cfg *models.SettingsGlobal) {
+	if cfg == nil || !cfg.CleanupDiskProtect {
+		return
+	}
+	c.resetDiskBudget()
+}
+
 func (c *CleanupMonitor) drainAndDebounce(ch <-chan events.Event) {
 	timer := time.NewTimer(diskEventDebounce)
 	defer timer.Stop()
@@ -146,13 +166,7 @@ func (c *CleanupMonitor) loadConfig() *models.SettingsGlobal {
 }
 
 func (c *CleanupMonitor) runOnce(cfg *models.SettingsGlobal) {
-	// Reset 必须在 PushMutex 内执行：否则可能在某个 worker 的「Reserve → push」
-	// 中间清零，让下一个 worker 看到 pre_reserved=0 而重复借用同一份磁盘空间
-	// （Issue #299 race 的另一形态）。
-	mu := ptinternal.PushMutex()
-	mu.Lock()
-	ptinternal.GetDiskBudget().Reset()
-	mu.Unlock()
+	c.resetDiskBudget()
 
 	dlNames := c.downloaderMgr.ListDownloaders()
 	if len(dlNames) == 0 {
@@ -166,6 +180,17 @@ func (c *CleanupMonitor) runOnce(cfg *models.SettingsGlobal) {
 		}
 		c.processDownloader(cfg, dl, name)
 	}
+}
+
+// resetDiskBudget 在 PushMutex 内清零 DiskBudget。
+// PushMutex 内 Reset 是必须的：否则可能在某个 worker 的「Reserve → push」中间
+// 清零，让下一个 worker 看到 pre_reserved=0 而重复借用同一份磁盘空间
+// （Issue #299 race 的另一形态）。
+func (c *CleanupMonitor) resetDiskBudget() {
+	mu := ptinternal.PushMutex()
+	mu.Lock()
+	ptinternal.GetDiskBudget().Reset()
+	mu.Unlock()
 }
 
 func (c *CleanupMonitor) processDownloader(cfg *models.SettingsGlobal, dl downloader.Downloader, dlName string) {

--- a/scheduler/regression_issue374_disk_budget_test.go
+++ b/scheduler/regression_issue374_disk_budget_test.go
@@ -1,0 +1,170 @@
+// MIT License
+// Copyright (c) 2025 pt-tools
+
+// Issue #374 regression tests: 「本进程预留」必须在 CleanupDiskProtect=true 时
+// 周期归零，独立于 CleanupEnabled 开关。
+//
+// 修复后契约：
+//   maybeResetDiskBudget(cfg):
+//     cfg.CleanupDiskProtect=true → Reset() 一次
+//     cfg.CleanupDiskProtect=false → no-op
+//   与 cfg.CleanupEnabled 解耦。
+
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sunerpy/pt-tools/global"
+	ptinternal "github.com/sunerpy/pt-tools/internal"
+	"github.com/sunerpy/pt-tools/models"
+	"github.com/sunerpy/pt-tools/thirdpart/downloader"
+)
+
+const oneGB = int64(1024 * 1024 * 1024)
+
+// TestIssue374_DiskProtectOn_CleanupOff_ResetStillRuns 修复后核心契约：
+// 用户配置「磁盘保护开但自动删种关」时，maybeResetDiskBudget 仍会触发 Reset，
+// 预留不再单调累积。这是 Bug 报告中 984.6 GB 现象的直接验证。
+func TestIssue374_DiskProtectOn_CleanupOff_ResetStillRuns(t *testing.T) {
+	db := setupTestDB(t)
+	t.Cleanup(func() { global.GlobalDB = nil })
+	require.NoError(t, db.DB.Create(&models.SettingsGlobal{
+		DownloadDir:           t.TempDir(),
+		CleanupDiskProtect:    true,
+		CleanupMinDiskSpaceGB: 200,
+		CleanupEnabled:        false, // 关键：自动删种关
+	}).Error)
+
+	budget := ptinternal.GetDiskBudget()
+	budget.Reset()
+	t.Cleanup(func() { budget.Reset() })
+
+	const n = 30
+	const sizePerTorrent = 30 * oneGB
+	for i := 0; i < n; i++ {
+		budget.Reserve(sizePerTorrent)
+	}
+	require.Equal(t, int64(n)*sizePerTorrent, budget.Reserved(), "sanity: 累计 900 GB")
+
+	cm := NewCleanupMonitor(db.DB, downloader.NewDownloaderManager())
+	cfg := cm.loadConfig()
+	require.NotNil(t, cfg)
+	require.True(t, cfg.CleanupDiskProtect)
+	require.False(t, cfg.CleanupEnabled)
+
+	cm.maybeResetDiskBudget(cfg)
+
+	assert.Equal(t, int64(0), budget.Reserved(),
+		"修复 #374：CleanupDiskProtect=true + CleanupEnabled=false 时 Reset 必须运行")
+}
+
+// TestIssue374_DiskProtectOff_ResetSkipped 反向：
+// 当 CleanupDiskProtect=false 时（用户根本没开磁盘保护），无需 Reset；
+// 否则我们就是在偷偷修改一个用户没启用的子系统的状态。
+func TestIssue374_DiskProtectOff_ResetSkipped(t *testing.T) {
+	db := setupTestDB(t)
+	t.Cleanup(func() { global.GlobalDB = nil })
+	row := models.SettingsGlobal{
+		DownloadDir:           t.TempDir(),
+		CleanupDiskProtect:    false,
+		CleanupMinDiskSpaceGB: 0,
+		CleanupEnabled:        false,
+	}
+	require.NoError(t, db.DB.Create(&row).Error)
+	// GORM `default:true` 标签会把零值 false 覆盖回 true，必须显式 Update
+	require.NoError(t, db.DB.Model(&row).Update("cleanup_disk_protect", false).Error)
+
+	budget := ptinternal.GetDiskBudget()
+	budget.Reset()
+	t.Cleanup(func() { budget.Reset() })
+
+	budget.Reserve(50 * oneGB)
+	require.Equal(t, 50*oneGB, budget.Reserved())
+
+	cm := NewCleanupMonitor(db.DB, downloader.NewDownloaderManager())
+	cfg := cm.loadConfig()
+	require.NotNil(t, cfg)
+	require.False(t, cfg.CleanupDiskProtect)
+
+	cm.maybeResetDiskBudget(cfg)
+
+	assert.Equal(t, 50*oneGB, budget.Reserved(),
+		"CleanupDiskProtect=false → Reset 不该跑（DiskBudget 子系统未启用，prep 状态保留）")
+}
+
+// TestIssue374_NilConfig_NoOp 防御性：
+// loadConfig 失败返回 nil 时 maybeResetDiskBudget 必须是 no-op，
+// 不能 panic 或访问 nil 字段。
+func TestIssue374_NilConfig_NoOp(t *testing.T) {
+	db := setupTestDB(t)
+	t.Cleanup(func() { global.GlobalDB = nil })
+
+	budget := ptinternal.GetDiskBudget()
+	budget.Reset()
+	t.Cleanup(func() { budget.Reset() })
+
+	budget.Reserve(10 * oneGB)
+	cm := NewCleanupMonitor(db.DB, downloader.NewDownloaderManager())
+
+	require.NotPanics(t, func() {
+		cm.maybeResetDiskBudget(nil)
+	})
+	assert.Equal(t, 10*oneGB, budget.Reserved(), "nil cfg → no-op，不动现状")
+}
+
+// TestIssue374_BothFlagsOn_ResetRunsViaRunOnce 兼容性：
+// 用户同时开 CleanupEnabled+CleanupDiskProtect 时，runOnce 路径仍会 Reset
+// （runOnce 内的 resetDiskBudget 调用未被删除）。证明 fix 没破坏旧的 happy path。
+func TestIssue374_BothFlagsOn_ResetRunsViaRunOnce(t *testing.T) {
+	db := setupTestDB(t)
+	t.Cleanup(func() { global.GlobalDB = nil })
+	require.NoError(t, db.DB.Create(&models.SettingsGlobal{
+		DownloadDir:           t.TempDir(),
+		CleanupDiskProtect:    true,
+		CleanupMinDiskSpaceGB: 200,
+		CleanupEnabled:        true,
+	}).Error)
+
+	budget := ptinternal.GetDiskBudget()
+	budget.Reset()
+	t.Cleanup(func() { budget.Reset() })
+
+	budget.Reserve(500 * oneGB)
+	cm := NewCleanupMonitor(db.DB, downloader.NewDownloaderManager())
+	cfg := cm.loadConfig()
+	require.NotNil(t, cfg)
+
+	cm.runOnce(cfg)
+
+	assert.Equal(t, int64(0), budget.Reserved(),
+		"CleanupEnabled=true 时 runOnce 路径仍正确清零")
+}
+
+// TestIssue374_ResetIsIdempotent 性质测试：
+// 多次连续 Reset 等价于一次，不会下溢或异常。runLoop 在 5 分钟节奏下会反复
+// 调用，必须保证幂等。
+func TestIssue374_ResetIsIdempotent(t *testing.T) {
+	db := setupTestDB(t)
+	t.Cleanup(func() { global.GlobalDB = nil })
+	require.NoError(t, db.DB.Create(&models.SettingsGlobal{
+		DownloadDir:        t.TempDir(),
+		CleanupDiskProtect: true,
+	}).Error)
+
+	budget := ptinternal.GetDiskBudget()
+	budget.Reset()
+	t.Cleanup(func() { budget.Reset() })
+
+	cm := NewCleanupMonitor(db.DB, downloader.NewDownloaderManager())
+	cfg := cm.loadConfig()
+	require.NotNil(t, cfg)
+
+	for i := 0; i < 10; i++ {
+		cm.maybeResetDiskBudget(cfg)
+	}
+	assert.Equal(t, int64(0), budget.Reserved(), "连续 10 次 Reset 仍为 0")
+}

--- a/site/v2/definitions/mua.go
+++ b/site/v2/definitions/mua.go
@@ -1,0 +1,132 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+var MuaDefinition = &v2.SiteDefinition{
+	ID:             "mua",
+	Name:           "Mua",
+	Aka:            []string{"xloli", "mua.xloli.cc"},
+	Description:    "Mua (xloli) — NexusPHP 二次元/动画 PT 站点",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://mua.xloli.cc/"},
+	FaviconURL:     "https://mua.xloli.cc/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "bonus", "seeding", "leeching"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields: []string{
+					"name", "uploaded", "downloaded", "ratio", "levelName", "joinTime",
+				},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/mybonus.php", ResponseType: "document"},
+				Fields:        []string{"bonusPerHour"},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			"id": {
+				Selector: []string{
+					"td.rowhead:contains('用户ID/UID') + td",
+					"td.rowhead:contains('用户ID') + td",
+					"#info_block a.User_Name",
+				},
+				Filters: []v2.Filter{{Name: "regex", Args: []any{`(\d+)`}}, {Name: "parseNumber"}},
+			},
+			"name": {
+				Selector: []string{"#info_block a.User_Name", "#info_block a[href*='userdetails.php']"},
+			},
+			"uploaded": {
+				Selector: []string{"#info_block", "td.rowhead:contains('传输') + td", "td.rowhead:contains('上传量') + td"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:上传量|Uploaded)[^\d]*([\d.,]+\s*[KMGTP]?i?B)`}}, {Name: "parseSize"}},
+			},
+			"downloaded": {
+				Selector: []string{"#info_block", "td.rowhead:contains('传输') + td", "td.rowhead:contains('下载量') + td"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:下载量|Downloaded)[^\d]*([\d.,]+\s*[KMGTP]?i?B)`}}, {Name: "parseSize"}},
+			},
+			"ratio": {
+				Selector: []string{"#info_block", "td.rowhead:contains('传输') + td"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:分享率|Ratio)[\s:：]*([\d.,]+|无限|∞|Inf|---)`}}, {Name: "parseNumber"}},
+			},
+			"levelName": {
+				Selector: []string{"td.rowhead:contains('等级') + td > img", "td.rowhead:contains('等级') + td img"},
+				Attr:     "title",
+			},
+			"bonus": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:魔力值|Bonus)[^\d]*?\[<a[^>]*>使用</a>\][:：]?\s*([\d.,]+)`}}, {Name: "parseNumber"}},
+			},
+			"joinTime": {
+				Selector: []string{"td.rowhead:contains('加入日期') + td", "td.rowhead:contains('Join') + td"},
+				Filters:  []v2.Filter{{Name: "split", Args: []any{" (", 0}}, {Name: "parseTime"}},
+			},
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`class="arrowup"[^>]*/?>\s*(\d+)`}}, {Name: "parseNumber"}},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`class="arrowdown"[^>]*/?>\s*(\d+)`}}, {Name: "parseNumber"}},
+			},
+			"bonusPerHour": {
+				Selector: []string{"#outer", "body"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:你当前每小时能获取|您当前每小时能获取)[^\d-]{0,20}([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		TableRows:          "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:              "table.torrentname a[href*='details.php']",
+		TitleLink:          "table.torrentname a[href*='details.php']",
+		Subtitle:           "table.torrentname td.embedded > span:not(.optiontag):not(.tag)",
+		Size:               "td.rowfollow:nth-child(5)",
+		Seeders:            "td.rowfollow:nth-child(6)",
+		Leechers:           "td.rowfollow:nth-child(7)",
+		Snatched:           "td.rowfollow:nth-child(8)",
+		DiscountIcon:       "img.pro_free, img.pro_free2up, img.pro_50pctdown, img.pro_30pctdown, img.pro_2up, img.pro_50pctdown2up",
+		Category:           "td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:         "td.rowfollow:nth-child(4) span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords:       []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		DiscountSelector: "h1 font.free, h1 font[class]",
+		EndTimeSelector:  "h1 span[title]",
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(MuaDefinition)
+}

--- a/site/v2/definitions/mua_fixture_test.go
+++ b/site/v2/definitions/mua_fixture_test.go
@@ -1,0 +1,191 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "mua",
+		Search:   testMuaSearch,
+		Detail:   testMuaDetail,
+		UserInfo: testMuaUserInfo,
+	})
+}
+
+// 站点真实 HTML 结构（来自 issue #339 附件 mua.xloli.cc-*.zip）的脱敏版本：
+//   - 9 列 NexusPHP 表格（无"进度"列）：cat / title / 评论 / 时间 / 大小 / 种子 / 下载 / 完成 / 发布者
+//   - userdetails URL 使用 uuid= 而非 id=（id 必须从 'td.rowhead:contains 用户ID/UID' 提取）
+//   - 详情页 h1 嵌入 free 折扣
+//   - 二次元主题站点，副标题在 td.embedded > span（不带 optiontag/tag class）
+const muaSearchFixture = `<html><body>
+<table class="torrents" cellspacing="0" cellpadding="5" width="100%">
+<tr><td class="colhead">类型</td><td class="colhead">标题</td><td class="colhead">评论</td><td class="colhead">时间</td><td class="colhead">大小</td><td class="colhead">做种</td><td class="colhead">下载</td><td class="colhead">完成</td><td class="colhead">发布者</td></tr>
+<tr>
+  <td class="rowfollow nowrap"><a href="?cat=401"><img class="m_animation" alt="Animation" title="Animation" /></a></td>
+  <td class="rowfollow"><table class="torrentname"><tr><td class="embedded">
+    <a title="Demo.Anime.S01E06.2026.1080p" href="details.php?id=20001"><b>Demo.Anime.S01E06.2026.1080p</b></a>
+    <img class="pro_free" src="pic/trans.gif" alt="Free" />
+    <font color="#0000FF">剩余时间：<span title="2026-06-15 20:49:40">29天23时</span></font>
+    <br/>
+    <span>精选</span><span>中字</span><span>特效</span><span>分集</span>
+    演示动画副标题
+  </td></tr></table></td>
+  <td class="rowfollow">0</td>
+  <td class="rowfollow nowrap"><span title="2026-05-16 18:30:00">2时0分钟</span></td>
+  <td class="rowfollow">1.37 GB</td>
+  <td class="rowfollow">18</td>
+  <td class="rowfollow">2</td>
+  <td class="rowfollow">22</td>
+  <td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr>
+  <td class="rowfollow nowrap"><a href="?cat=410"><img class="m_music" alt="Music" title="Music" /></a></td>
+  <td class="rowfollow"><table class="torrentname"><tr><td class="embedded">
+    <a title="Demo.Album.2026.FLAC" href="details.php?id=20002"><b>Demo.Album.2026.FLAC</b></a>
+    <img class="pro_50pctdown" src="pic/trans.gif" alt="50%" title="50%" />
+    <br/>演示音乐副标题
+  </td></tr></table></td>
+  <td class="rowfollow">5</td>
+  <td class="rowfollow nowrap"><span title="2026-05-15 12:00:00">1天</span></td>
+  <td class="rowfollow">450 MB</td>
+  <td class="rowfollow">12</td>
+  <td class="rowfollow">3</td>
+  <td class="rowfollow">9</td>
+  <td class="rowfollow">DemoUploader</td>
+</tr>
+</table>
+</body></html>`
+
+const muaIndexFixture = `<html><body>
+<table id="info_block"><tr><td><span class="medium">
+欢迎回来, <span class="nowrap"><a href="https://mua.xloli.cc/userdetails.php?uuid=demo-uuid-0000-0000-0000-000000000000" target="_blank" class='User_Name'><b>mua_demo_user</b></a></span>
+[<a href="logout.php?token=REDACTED">退出</a>]
+<span class="color_bonus">魔力值 </span>[<a href="mybonus.php">使用</a>]: 105.5
+[已签到，获得70魔力，补签卡：0张]
+<span class="color_invite">邀请 </span>[<a href="invite.php">发送</a>]: 0(0)<br/>
+<span class="color_ratio">分享率：</span> 无限
+<font class='color_uploaded'>上传量：</font> 125.80 GB
+<font class='color_downloaded'> 下载量：</font> 0.00 KB
+<font class='color_active'>当前活动：</font>
+<img class="arrowup" alt="Torrents seeding" title="当前做种" src="pic/trans.gif" />5
+<img class="arrowdown" alt="Torrents leeching" title="当前下载" src="pic/trans.gif" />1
+&nbsp;<font class="color_connectable">可连接：</font>是
+</span></td></tr></table>
+</body></html>`
+
+const muaUserdetailsFixture = `<html><body>
+<table>
+  <tr><td class="rowhead nowrap" valign="top" align="right">用户ID/UID</td><td class="rowfollow">100901</td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">用户UUID</td><td class="rowfollow">demo-uuid-0000-0000-0000-000000000000</td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">加入日期</td><td class="rowfollow">2026-05-15 14:53:02 (<span title="2026-05-15 14:53:02">1天6时前, 0.2周</span>)</td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">传输</td><td class="rowfollow">
+    <table>
+      <tr><td>分享率: 无限</td></tr>
+      <tr><td>上传量: 125.80 GB</td><td>下载量: 0.00 KB</td></tr>
+    </table>
+  </td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">等级</td><td class="rowfollow"><img title="User" src="pic/user.gif" /></td></tr>
+</table>
+</body></html>`
+
+const muaMyBonusFixture = `<html><body>
+<div id="outer">
+您当前每小时能获取 1.20 个魔力值
+</div>
+</body></html>`
+
+const muaDetailFixture = `<html><body>
+<h1 align="center" id="top">Demo.Anime.S01E06.2026.1080p&nbsp; <b>[<font class='free'>免费</font>]</b> <font color="#0000FF">剩余时间：<span title="2026-06-15 20:49:40">29天23时</span></font></h1>
+<table>
+  <tr><td class="rowhead">下载</td><td class="rowfollow"><a href="download.php?id=20001">demo.torrent</a></td></tr>
+  <tr><td class="rowhead">副标题</td><td class="rowfollow">演示动画副标题</td></tr>
+  <tr><td class="rowhead">基本信息</td><td class="rowfollow">大小：1.37 GB 类型: 动画 (Animation) 来源: 日本 (JPN) 媒介: WEB-DL 编码: AVC/x264 音频编码: AAC 分辨率: 1080p 制作组: Other</td></tr>
+</table>
+</body></html>`
+
+func getMuaDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("mua")
+	require.True(t, ok)
+	return def
+}
+
+func testMuaSearch(t *testing.T) {
+	def := getMuaDef(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(muaSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{BaseURL: server.URL, Cookie: "test=1", Selectors: def.Selectors})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: http.MethodGet})
+	require.NoError(t, err)
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+
+	assert.Equal(t, "20001", items[0].ID)
+	assert.Equal(t, "Demo.Anime.S01E06.2026.1080p", items[0].Title)
+	assert.Equal(t, v2.DiscountFree, items[0].DiscountLevel)
+	assert.Equal(t, 18, items[0].Seeders)
+	assert.Equal(t, 2, items[0].Leechers)
+	assert.Equal(t, 22, items[0].Snatched)
+
+	assert.Equal(t, "20002", items[1].ID)
+	assert.Equal(t, v2.DiscountPercent50, items[1].DiscountLevel)
+}
+
+func testMuaDetail(t *testing.T) {
+	def := getMuaDef(t)
+	parser := v2.NewNexusPHPParserFromDefinition(def)
+
+	doc := FixtureDoc(t, "mua_detail", muaDetailFixture)
+	info := parser.ParseAll(doc.Selection)
+	assert.Equal(t, v2.DiscountFree, info.DiscountLevel)
+	assert.InDelta(t, 1402.88, info.SizeMB, 5.0)
+}
+
+func testMuaUserInfo(t *testing.T) {
+	def := getMuaDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	indexDoc := FixtureDoc(t, "mua_index", muaIndexFixture)
+	assert.Equal(t, "mua_demo_user", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["name"]))
+	assert.Equal(t, "105.5", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["bonus"]))
+	assert.Equal(t, "5", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["seeding"]))
+	assert.Equal(t, "1", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["leeching"]))
+
+	userDoc := FixtureDoc(t, "mua_userdetails", muaUserdetailsFixture)
+	assert.Equal(t, "100901", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["id"]),
+		"id 必须从 td.rowhead:contains('用户ID/UID') + td 提取（mua 的 userdetails URL 使用 uuid 而非整数 id）")
+	assert.NotEmpty(t, driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["uploaded"]))
+	assert.Equal(t, "User", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["levelName"]))
+
+	bonusDoc := FixtureDoc(t, "mua_mybonus", muaMyBonusFixture)
+	assert.Equal(t, "1.2", driver.ExtractFieldValuePublic(bonusDoc, def.UserInfo.Selectors["bonusPerHour"]))
+}
+
+func TestMua_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":      muaSearchFixture,
+		"index":       muaIndexFixture,
+		"userdetails": muaUserdetailsFixture,
+		"mybonus":     muaMyBonusFixture,
+		"detail":      muaDetailFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) { RequireNoSecrets(t, name, data) })
+	}
+}

--- a/site/v2/definitions/ourbits.go
+++ b/site/v2/definitions/ourbits.go
@@ -1,0 +1,147 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+var OurBitsDefinition = &v2.SiteDefinition{
+	ID:             "ourbits",
+	Name:           "OurBits",
+	Aka:            []string{"OB", "我们的部落"},
+	Description:    "OurBits — NexusPHP 综合性 PT 站点",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://ourbits.club/"},
+	FaviconURL:     "https://ourbits.club/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	HREnabled:      true,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "bonus", "seeding", "leeching"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields: []string{
+					"name", "uploaded", "downloaded", "ratio", "levelName", "joinTime",
+					"trueUploaded", "trueDownloaded",
+				},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/mybonus.php", ResponseType: "document"},
+				Fields:        []string{"bonusPerHour"},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			"id": {
+				Selector: []string{"#info_block a.User_Name", "#info_block a[href*='userdetails.php']"},
+				Attr:     "href",
+				Filters:  []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{"#info_block a.User_Name", "#info_block a[href*='userdetails.php']"},
+			},
+			"uploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('上传量') + td", "#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:上传量|Uploaded)[^\d]*([\d.,]+\s*[KMGTP]?i?B)`}}, {Name: "parseSize"}},
+			},
+			"downloaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('下载量') + td", "#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:下载量|Downloaded)[^\d]*([\d.,]+\s*[KMGTP]?i?B)`}}, {Name: "parseSize"}},
+			},
+			"ratio": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('分享率') + td", "#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:分享率|Ratio)[^\d∞]*([\d.,]+|∞|Inf|---)`}}, {Name: "parseNumber"}},
+			},
+			"levelName": {
+				Selector: []string{"td.rowhead:contains('等级') + td > img", "td.rowhead:contains('等级') + td img", "td.rowhead:contains('Class') + td img"},
+				Attr:     "title",
+			},
+			"bonus": {
+				Selector: []string{"#info_block", "td.rowhead:contains('魔力值') + td", "td.rowhead:contains('Bonus') + td"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`(?:魔力值|Bonus)[^\d]*?\[<a[^>]*>使用</a>\][:：]?\s*([\d.,]+)`}}, {Name: "parseNumber"}},
+			},
+			"joinTime": {
+				Selector: []string{"td.rowhead:contains('加入日期') + td", "td.rowhead:contains('Join') + td"},
+				Filters:  []v2.Filter{{Name: "split", Args: []any{" (", 0}}, {Name: "parseTime"}},
+			},
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`class="arrowup"[^>]*/>\s*(\d+)`}}, {Name: "parseNumber"}},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters:  []v2.Filter{{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}}, {Name: "parseNumber"}},
+			},
+			"trueUploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:真实上传量|实际上传量)[^\d]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"trueDownloaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:真实下载量|实际下载量)[^\d]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"bonusPerHour": {
+				Selector: []string{"#outer", "body"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:你当前每小时能获取|您当前每小时能获取)[^\d-]{0,20}([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		TableRows:          "table#torrenttable > tbody > tr:has(table.torrentname), table#torrenttable > tr:has(table.torrentname), table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:              "table.torrentname a[href*='details.php']",
+		TitleLink:          "table.torrentname a[href*='details.php']",
+		Subtitle:           "table.torrentname td.embedded > span:not(.optiontag)",
+		Size:               "td.rowfollow:nth-child(5)",
+		Seeders:            "td.rowfollow:nth-child(6)",
+		Leechers:           "td.rowfollow:nth-child(7)",
+		Snatched:           "td.rowfollow:nth-child(8)",
+		DiscountIcon:       "img.pro_free, img.pro_free2up, img.pro_50pctdown, img.pro_30pctdown, img.pro_2up, img.pro_50pctdown2up",
+		Category:           "td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:         "td.rowfollow:nth-child(4) span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords:       []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run", "H&R"},
+		DiscountSelector: "h1 font.free, h1 font[class]",
+		EndTimeSelector:  "h1 span[title]",
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(OurBitsDefinition)
+}

--- a/site/v2/definitions/ourbits_fixture_test.go
+++ b/site/v2/definitions/ourbits_fixture_test.go
@@ -1,0 +1,195 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "ourbits",
+		Search:   testOurbitsSearch,
+		Detail:   testOurbitsDetail,
+		UserInfo: testOurbitsUserInfo,
+	})
+}
+
+// 站点真实 HTML 结构（来自 issue #329 附件 ourbits.club-*.zip）的脱敏版本：
+//   - 10 列 NexusPHP 标准表格：cat / title / 评论 / 时间 / 大小 / 种子 / 下载 / 完成 / 进度 / 发布者
+//   - 详情页 h1 嵌入 free 折扣 + onmouseover 含剩余时间
+//   - userinfo: index 含 #info_block、userdetails 标准 NexusPHP 行
+const ourbitsSearchFixture = `<html><body>
+<table class="torrents" cellspacing="0" cellpadding="5" width="100%" id="torrenttable">
+<tr><td class="colhead">类型</td><td class="colhead">标题</td><td class="colhead">评论</td><td class="colhead">时间</td><td class="colhead">大小</td><td class="colhead">种子数</td><td class="colhead">下载数</td><td class="colhead">完成数</td><td class="colhead">进度</td><td class="colhead">发布者</td></tr>
+<tr>
+  <td class="rowfollow nowrap"><a href="?cat=401"><img class="c2_movies" alt="Movies" title="Movies" /></a></td>
+  <td class="rowfollow"><table class="torrentname"><tr><td class="embedded">
+    <a title="Demo.Movie.2026.UHD.BluRay.2160p" href="details.php?id=10001&amp;hit=1"><b>Demo.Movie.2026.UHD.BluRay.2160p</b></a>
+    <img class="pro_free" src="pic/trans.gif" alt="Free" onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;free&quot;&gt;免费&lt;/font&gt;&lt;/b&gt;剩余时间：&lt;b&gt;&lt;span title=&quot;2026-05-15 19:26:44&quot;&gt;9时35分&lt;/span&gt;&lt;/b&gt;', 'trail', false);" />
+    &nbsp;剩余时间：<b><span title="2026-05-15 19:26:44">9时35分</span></b>
+    <br/>演示电影副标题
+  </td></tr></table></td>
+  <td class="rowfollow">0</td>
+  <td class="rowfollow nowrap"><span title="2026-05-14 22:00:00">14时24分</span></td>
+  <td class="rowfollow">86.63 GB</td>
+  <td class="rowfollow">233</td>
+  <td class="rowfollow">14</td>
+  <td class="rowfollow">492</td>
+  <td>-</td>
+  <td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr>
+  <td class="rowfollow nowrap"><a href="?cat=402"><img class="c2_tv" alt="TV" title="TV" /></a></td>
+  <td class="rowfollow"><table class="torrentname"><tr><td class="embedded">
+    <a title="Demo.TV.S01E01.2026.1080p" href="details.php?id=10002"><b>Demo.TV.S01E01.2026.1080p</b></a>
+    <img class="pro_50pctdown" src="pic/trans.gif" alt="50%" title="50%" />
+    <img class="hitandrun" src="pic/trans.gif" alt="H&amp;R" title="H&amp;R" />
+    <br/>演示剧集副标题
+  </td></tr></table></td>
+  <td class="rowfollow">2</td>
+  <td class="rowfollow nowrap"><span title="2026-05-13 12:00:00">1天</span></td>
+  <td class="rowfollow">2.34 GB</td>
+  <td class="rowfollow">42</td>
+  <td class="rowfollow">8</td>
+  <td class="rowfollow">17</td>
+  <td>-</td>
+  <td class="rowfollow">DemoUploader</td>
+</tr>
+</table>
+</body></html>`
+
+const ourbitsIndexFixture = `<html><body>
+<table id="info_block"><tr><td><span class="medium">
+欢迎回来, <span class="nowrap"><a href="userdetails.php?id=70001" target="_blank" class='User_Name'><b>ob_demo_user</b></a></span>
+[<a href="logout.php?token=REDACTED">退出</a>]
+<span class="color_bonus">魔力值 </span>[<a href="mybonus.php">使用</a>]: 33,739.5
+&nbsp;(签到已得85)
+<span class="color_invite">邀请 </span>[<a href="invite.php?id=70001">发送</a>]: 0/0<br/>
+<span class="color_ratio">分享率：</span> 9.258
+<font class='color_uploaded'>上传量：</font> 337.04 GB
+<font class='color_downloaded'> 下载量：</font> 36.41 GB
+<font class='color_active'>当前活动：</font>
+<img class="arrowup" alt="Torrents seeding" title="当前做种" src="pic/trans.gif" />22
+<img class="arrowdown" alt="Torrents leeching" title="当前下载" src="pic/trans.gif" />0
+&nbsp;<font class="color_connectable">H&R: </font>0/10
+</span></td></tr></table>
+</body></html>`
+
+const ourbitsUserdetailsFixture = `<html><body>
+<table>
+  <tr><td class="rowhead nowrap" valign="top" align="right">加入日期</td><td class="rowfollow">2025-11-20 20:26:31 (<span title="2025-11-20 20:26:31">5月25天前</span>)</td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">最近动向</td><td class="rowfollow">网站访问: 2026-05-15 02:49:47 (7时1分前)</td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">传输</td><td class="rowfollow">
+    <table>
+      <tr><td>分享率: <font color="">1,930.915</font></td></tr>
+      <tr><td>上传量: 195.215 TB</td><td>下载量: 103.53 GB</td></tr>
+      <tr><td>真实分享率: 145.107</td></tr>
+      <tr><td>真实上传量: 99.104 TB</td><td>真实下载量: 699.36 GB</td></tr>
+    </table>
+  </td></tr>
+  <tr><td class="rowhead nowrap" valign="top" align="right">等级</td><td class="rowfollow"><img title="Power User" src="pic/poweruser.gif" /></td></tr>
+</table>
+</body></html>`
+
+const ourbitsMyBonusFixture = `<html><body>
+<div id="outer">
+您当前每小时能获取 18.50 个魔力值
+</div>
+</body></html>`
+
+const ourbitsDetailFixture = `<html><body>
+<h1 align="center" id="top">Demo.Movie.2026.UHD.BluRay.2160p&nbsp; <b>[<font class='free' onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;free&quot;&gt;免费&lt;/font&gt;&lt;/b&gt;剩余时间：&lt;b&gt;&lt;span title=&quot;2026-05-15 19:26:44&quot;&gt;9时35分&lt;/span&gt;&lt;/b&gt;', 'trail', false);">免费</font>]</b> 剩余时间：<b><span title="2026-05-15 19:26:44">9时35分</span></b></h1>
+<table>
+  <tr><td class="rowhead">下载</td><td class="rowfollow"><a href="download.php?id=10001">demo.torrent</a></td></tr>
+  <tr><td class="rowhead">副标题</td><td class="rowfollow">演示电影副标题</td></tr>
+  <tr><td class="rowhead">基本信息</td><td class="rowfollow">大小：86.63 GB 类型: Movies 媒介: UHD Blu-ray 编码: HEVC 音频编码: TrueHD 分辨率: 2160p 制作组: OurBits</td></tr>
+</table>
+</body></html>`
+
+func getOurbitsDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("ourbits")
+	require.True(t, ok)
+	return def
+}
+
+func testOurbitsSearch(t *testing.T) {
+	def := getOurbitsDef(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(ourbitsSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{BaseURL: server.URL, Cookie: "test=1", Selectors: def.Selectors})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: http.MethodGet})
+	require.NoError(t, err)
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+
+	assert.Equal(t, "10001", items[0].ID)
+	assert.Equal(t, "Demo.Movie.2026.UHD.BluRay.2160p", items[0].Title)
+	assert.Equal(t, v2.DiscountFree, items[0].DiscountLevel)
+	assert.Equal(t, 233, items[0].Seeders)
+	assert.Equal(t, 14, items[0].Leechers)
+	assert.Equal(t, 492, items[0].Snatched)
+
+	assert.Equal(t, "10002", items[1].ID)
+	assert.Equal(t, v2.DiscountPercent50, items[1].DiscountLevel)
+}
+
+func testOurbitsDetail(t *testing.T) {
+	def := getOurbitsDef(t)
+	parser := v2.NewNexusPHPParserFromDefinition(def)
+
+	doc := FixtureDoc(t, "ourbits_detail", ourbitsDetailFixture)
+	info := parser.ParseAll(doc.Selection)
+	assert.Equal(t, v2.DiscountFree, info.DiscountLevel)
+	assert.InDelta(t, 88708.92, info.SizeMB, 5.0)
+}
+
+func testOurbitsUserInfo(t *testing.T) {
+	def := getOurbitsDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	indexDoc := FixtureDoc(t, "ourbits_index", ourbitsIndexFixture)
+	assert.Equal(t, "70001", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["id"]))
+	assert.Equal(t, "ob_demo_user", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["name"]))
+	assert.Equal(t, "33739.5", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["bonus"]))
+	assert.Equal(t, "22", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["seeding"]))
+	assert.Equal(t, "0", driver.ExtractFieldValuePublic(indexDoc, def.UserInfo.Selectors["leeching"]))
+
+	userDoc := FixtureDoc(t, "ourbits_userdetails", ourbitsUserdetailsFixture)
+	assert.Equal(t, "214641162416291", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["uploaded"]))
+	assert.Equal(t, "111164491038", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["downloaded"]))
+	assert.Equal(t, "1930.915", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["ratio"]))
+	assert.Equal(t, "Power User", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["levelName"]))
+	assert.Equal(t, "108966000359112", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["trueUploaded"]))
+	assert.Equal(t, "750932082032", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["trueDownloaded"]))
+
+	bonusDoc := FixtureDoc(t, "ourbits_mybonus", ourbitsMyBonusFixture)
+	assert.Equal(t, "18.5", driver.ExtractFieldValuePublic(bonusDoc, def.UserInfo.Selectors["bonusPerHour"]))
+}
+
+func TestOurbits_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":      ourbitsSearchFixture,
+		"index":       ourbitsIndexFixture,
+		"userdetails": ourbitsUserdetailsFixture,
+		"mybonus":     ourbitsMyBonusFixture,
+		"detail":      ourbitsDetailFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) { RequireNoSecrets(t, name, data) })
+	}
+}

--- a/site/v2/definitions/real_html_validation_test.go
+++ b/site/v2/definitions/real_html_validation_test.go
@@ -61,6 +61,18 @@ func TestRealHTML_UserInfo(t *testing.T) {
 			indexFields:  []string{"id", "name", "seeding", "leeching"},
 			detailFields: []string{"uploaded", "downloaded", "ratio", "levelName", "joinTime"},
 		},
+		{
+			siteID:       "ourbits",
+			zipDir:       "/tmp/site-zips/ourbits",
+			indexFields:  []string{"id", "name", "bonus", "seeding", "leeching"},
+			detailFields: []string{"uploaded", "downloaded", "ratio", "levelName", "joinTime", "trueUploaded", "trueDownloaded"},
+		},
+		{
+			siteID:       "mua",
+			zipDir:       "/tmp/site-zips/mua",
+			indexFields:  []string{"id", "name", "bonus", "seeding", "leeching"},
+			detailFields: []string{"uploaded", "downloaded", "ratio", "joinTime"},
+		},
 	}
 
 	for _, tc := range sites {
@@ -138,6 +150,8 @@ func TestRealHTML_Search(t *testing.T) {
 		{"52pt", "/tmp/site-zips/52pt"},
 		{"lajidui", "/tmp/site-zips/lajidui"},
 		{"1ptba", "/tmp/site-zips/1ptba"},
+		{"ourbits", "/tmp/site-zips/ourbits"},
+		{"mua", "/tmp/site-zips/mua"},
 	}
 
 	for _, tc := range sites {
@@ -189,6 +203,8 @@ func TestRealHTML_Detail(t *testing.T) {
 		{"52pt", "/tmp/site-zips/52pt"},
 		{"lajidui", "/tmp/site-zips/lajidui"},
 		{"1ptba", "/tmp/site-zips/1ptba"},
+		{"ourbits", "/tmp/site-zips/ourbits"},
+		{"mua", "/tmp/site-zips/mua"},
 	}
 
 	for _, tc := range sites {

--- a/tools/browser-extension/src/core/constants.ts
+++ b/tools/browser-extension/src/core/constants.ts
@@ -391,6 +391,24 @@ export const KNOWN_SITES: KnownSite[] = [
     cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
     syncField: "cookie",
   },
+  {
+    id: "ourbits",
+    name: "OurBits",
+    domains: ["ourbits.club"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
+  {
+    id: "mua",
+    name: "Mua",
+    domains: ["mua.xloli.cc"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
 ];
 
 export const PAGE_PATTERNS: Array<{ pattern: RegExp; pageType: PageType }> = [


### PR DESCRIPTION
## Summary

3 个独立改动一起发版：

- **feat(sites)**: 新增 OurBits、Mua 两个 NexusPHP 站点适配（用 issue 附件 ZIP 验证）
- **fix(downloader)**: RSS 推送遵循站点-下载器绑定 (#373)
- **fix(scheduler)**: 磁盘预留独立于 CleanupEnabled 周期归零 (#374)

## feat(sites): OurBits + Mua

| 站点 | URL | Issue |
|---|---|---|
| OurBits | https://ourbits.club/ | #329 |
| Mua | https://mua.xloli.cc/ | #339 |

两站均为 NexusPHP + Cookie。Mua 的特殊点：userdetails URL 用 \`uuid=\` 而非 \`id=\`，所以整数 UID 必须从 \`td.rowhead:contains('用户ID/UID') + td\` 提取。

**用 issue 附件 ZIP 解压到 \`/tmp/site-zips/<id>/\` 后跑 \`TestRealHTML_*\` 全 PASS**：

- OurBits: 100 行真实搜索解析；详情 SizeMB=88709.1, Discount=FREE; 12 个 userinfo 字段全解析（含 trueUploaded/trueDownloaded）
- Mua: 100 行真实搜索解析；详情 SizeMB=1402.9, Discount=FREE; UID=100901 从 rowhead 正确提取

新增 6 个文件：
- \`site/v2/definitions/ourbits.go\` + \`ourbits_fixture_test.go\`
- \`site/v2/definitions/mua.go\` + \`mua_fixture_test.go\`
- \`site/v2/definitions/real_html_validation_test.go\` 加入两站
- \`tools/browser-extension/src/core/constants.ts\` KNOWN_SITES 同步
- \`docs/sites.md\` 41→43，NexusPHP 37→39

Closes #329
Closes #339
Note: #338 (btschool) 已在仓库中实现，无需新增。

## fix(downloader): #373

PR #294 之前 resolver 只看 \`RSSConfig.DownloaderID\` 与 \`is_default=true\`，导致用户在 UI 把站点（如 mteam）绑定到非默认下载器后，RSS 推送仍走 is_default。

修复：
- 新增 \`GetDownloaderForRSSAndSiteWithInfo(rssCfg, siteName)\`，优先级 RSS 行 → SiteSetting.DownloaderID → is_default
- 直接查 SiteSetting 表（不用 manager 内存 map，避免 init/Reload 后状态过时）
- 5 个边界场景：站点未绑定 / 站点行不存在 / 绑定下载器被删 / 绑定下载器禁用 / 旧 API 向后兼容
- 7 个回归测试

Closes #373

## fix(scheduler): #374

\`DiskBudget.Reset()\` 之前只在 \`CleanupMonitor.runOnce\` 内调用，被 \`CleanupEnabled\` gate 拦下，导致 \`CleanupDiskProtect=true + CleanupEnabled=false\` 时 reserved 单调累加（用户日志「本进程预留 984.6 GB」即此 bug 现场）。

修复：
- 抽出 \`maybeResetDiskBudget(cfg)\`，在 \`runLoop\` 顶部独立运行，与 \`CleanupEnabled\` 解耦
- 只要 \`CleanupDiskProtect=true\` 就周期 Reset
- 5 个回归测试覆盖核心契约 + 反向 + 防御 + 向后兼容 + 幂等

Closes #374

## Verification

- \`go test -race ./site/v2/... ./internal/ ./scheduler/\` 全绿
- \`make fmt-go\` + \`make lint-go\` 0 issues
- \`go vet ./...\` 无问题
- \`scripts/check-sites.ts\` 站点同步 OK（43/43）
- 12 个新回归测试 + 13 个新 fixture 测试，无现存测试 regression