### PR TITLE
feat(site): 适配 ZmPT 站点

### DIFF
--- a/docs/sites.md
+++ b/docs/sites.md
@@ -1,8 +1,8 @@
 ## 支持站点
 
-当前已适配 **44** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
+当前已适配 **45** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
 
-### NexusPHP 系列（40）
+### NexusPHP 系列（41）
 
 | 站点                  | 认证方式 | 支持功能                      | 适配情况 | 备注                                                             |
 | --------------------- | -------- | ----------------------------- | -------- | ---------------------------------------------------------------- |
@@ -46,6 +46,7 @@
 | **1PTBar**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
 | **lajidui**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
 | **PTLGS**             | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（ptlgs.org，issue #377）                                  |
+| **ZmPT**              | Cookie   | RSS、搜索、用户信息           | ✅       | 织梦（zmpt.cc，电力值=魔力值）                                   |
 
 ### 其他架构（4）
 

--- a/site/v2/definitions/zmpt.go
+++ b/site/v2/definitions/zmpt.go
@@ -1,0 +1,178 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+// ZmptDefinition is the site definition for ZmPT (zmpt.cc, 织梦), a vanilla
+// NexusPHP site. UserInfo stats are read from the top-of-page #info_block
+// (color-class fonts); note ZmPT labels bonus as「电力值」instead of「魔力值」.
+var ZmptDefinition = &v2.SiteDefinition{
+	ID:             "zmpt",
+	Name:           "ZmPT",
+	Aka:            []string{"织梦", "ZM"},
+	Description:    "综合性 PT 站点",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://zmpt.cc/"},
+	FaviconURL:     "https://zmpt.cc/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "uploaded", "downloaded", "ratio", "seeding", "leeching", "bonus"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields:        []string{"levelName", "joinTime", "lastAccessAt"},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			"id": {
+				Selector: []string{
+					"a[href*='userdetails.php'][class*='Name']",
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php']",
+				},
+				Attr:    "href",
+				Filters: []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{
+					"a[href*='userdetails.php'][class*='Name']",
+					"#info_block a[href*='userdetails.php']",
+				},
+			},
+			"uploaded": {
+				Selector: []string{"#info_block", "td.rowhead:contains('传输') + td", "td.rowhead:contains('上传量') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:上传量|上傳量|Uploaded)[^\d]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"downloaded": {
+				Selector: []string{"#info_block", "td.rowhead:contains('传输') + td", "td.rowhead:contains('下载量') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:下载量|下載量|Downloaded)[^\d]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"ratio": {
+				Selector: []string{"#info_block", "td.rowhead:contains('传输') + td", "td.rowhead:contains('分享率') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:分享率|Ratio)[^\d∞]*([\d.,]+|∞|Inf|---)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			// ZmPT labels bonus as「电力值」(not the usual「魔力值」).
+			"bonus": {
+				Selector: []string{"#info_block", "td.rowhead:contains('电力值') + td", "td.rowhead:contains('魔力值') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:电力值|電力值|魔力值|Bonus)[^\d]*([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowup"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"levelName": {
+				Selector: []string{
+					"td.rowhead:contains('等级') + td img",
+					"td.rowhead:contains('等級') + td img",
+					"td.rowhead:contains('Class') + td img",
+				},
+				Attr: "title",
+			},
+			"joinTime": {
+				Selector: []string{
+					"td.rowhead:contains('加入日期') + td",
+					"td.rowhead:contains('加入時間') + td",
+					"td.rowhead:contains('Join') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+			// 保号探测所需：最近动向 → UserInfo.LastAccess
+			"lastAccessAt": {
+				Selector: []string{
+					"td.rowhead:contains('最近动向') + td",
+					"td.rowhead:contains('最近動向') + td",
+					"td.rowhead:contains('最后活动') + td",
+					"td.rowhead:contains('最後活動') + td",
+					"td.rowhead:contains('上次访问') + td",
+					"td.rowhead:contains('Last access') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+		},
+	},
+	// 搜索结果行结构：类型 | 标题 | 评论 | 存活时间 | 大小 | 种子 | 下载 | 完成 | 发布者
+	Selectors: &v2.SiteSelectors{
+		TableRows:          "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:              "table.torrentname a[href*='details.php']",
+		TitleLink:          "table.torrentname a[href*='details.php']",
+		Subtitle:           "table.torrentname td.embedded > span:last-of-type, table.torrentname td.embedded > span",
+		Size:               "td.rowfollow:nth-child(5)",
+		Seeders:            "td.rowfollow:nth-child(6)",
+		Leechers:           "td.rowfollow:nth-child(7)",
+		Snatched:           "td.rowfollow:nth-child(8)",
+		DiscountIcon:       "img.pro_free, img.pro_free2up, img.pro_2up, img.pro_50pctdown, img.pro_30pctdown, img.pro_50pctdown2up",
+		Category:           "td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:         "td.rowfollow:nth-child(4) span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords:       []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		TitleSelector:    "input[name='torrent_name']",
+		IDSelector:       "input[name='detail_torrent_id']",
+		DiscountSelector: "h1 font.free, h1 font[class]",
+		EndTimeSelector:  "h1 span[title]",
+		SizeSelector:     "td.rowhead:contains('基本信息')",
+		SizeRegex:        `大小：[^\d]*([\d.]+)\s*(GB|MB|KB|TB)`,
+	},
+	LevelRequirements: []v2.SiteLevelRequirement{
+		{ID: 1, Name: "User", NameAka: []string{"新人"}},
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(ZmptDefinition)
+}

--- a/site/v2/definitions/zmpt_fixture_test.go
+++ b/site/v2/definitions/zmpt_fixture_test.go
@@ -1,0 +1,204 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "zmpt",
+		Search:   testZmptSearch,
+		Detail:   testZmptDetail,
+		UserInfo: testZmptUserInfo,
+	})
+}
+
+// --- Fixtures (anonymized, modeled on zmpt.cc real HTML) ---
+
+const zmptSearchFixture = `<html><body>
+<table class="torrents" cellspacing="0" cellpadding="5" width="100%">
+<tr>
+	<td class="colhead">类型</td><td class="colhead">标题</td><td class="colhead">评论</td>
+	<td class="colhead">存活时间</td><td class="colhead">大小</td><td class="colhead">种子数</td>
+	<td class="colhead">下载数</td><td class="colhead">完成数</td><td class="colhead">发布者</td>
+</tr>
+<tr>
+	<td class="rowfollow nowrap"><a href="?cat=404"><img class="c_anime" alt="动漫" title="动漫" /></a></td>
+	<td class="rowfollow" width="100%" align="left">
+		<table class="torrentname" width="100%"><tr><td class="embedded">
+			<a title="Test.Anime.S01.2025.2160p.WEB-DL.H264-GRP" href="details.php?id=343859&amp;hit=1"><b>Test.Anime.S01.2025.2160p.WEB-DL.H264-GRP</b></a>
+			<img class="pro_free" src="pic/trans.gif" alt="Free" />
+			<font color='#0000FF'>剩余时间：<span title="2026-06-06 19:04:17">4时14分钟</span></font>
+			<br />
+			<span title="">国语</span><span title="">中字</span>测试动画 / Test Anime
+		</td>
+		<td class="embedded"><a href="download.php?id=343859"><img class="download" alt="download" title="下载" /></a></td>
+		</tr></table>
+	</td>
+	<td class="rowfollow"><a href="comment.php?action=add&amp;pid=343859">0</a></td>
+	<td class="rowfollow nowrap"><span title="2025-12-01 10:20:30">6月<br />5天</span></td>
+	<td class="rowfollow">344.65<br />GB</td>
+	<td class="rowfollow" align="center"><b><a href="details.php?id=343859&amp;dllist=1#seeders">42</a></b></td>
+	<td class="rowfollow">3</td>
+	<td class="rowfollow"><a href="viewsnatches.php?id=343859"><b>120</b></a></td>
+	<td class="rowfollow"><i>匿名</i></td>
+</tr>
+</table>
+</body></html>`
+
+const zmptDetailFixture = `<html><body>
+<h1 align="center" id="top">Test.Anime.S01.2025.2160p.WEB-DL.H264-GRP&nbsp;&nbsp;&nbsp; <b>[<font class='free' >免费</font>]</b> <font color='#0000FF'>剩余时间：<span title="2026-06-06 19:04:17">4时14分钟</span></font>
+	<input name="torrent_name" type="hidden" value="Test.Anime.S01.2025.2160p.WEB-DL.H264-GRP" />
+	<input name="detail_torrent_id" type="hidden" value="343859" />
+</h1>
+<table>
+<tr><td class="rowhead nowrap" valign="top" align="right">基本信息</td>
+	<td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>344.65 GB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;动漫 / Anime</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">副标题</td>
+	<td class="rowfollow" valign="top" align="left">测试动画 / Test Anime 国语中字</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">下载</td>
+	<td class="rowfollow" valign="top" align="left"><a href="download.php?id=343859">下载种子</a></td></tr>
+</table>
+</body></html>`
+
+// zmptIndexFixture models the top-of-page #info_block (logged-in user). ZmPT
+// uses color-class fonts and labels bonus as「电力值」.
+const zmptIndexFixture = `<html><body>
+<table id="info_block"><tr><td>
+	<span class="nowrap"><a href="https://zmpt.cc/userdetails.php?id=23124" class='User_Name'><b>testuser</b></a></span>
+	<font class="color_ratio"> 分享率: </font> 12.197
+	<font class='color_uploaded'> 上传量: </font> 248.64 GB
+	<font class='color_downloaded'> 下载量: </font> 20.38 GB
+	<font class='color_active'> 当前活动: </font> <img class="arrowup" alt="Torrents seeding" title="当前做种" src="pic/trans.gif" />33 <img class="arrowdown" alt="Torrents leeching" title="当前下载" src="pic/trans.gif" />0
+	<a href="mybonus.php" id="self_bonus"><font class='color_bonus'> 电力值 </font> 1,474,397.2</a>
+</td></tr></table>
+</body></html>`
+
+// zmptUserdetailsFixture models the SELF userdetails.php main table rows.
+// (The captured ZIP's userdetails was a privacy-protected OTHER user, so these
+// standard NexusPHP rows are modeled from the 织梦/NexusPHP template.)
+const zmptUserdetailsFixture = `<html><body>
+<table>
+<tr><td class="rowhead nowrap">等级</td><td class="rowfollow"><img alt="User" title="User" src="pic/user.gif" /></td></tr>
+<tr><td class="rowhead nowrap">加入日期</td><td class="rowfollow">2024-03-10 09:15:00 (<span title="2024-03-10 09:15:00">2年前</span>)</td></tr>
+<tr><td class="rowhead nowrap">最近动向</td><td class="rowfollow">2026-06-06 14:30:00 (<span title="2026-06-06 14:30:00">&lt; 1分钟前</span>)</td></tr>
+</table>
+</body></html>`
+
+// --- Tests ---
+
+func getZmptDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("zmpt")
+	require.True(t, ok, "zmpt definition not found")
+	return def
+}
+
+func testZmptSearch(t *testing.T) {
+	def := getZmptDef(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(zmptSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{
+		BaseURL:   server.URL,
+		Cookie:    "test_cookie=1",
+		Selectors: def.Selectors,
+	})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: "GET"})
+	require.NoError(t, err)
+
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	item := items[0]
+	assert.Equal(t, "343859", item.ID)
+	assert.Equal(t, "Test.Anime.S01.2025.2160p.WEB-DL.H264-GRP", item.Title)
+	assert.Equal(t, v2.DiscountFree, item.DiscountLevel)
+	assert.Equal(t, 42, item.Seeders)
+	assert.Equal(t, 3, item.Leechers)
+	assert.Equal(t, 120, item.Snatched)
+	assert.True(t, item.SizeBytes > 0, "size should be parsed")
+}
+
+func testZmptDetail(t *testing.T) {
+	def := getZmptDef(t)
+
+	doc := FixtureDoc(t, "zmpt_detail", zmptDetailFixture)
+	parser := v2.NewNexusPHPParserFromDefinition(def)
+	info := parser.ParseAll(doc.Selection)
+
+	assert.Equal(t, "Test.Anime.S01.2025.2160p.WEB-DL.H264-GRP", info.Title)
+	assert.Equal(t, "343859", info.TorrentID)
+	assert.Equal(t, v2.DiscountFree, info.DiscountLevel)
+	assert.InDelta(t, 344.65*1024, info.SizeMB, 0.1)
+}
+
+func testZmptUserInfo(t *testing.T) {
+	def := getZmptDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	// Fields from index.php #info_block.
+	indexDoc := FixtureDoc(t, "zmpt_index", zmptIndexFixture)
+	indexFields := map[string]string{
+		"id":         "23124",
+		"name":       "testuser",
+		"ratio":      "12.197",
+		"seeding":    "33",
+		"leeching":   "0",
+		"uploaded":   "266975167119",
+		"downloaded": "21882858373",
+		"bonus":      "1.4743972e+06",
+	}
+	for field, expected := range indexFields {
+		t.Run(field, func(t *testing.T) {
+			sel, ok := def.UserInfo.Selectors[field]
+			require.True(t, ok, "selector %q not found", field)
+			assert.Equal(t, expected, driver.ExtractFieldValuePublic(indexDoc, sel))
+		})
+	}
+
+	// Fields from userdetails.php main table.
+	userDoc := FixtureDoc(t, "zmpt_userdetails", zmptUserdetailsFixture)
+	t.Run("levelName", func(t *testing.T) {
+		assert.Equal(t, "User", driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["levelName"]))
+	})
+	t.Run("lastAccessAt", func(t *testing.T) {
+		got := driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["lastAccessAt"])
+		assert.NotEmpty(t, got, "lastAccessAt must parse (保号 probe depends on UserInfo.LastAccess)")
+		assert.NotEqual(t, "0", got)
+	})
+	t.Run("joinTime", func(t *testing.T) {
+		got := driver.ExtractFieldValuePublic(userDoc, def.UserInfo.Selectors["joinTime"])
+		assert.NotEmpty(t, got)
+		assert.NotEqual(t, "0", got)
+	})
+}
+
+func TestZmpt_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":      zmptSearchFixture,
+		"detail":      zmptDetailFixture,
+		"index":       zmptIndexFixture,
+		"userdetails": zmptUserdetailsFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			RequireNoSecrets(t, name, data)
+		})
+	}
+}

--- a/tools/browser-extension/src/core/constants.ts
+++ b/tools/browser-extension/src/core/constants.ts
@@ -77,6 +77,15 @@ export const KNOWN_SITES: KnownSite[] = [
     syncField: "cookie",
   },
   {
+    id: "zmpt",
+    name: "ZmPT",
+    domains: ["zmpt.cc"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
+  {
     id: "rousipro",
     name: "Rousi Pro",
     domains: ["rousi.pro", "www.rousi.pro"],


### PR DESCRIPTION
## Summary
适配 NexusPHP 站点 ZmPT（zmpt.cc，织梦），含完整保号（lastAccess）支持。

## Changes
- **feat(site)**: 新增 `site/v2/definitions/zmpt.go` + fixture 测试
  - 从 `#info_block` 解析 id/name/ratio/uploaded/downloaded/seeding/leeching/bonus
  - bonus 适配 ZmPT 特有的「电力值」标签（非「魔力值」）
  - 配置 `lastAccessAt` 选择器支持保号探测（Pitfall #16）
  - detail 复用标准 NexusPHP 配置（input title + 基本信息 size）
- **extension**: `constants.ts` KNOWN_SITES 增加 zmpt（`pt-sites.ts` 已含 zmpt.cc）
- **docs**: `docs/sites.md` 新增 ZmPT 行，站点计数 44→45、NexusPHP 40→41

## Test
- `make fmt` 干净（含 .oxfmtignore 修复，不再误改 CHANGELOG）
- 新增 fixture 测试全 PASS（Search/Detail/UserInfo + NoSecrets，断言 lastAccess/joinTime 非零）
- 完整 definitions 套件无回归
- 浏览器扩展站点一致性检查通过（Go 45 == 扩展 45）

## 备注
ZmPT 抓取的 userdetails 为隐私页，lastAccess/join/level 行采用标准 NexusPHP 模板建模（zmpt 为 vanilla NexusPHP，footer 确认）。