### PR TITLE
fix(build): Docker 构建镜像同步升级至 Go 1.26.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ HTTPS_PROXY ?= $(https_proxy)
 NO_PROXY ?= $(no_proxy)
 
 # 默认基础镜像
-BUILD_IMAGE ?= golang:1.26.3
+BUILD_IMAGE ?= golang:1.26.4
 BASE_IMAGE ?= alpine:3.20.3
 NODE_IMAGE ?= node:25.2.0-alpine
 BUILD_ENV ?= remote


### PR DESCRIPTION
修复 v0.35.0 release 流水线 Docker 构建失败：Makefile BUILD_IMAGE 仍为 golang:1.26.3，与 go.mod 要求的 >=1.26.4 冲突。