### PR TITLE
fix(build): fmt 流程排除 CHANGELOG 与 release 清单

### DIFF
--- a/.oxfmtignore
+++ b/.oxfmtignore
@@ -1,0 +1,6 @@
+# release 工作流（update-changelog job）专门生成并格式化以下文件，
+# 开发与 CI 的 fmt / fmt-check 流程不应触碰它们，否则 git-cliff 重新生成后
+# 会与 oxfmt 期望格式冲突，导致 format-check 在两次 release 之间对所有 PR 误报。
+CHANGELOG.md
+.release-please-manifest.json
+release-please-config.json

--- a/Makefile
+++ b/Makefile
@@ -224,13 +224,18 @@ GO_FILES = $(shell find . -name "*.go" -not -path "./vendor/*" -not -path "./web
 fmt: fmt-oxfmt fmt-go
 	@echo "Formatting complete."
 
+# CHANGELOG.md 与 release-please 清单由 release 工作流（update-changelog job）专门生成并格式化，
+# 开发与 CI 的 fmt 流程不应触碰，否则 git-cliff 重新生成后会与 oxfmt 期望格式冲突，导致
+# format-check 在两次 release 之间对所有 PR 误报。排除清单见仓库根目录 .oxfmtignore。
+OXFMT_IGNORE = --ignore-path "$(PROJECT_ROOT)/.oxfmtignore"
+
 fmt-oxfmt:
 	@echo "Formatting with oxfmt..."
 	@cd web/frontend && if [ ! -d "node_modules" ]; then \
 		echo "Installing dependencies..."; \
 		pnpm install; \
 	fi && \
-	pnpm oxfmt --no-error-on-unmatched-pattern "$(PROJECT_ROOT)"
+	pnpm oxfmt --no-error-on-unmatched-pattern $(OXFMT_IGNORE) "$(PROJECT_ROOT)"
 
 fmt-go:
 	@echo "Formatting Go code..."
@@ -253,7 +258,7 @@ fmt-check:
 		echo "Installing dependencies..."; \
 		pnpm install; \
 	fi && \
-	pnpm oxfmt --no-error-on-unmatched-pattern --check "$(PROJECT_ROOT)"
+	pnpm oxfmt --no-error-on-unmatched-pattern --check $(OXFMT_IGNORE) "$(PROJECT_ROOT)"
 
 unit-test:
 	@mkdir -p $(DIST_DIR)


### PR DESCRIPTION
## 背景

`make fmt` / `make fmt-check`（`fmt-oxfmt`）对**整个仓库**跑 oxfmt，包含 `CHANGELOG.md`。但 CHANGELOG 由 release 工作流的 `update-changelog` job（git-cliff + oxfmt）专门生成并格式化。两者时机不同步：release-please 写入 CHANGELOG 后（`chore(changelog): update [skip ci]`），在下一次 release 之前，main 上的 CHANGELOG 处于 git-cliff 原始态。任何此期间开的 PR 跑 format-check 时，`make fmt` 会重新格式化 CHANGELOG → `git status` 非空 → **format-check 对所有 PR 误报失败**（如 #390）。

## 改动

- 新增仓库根 `.oxfmtignore`，列出 `CHANGELOG.md` + `.release-please-manifest.json` + `release-please-config.json`
- `fmt-oxfmt` / `fmt-check` 经 `--ignore-path "$(PROJECT_ROOT)/.oxfmtignore"` 跳过这些文件

## 关于「release 后是否需要手动/CI 格式化 CHANGELOG」

**不需要任何额外动作**：
- **Release 时**：`release-please.yml` 的 `update-changelog` job 仍用显式文件参数 `oxfmt ".../CHANGELOG.md" ...` 格式化并 commit（不受 `.oxfmtignore` 影响，因为它不走 `--ignore-path`）。**保持不变，照常自动格式化。**
- **开发 / PR 时**：经 `.oxfmtignore` 跳过 CHANGELOG，不再误报。

职责清晰分离：CHANGELOG 的格式化只由 release 工作流负责，开发流程不碰。

## 验证

- 干净 main 状态下 `make fmt` 不再改动 CHANGELOG（仅 Makefile/.oxfmtignore 本身）
- `make fmt-check` EXIT 0
- 模拟 release job 的显式 CHANGELOG 调用仍正常格式化（分离有效）