### PR TITLE
fix: 修复重复下载/探测诊断并新增单站点刷流容量限制

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .kiro
+.omo
 .pt-tools
 .sisyphus
 .trae

--- a/core/config_store.go
+++ b/core/config_store.go
@@ -151,7 +151,7 @@ func (s *ConfigStore) Load() (*models.Config, error) {
 			if e != nil {
 				return e
 			}
-			sc := models.SiteConfig{Enabled: boolPtr(sitem.Enabled), AuthMethod: sitem.AuthMethod, Cookie: cookie, APIKey: sitem.APIKey, APIUrl: sitem.APIUrl, Passkey: sitem.Passkey, UploadLimitKBs: sitem.UploadLimitKBs, DownloadLimitKBs: sitem.DownloadLimitKBs, RSS: []models.RSSConfig{}}
+			sc := models.SiteConfig{Enabled: boolPtr(sitem.Enabled), AuthMethod: sitem.AuthMethod, Cookie: cookie, APIKey: sitem.APIKey, APIUrl: sitem.APIUrl, Passkey: sitem.Passkey, UploadLimitKBs: sitem.UploadLimitKBs, DownloadLimitKBs: sitem.DownloadLimitKBs, SeedingCapacityGB: sitem.SeedingCapacityGB, RSS: []models.RSSConfig{}}
 			var rss []models.RSSSubscription
 			if e := tx.Where("site_id = ?", sitem.ID).Find(&rss).Error; e != nil {
 				return e
@@ -574,6 +574,7 @@ func (s *ConfigStore) UpsertSiteWithRSS(site models.SiteGroup, sc models.SiteCon
 		row.Passkey = sc.Passkey
 		row.UploadLimitKBs = sc.UploadLimitKBs
 		row.DownloadLimitKBs = sc.DownloadLimitKBs
+		row.SeedingCapacityGB = sc.SeedingCapacityGB
 		if err := tx.Save(&row).Error; err != nil {
 			return err
 		}
@@ -790,7 +791,7 @@ func (s *ConfigStore) ListSites() (map[models.SiteGroup]models.SiteConfig, error
 		if err != nil {
 			return nil, err
 		}
-		sc := models.SiteConfig{Enabled: boolPtr(ss.Enabled), AuthMethod: ss.AuthMethod, Cookie: cookie, APIKey: ss.APIKey, APIUrl: ss.APIUrl, Passkey: ss.Passkey, UploadLimitKBs: ss.UploadLimitKBs, DownloadLimitKBs: ss.DownloadLimitKBs, RSS: []models.RSSConfig{}}
+		sc := models.SiteConfig{Enabled: boolPtr(ss.Enabled), AuthMethod: ss.AuthMethod, Cookie: cookie, APIKey: ss.APIKey, APIUrl: ss.APIUrl, Passkey: ss.Passkey, UploadLimitKBs: ss.UploadLimitKBs, DownloadLimitKBs: ss.DownloadLimitKBs, SeedingCapacityGB: ss.SeedingCapacityGB, RSS: []models.RSSConfig{}}
 		var rss []models.RSSSubscription
 		if err := s.db.DB.Where("site_id = ?", ss.ID).Find(&rss).Error; err != nil {
 			return nil, err
@@ -815,7 +816,7 @@ func (s *ConfigStore) GetSiteConf(name models.SiteGroup) (models.SiteConfig, err
 	if err != nil {
 		return models.SiteConfig{}, err
 	}
-	sc := models.SiteConfig{Enabled: boolPtr(ss.Enabled), AuthMethod: ss.AuthMethod, Cookie: cookie, APIKey: ss.APIKey, APIUrl: ss.APIUrl, Passkey: ss.Passkey, UploadLimitKBs: ss.UploadLimitKBs, DownloadLimitKBs: ss.DownloadLimitKBs, RSS: []models.RSSConfig{}}
+	sc := models.SiteConfig{Enabled: boolPtr(ss.Enabled), AuthMethod: ss.AuthMethod, Cookie: cookie, APIKey: ss.APIKey, APIUrl: ss.APIUrl, Passkey: ss.Passkey, UploadLimitKBs: ss.UploadLimitKBs, DownloadLimitKBs: ss.DownloadLimitKBs, SeedingCapacityGB: ss.SeedingCapacityGB, RSS: []models.RSSConfig{}}
 	var rss []models.RSSSubscription
 	if err := s.db.DB.Where("site_id = ?", ss.ID).Find(&rss).Error; err != nil {
 		return models.SiteConfig{}, err

--- a/internal/common.go
+++ b/internal/common.go
@@ -711,7 +711,7 @@ func downloadWorkerUnified(
 			if len(item.Enclosures) > 0 {
 				torrentURL = item.Enclosures[0].URL
 			} else {
-				torrentURL = ""
+				torrentURL = item.Link
 			}
 			title := item.Title
 			// 查询数据库记录
@@ -1169,17 +1169,23 @@ func FetchAndDownloadFreeRSSUnified(ctx context.Context, m UnifiedPTSite, rssCfg
 		)
 	}
 
+	var discarded int
 	for _, item := range feed.Items {
-		if len(item.Enclosures) > 0 {
-			select {
-			case <-ctxWithTimeout.Done():
-				sLogger().Info("任务被取消")
-				close(torrentChan)
-				wg.Wait()
-				return ctxWithTimeout.Err()
-			case torrentChan <- item:
-			}
+		if len(item.Enclosures) == 0 && strings.TrimSpace(item.Link) == "" {
+			discarded++
+			continue
 		}
+		select {
+		case <-ctxWithTimeout.Done():
+			sLogger().Info("任务被取消")
+			close(torrentChan)
+			wg.Wait()
+			return ctxWithTimeout.Err()
+		case torrentChan <- item:
+		}
+	}
+	if discarded > 0 {
+		sLogger().Warnf("[RSS] 站点=%s, RSS=%s, 丢弃 %d 个无下载链接条目", siteName, rssCfg.Name, discarded)
 	}
 	close(torrentChan)
 	wg.Wait()
@@ -1278,17 +1284,23 @@ func FetchAndDownloadFreeRSS[T models.ResType](ctx context.Context, siteName mod
 		)
 	}
 	// 将种子发送到下载队列
+	var discarded int
 	for _, item := range feed.Items {
-		if len(item.Enclosures) > 0 {
-			select {
-			case <-ctxWithTimeout.Done():
-				sLogger().Info("任务被取消")
-				close(torrentChan)
-				wg.Wait()
-				return ctxWithTimeout.Err()
-			case torrentChan <- item:
-			}
+		if len(item.Enclosures) == 0 && strings.TrimSpace(item.Link) == "" {
+			discarded++
+			continue
 		}
+		select {
+		case <-ctxWithTimeout.Done():
+			sLogger().Info("任务被取消")
+			close(torrentChan)
+			wg.Wait()
+			return ctxWithTimeout.Err()
+		case torrentChan <- item:
+		}
+	}
+	if discarded > 0 {
+		sLogger().Warnf("[RSS] 站点=%s, RSS=%s, 丢弃 %d 个无下载链接条目", siteName, rssCfg.Name, discarded)
 	}
 	close(torrentChan)
 	wg.Wait()
@@ -1343,7 +1355,7 @@ func downloadWorker[T models.ResType](
 			if len(item.Enclosures) > 0 {
 				torrentURL = item.Enclosures[0].URL
 			} else {
-				torrentURL = ""
+				torrentURL = item.Link
 			}
 			title := item.Title
 			// 查询数据库记录

--- a/internal/common.go
+++ b/internal/common.go
@@ -614,6 +614,24 @@ type rssTaskStats struct {
 	downloadFailed atomic.Int64
 }
 
+func shouldSkipSiteDownload(torrent *models.TorrentInfo, downloadPath, fileBase string, maxRetry int) (bool, string) {
+	if torrent == nil {
+		return false, ""
+	}
+	if torrent.IsPushed != nil && *torrent.IsPushed {
+		return true, "已推送，跳过重新下载"
+	}
+	if maxRetry > 0 && torrent.RetryCount >= maxRetry {
+		return true, fmt.Sprintf("超过最大重试次数 %d", maxRetry)
+	}
+	if torrent.IsDownloaded {
+		if _, statErr := os.Stat(filepath.Join(downloadPath, fileBase+".torrent")); statErr == nil {
+			return true, "已下载且本地文件存在"
+		}
+	}
+	return false, ""
+}
+
 func shouldSkipExistingTorrent(torrent *models.TorrentInfo) bool {
 	if torrent == nil {
 		return false
@@ -885,6 +903,11 @@ func downloadWorkerUnified(
 				}
 				// 文件命名统一为 siteName-torrentID.torrent，避免重复与歧义
 				fileBase := fmt.Sprintf("%s-%s", strings.ToLower(string(siteName)), item.GUID)
+				if skip, reason := shouldSkipSiteDownload(torrent, downloadPath, fileBase, gl.MaxRetry); skip {
+					sLogger().Infof("种子: %s 跳过重新下载 (原因: %s)", title, reason)
+					stats.skipped.Add(1)
+					continue
+				}
 				hash, downloadErr := site.DownloadTorrent(torrentURL, fileBase, downloadPath)
 				if downloadErr != nil {
 					sLogger().Errorf("%s: 种子下载失败, %v", title, downloadErr)
@@ -1454,6 +1477,10 @@ func downloadWorker[T models.ResType](
 					}
 					// 文件命名统一为 siteName-torrentID.torrent，避免重复与歧义
 					fileBase := fmt.Sprintf("%s-%s", strings.ToLower(string(siteName)), item.GUID)
+					if skip, reason := shouldSkipSiteDownload(torrent, downloadPath, fileBase, gl.MaxRetry); skip {
+						sLogger().Infof("种子: %s 跳过重新下载 (原因: %s)", title, reason)
+						return nil
+					}
 					hash, downloadErr := site.DownloadTorrent(torrentURL, fileBase, downloadPath)
 					if downloadErr != nil {
 						return fmt.Errorf("种子下载失败: %w", downloadErr)

--- a/internal/common_test.go
+++ b/internal/common_test.go
@@ -1518,3 +1518,84 @@ func TestFilterTorrentFilesBySite_FallbackAllWhenNoPrefixMatch(t *testing.T) {
 	require.Equal(t, files[0], filtered[0])
 	require.Equal(t, files[1], filtered[1])
 }
+
+func TestShouldSkipSiteDownload(t *testing.T) {
+	dir := t.TempDir()
+	fileBase := "site-123"
+	existingPath := filepath.Join(dir, fileBase+".torrent")
+	require.NoError(t, os.WriteFile(existingPath, []byte("d4:test4:datae"), 0o644))
+
+	boolPtr := func(b bool) *bool { return &b }
+
+	tests := []struct {
+		name       string
+		torrent    *models.TorrentInfo
+		fileBase   string
+		maxRetry   int
+		wantSkip   bool
+		wantReason string
+	}{
+		{
+			name:       "已推送应跳过",
+			torrent:    &models.TorrentInfo{IsPushed: boolPtr(true)},
+			fileBase:   fileBase,
+			maxRetry:   3,
+			wantSkip:   true,
+			wantReason: "已推送，跳过重新下载",
+		},
+		{
+			name:       "超过最大重试次数应跳过",
+			torrent:    &models.TorrentInfo{RetryCount: 3},
+			fileBase:   fileBase,
+			maxRetry:   3,
+			wantSkip:   true,
+			wantReason: "超过最大重试次数 3",
+		},
+		{
+			name:       "已下载且本地文件存在应跳过",
+			torrent:    &models.TorrentInfo{IsDownloaded: true},
+			fileBase:   fileBase,
+			maxRetry:   3,
+			wantSkip:   true,
+			wantReason: "已下载且本地文件存在",
+		},
+		{
+			name:     "已下载但本地文件不存在不跳过",
+			torrent:  &models.TorrentInfo{IsDownloaded: true},
+			fileBase: "missing-file",
+			maxRetry: 3,
+			wantSkip: false,
+		},
+		{
+			name:     "torrent为nil不跳过",
+			torrent:  nil,
+			fileBase: fileBase,
+			maxRetry: 3,
+			wantSkip: false,
+		},
+		{
+			name:     "未下载不跳过",
+			torrent:  &models.TorrentInfo{IsDownloaded: false},
+			fileBase: fileBase,
+			maxRetry: 3,
+			wantSkip: false,
+		},
+		{
+			name:     "maxRetry为0时高重试次数不跳过",
+			torrent:  &models.TorrentInfo{RetryCount: 99},
+			fileBase: fileBase,
+			maxRetry: 0,
+			wantSkip: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skip, reason := shouldSkipSiteDownload(tt.torrent, dir, tt.fileBase, tt.maxRetry)
+			require.Equal(t, tt.wantSkip, skip)
+			if tt.wantReason != "" {
+				require.Equal(t, tt.wantReason, reason)
+			}
+		})
+	}
+}

--- a/internal/common_test.go
+++ b/internal/common_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -145,6 +146,70 @@ func TestFetchAndDownloadFreeRSS_Basic(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	require.NoError(t, FetchAndDownloadFreeRSS(ctx, models.SiteGroup("springsunday"), &rssSiteStub{}, models.RSSConfig{Name: "r", URL: srv.URL, Tag: "tag"}))
+}
+
+// linkURLSiteStub 记录传入 DownloadTorrent 的 url，用于断言无 enclosure 时回退 item.Link
+type linkURLSiteStub struct{ gotURL string }
+
+func (s *linkURLSiteStub) GetTorrentDetails(item *gofeed.Item) (*models.APIResponse[models.PHPTorrentInfo], error) {
+	d := models.PHPTorrentInfo{Title: item.Title, TorrentID: item.GUID, Discount: models.DISCOUNT_FREE, EndTime: time.Now().Add(1 * time.Hour), SizeMB: 64}
+	return &models.APIResponse[models.PHPTorrentInfo]{Code: "success", Data: d}, nil
+}
+func (s *linkURLSiteStub) IsEnabled() bool { return true }
+func (s *linkURLSiteStub) DownloadTorrent(url, title, dir string) (string, error) {
+	s.gotURL = url
+	_ = os.MkdirAll(dir, 0o755)
+	p := filepath.Join(dir, title+".torrent")
+	return "hash-link", os.WriteFile(p, []byte("d4:infoe"), 0o644)
+}
+func (s *linkURLSiteStub) MaxRetries() int           { return 1 }
+func (s *linkURLSiteStub) RetryDelay() time.Duration { return 0 }
+func (s *linkURLSiteStub) SendTorrentToDownloader(ctx context.Context, rssCfg models.RSSConfig) error {
+	return nil
+}
+func (s *linkURLSiteStub) Context() context.Context { return context.Background() }
+
+// TestFetchAndDownloadFreeRSS_FallbackToLink 验证无 <enclosure> 但有 <link> 的 mteam API 型 RSS
+// item 不再被静默丢弃，torrentURL 回退使用 item.Link。
+func TestFetchAndDownloadFreeRSS_FallbackToLink(t *testing.T) {
+	dir := t.TempDir()
+	db, err := core.NewTempDBDir(dir)
+	require.NoError(t, err)
+	global.GlobalDB = db
+	global.InitLogger(zap.NewNop())
+	require.NoError(t, core.NewConfigStore(db).SaveGlobalSettings(models.SettingsGlobal{DownloadDir: dir, DefaultIntervalMinutes: 10, DefaultEnabled: true}))
+	const dlURL = "http://mteam.example/dl/12345"
+	feed := bytes.NewBufferString(`<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel><title>Test</title>
+<item><title>ItemLink</title><guid>guid-link</guid><link>` + dlURL + `</link></item>
+</channel></rss>`)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200); _, _ = w.Write(feed.Bytes()) }))
+	defer srv.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stub := &linkURLSiteStub{}
+	require.NoError(t, FetchAndDownloadFreeRSS(ctx, models.SiteGroup("springsunday"), stub, models.RSSConfig{Name: "r", URL: srv.URL, Tag: "tag"}))
+	require.Equal(t, dlURL, stub.gotURL, "无 enclosure 时 torrentURL 应回退为 item.Link")
+}
+
+// TestComputeDiscarded 验证入队丢弃逻辑：无 enclosure 且无 link 视为丢弃，有任一则保留。
+func TestComputeDiscarded(t *testing.T) {
+	cases := []struct {
+		name      string
+		item      *gofeed.Item
+		discarded bool
+	}{
+		{"both empty", &gofeed.Item{GUID: "g1"}, true},
+		{"blank link", &gofeed.Item{GUID: "g2", Link: "   "}, true},
+		{"has link", &gofeed.Item{GUID: "g3", Link: "http://x/dl"}, false},
+		{"has enclosure", &gofeed.Item{GUID: "g4", Enclosures: []*gofeed.Enclosure{{URL: "http://x/e.torrent"}}}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := len(c.item.Enclosures) == 0 && strings.TrimSpace(c.item.Link) == ""
+			require.Equal(t, c.discarded, got)
+		})
+	}
 }
 
 type props404Transport struct{}

--- a/internal/push.go
+++ b/internal/push.go
@@ -128,7 +128,8 @@ func PushTorrentToDownloader(ctx context.Context, req PushTorrentRequest) (*Push
 	// gate           = effective_free - thisTorrentSize >= threshold
 	// 用全局互斥锁串行化整个 check + Reserve + push 临界区。
 	var pushTorrentSize int64
-	if glErr == nil && glOnly.CleanupDiskProtect && glOnly.CleanupMinDiskSpaceGB > 0 {
+	diskProtectOn := glErr == nil && glOnly.CleanupDiskProtect && glOnly.CleanupMinDiskSpaceGB > 0
+	if diskProtectOn {
 		mu := PushMutex()
 		mu.Lock()
 		defer mu.Unlock()
@@ -176,6 +177,48 @@ func PushTorrentToDownloader(ctx context.Context, req PushTorrentRequest) (*Push
 		}
 		if pushTorrentSize > 0 {
 			budget.Reserve(pushTorrentSize)
+		}
+	}
+
+	// 站点容量闸门（Issue #405）：超过该站点 SeedingCapacityGB 上限则拒绝推送。
+	// 接在 disk-protect 之后、AddTorrentFileEx 之前；disk-protect 关闭时本闸门自行加锁。
+	if capGB := siteSeedingCapacityGB(req.SiteID); capGB > 0 {
+		if !diskProtectOn {
+			mu := PushMutex()
+			mu.Lock()
+			defer mu.Unlock()
+		}
+		if pushTorrentSize == 0 {
+			if size, sizeErr := qbit.ComputeTorrentSize(req.TorrentData); sizeErr == nil {
+				pushTorrentSize = size
+			}
+		}
+		used, usedErr := getSiteSeedingSizeBytes(ctx, req.SiteID, dl)
+		if usedErr != nil {
+			sLogger().Warnf("[站点容量] %s: 获取站点做种总量失败，容量限制启用故拒绝推送: %v", req.SiteID, usedErr)
+			if pushTorrentSize > 0 {
+				GetDiskBudget().Release(pushTorrentSize)
+			}
+			return &PushTorrentResult{
+				Success:     false,
+				TorrentHash: torrentHash,
+				Message:     fmt.Sprintf("无法读取站点做种总量，已拒绝推送: %v", usedErr),
+			}, nil
+		}
+		capBytes := int64(capGB * gibiByte)
+		if used+pushTorrentSize > capBytes {
+			usedGB := float64(used) / gibiByte
+			tGB := float64(pushTorrentSize) / gibiByte
+			sLogger().Warnf("[站点容量] %s: 超过容量上限 (当前做种 %.1f GB + 本次种子 %.1f GB > 上限 %.1f GB)，跳过推送: id=%s",
+				req.SiteID, usedGB, tGB, capGB, req.TorrentID)
+			if pushTorrentSize > 0 {
+				GetDiskBudget().Release(pushTorrentSize)
+			}
+			return &PushTorrentResult{
+				Success:     false,
+				TorrentHash: torrentHash,
+				Message:     fmt.Sprintf("站点容量已满 (当前 %.1f GB + 种子 %.1f GB > %.1f GB)", usedGB, tGB, capGB),
+			}, nil
 		}
 	}
 

--- a/internal/site_capacity.go
+++ b/internal/site_capacity.go
@@ -1,0 +1,72 @@
+// MIT License
+// Copyright (c) 2025 pt-tools
+
+package internal
+
+import (
+	"context"
+	"strings"
+
+	"github.com/sunerpy/pt-tools/global"
+	"github.com/sunerpy/pt-tools/models"
+	"github.com/sunerpy/pt-tools/thirdpart/downloader"
+)
+
+// gibiByte 是 1 GiB 的字节数，用于 SeedingCapacityGB 与字节数之间换算。
+const gibiByte = 1024 * 1024 * 1024
+
+// getSiteSeedingSizeBytes 聚合指定站点在其绑定下载器中当前做种/已推送种子的总体积（bytes）。
+//
+// 数据源：下载器实时 GetAllTorrents()，按 Category/Tags 命中 siteName 后对 TotalSize 求和
+// （Downloader 接口不下推 tag/category 过滤，只能在 Go 侧本地匹配）。删种后下次拉取自动收敛。
+// 失败语义：下载器不可达时返回 error，调用方在容量闸门处 fail-closed（拒绝推送）。
+func getSiteSeedingSizeBytes(ctx context.Context, siteName string, dl downloader.Downloader) (int64, error) {
+	if dl == nil {
+		return 0, nil
+	}
+	torrents, err := dl.GetAllTorrents()
+	if err != nil {
+		return 0, err
+	}
+	return sumSiteSeedingSize(siteName, torrents), nil
+}
+
+// sumSiteSeedingSize 在 Go 侧按 Category/Tags 命中 siteName 求和 TotalSize（纯函数，便于测试）。
+func sumSiteSeedingSize(siteName string, torrents []downloader.Torrent) int64 {
+	if siteName == "" {
+		return 0
+	}
+	var total int64
+	for _, t := range torrents {
+		if torrentBelongsToSite(siteName, t) {
+			total += t.TotalSize
+		}
+	}
+	return total
+}
+
+// torrentBelongsToSite 判断种子是否归属指定站点：Category 等于 siteName，或 Tags 中含 siteName。
+// Tags 为逗号分隔的字符串（qBit tags / TR labels joined），逐项 trim 后大小写不敏感比较。
+func torrentBelongsToSite(siteName string, t downloader.Torrent) bool {
+	if strings.EqualFold(strings.TrimSpace(t.Category), siteName) {
+		return true
+	}
+	for _, tag := range strings.Split(t.Tags, ",") {
+		if strings.EqualFold(strings.TrimSpace(tag), siteName) {
+			return true
+		}
+	}
+	return false
+}
+
+// siteSeedingCapacityGB 读取指定站点的 SeedingCapacityGB 配置；未配置/查不到/DB 不可用时返回 0（不限制）。
+func siteSeedingCapacityGB(siteName string) float64 {
+	if siteName == "" || global.GlobalDB == nil {
+		return 0
+	}
+	var site models.SiteSetting
+	if err := global.GlobalDB.DB.Where("name = ?", siteName).First(&site).Error; err != nil {
+		return 0
+	}
+	return site.SeedingCapacityGB
+}

--- a/internal/site_capacity_test.go
+++ b/internal/site_capacity_test.go
@@ -1,0 +1,106 @@
+// MIT License
+// Copyright (c) 2025 pt-tools
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sm "github.com/sunerpy/pt-tools/mocks"
+	"github.com/sunerpy/pt-tools/thirdpart/downloader"
+)
+
+func TestTorrentBelongsToSite(t *testing.T) {
+	cases := []struct {
+		name     string
+		siteName string
+		torrent  downloader.Torrent
+		want     bool
+	}{
+		{"category 精确匹配", "mteam", downloader.Torrent{Category: "mteam"}, true},
+		{"category 大小写不敏感", "MTeam", downloader.Torrent{Category: "mteam"}, true},
+		{"category 带空格 trim", "mteam", downloader.Torrent{Category: " mteam "}, true},
+		{"tags 单标签匹配", "hdsky", downloader.Torrent{Tags: "hdsky"}, true},
+		{"tags 多标签命中其一", "hdsky", downloader.Torrent{Tags: "movie, hdsky, 4k"}, true},
+		{"tags 大小写不敏感", "HDSky", downloader.Torrent{Tags: "hdsky"}, true},
+		{"category 与 tags 均不匹配", "mteam", downloader.Torrent{Category: "other", Tags: "a,b"}, false},
+		{"空 category 空 tags", "mteam", downloader.Torrent{}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, torrentBelongsToSite(c.siteName, c.torrent))
+		})
+	}
+}
+
+func TestSumSiteSeedingSize(t *testing.T) {
+	torrents := []downloader.Torrent{
+		{Category: "mteam", TotalSize: 10 * gibiByte},
+		{Tags: "mteam", TotalSize: 5 * gibiByte},
+		{Category: "hdsky", TotalSize: 100 * gibiByte},
+		{Category: "other", Tags: "x,y", TotalSize: 200 * gibiByte},
+	}
+
+	t.Run("聚合 mteam（category + tag 命中）", func(t *testing.T) {
+		got := sumSiteSeedingSize("mteam", torrents)
+		assert.Equal(t, int64(15*gibiByte), got)
+	})
+	t.Run("聚合 hdsky", func(t *testing.T) {
+		got := sumSiteSeedingSize("hdsky", torrents)
+		assert.Equal(t, int64(100*gibiByte), got)
+	})
+	t.Run("无命中返回 0", func(t *testing.T) {
+		assert.Equal(t, int64(0), sumSiteSeedingSize("nosuch", torrents))
+	})
+	t.Run("空 siteName 返回 0", func(t *testing.T) {
+		assert.Equal(t, int64(0), sumSiteSeedingSize("", torrents))
+	})
+	t.Run("空列表返回 0", func(t *testing.T) {
+		assert.Equal(t, int64(0), sumSiteSeedingSize("mteam", nil))
+	})
+}
+
+// TestGetSiteSeedingSizeBytes 验证 getSiteSeedingSizeBytes 是 GetAllTorrents +
+// sumSiteSeedingSize 的组合：nil 下载器返回 0；注入固定种子列表求和；错误透传。
+func TestGetSiteSeedingSizeBytes(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("nil 下载器返回 0 且无错误", func(t *testing.T) {
+		got, err := getSiteSeedingSizeBytes(ctx, "mteam", nil)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), got)
+	})
+
+	t.Run("聚合命中站点的做种总量", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		dl := sm.NewMockDownloader(ctrl)
+		dl.EXPECT().GetAllTorrents().Return([]downloader.Torrent{
+			{Category: "mteam", TotalSize: 10 * gibiByte},
+			{Tags: "free,mteam", TotalSize: 5 * gibiByte},
+			{Category: "hdsky", TotalSize: 100 * gibiByte},
+		}, nil)
+
+		got, err := getSiteSeedingSizeBytes(ctx, "mteam", dl)
+		require.NoError(t, err)
+		assert.Equal(t, int64(15*gibiByte), got)
+	})
+
+	t.Run("GetAllTorrents 失败时透传 error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		dl := sm.NewMockDownloader(ctrl)
+		wantErr := errors.New("下载器不可达")
+		dl.EXPECT().GetAllTorrents().Return(nil, wantErr)
+
+		got, err := getSiteSeedingSizeBytes(ctx, "mteam", dl)
+		require.ErrorIs(t, err, wantErr)
+		assert.Equal(t, int64(0), got)
+	})
+}

--- a/internal/sitelogin/probe_nexusphp.go
+++ b/internal/sitelogin/probe_nexusphp.go
@@ -49,6 +49,11 @@ func classifyNexusPHPResult(info v2.UserInfo, err error, clock Clock, source Pro
 		result.Status = CHALLENGE
 	default:
 		result.Status = UNKNOWN
+		if isAuthError(err) {
+			result.Diagnostic = "Cookie 未配置或已失效，请用浏览器扩展同步 Cookie 后重试"
+		} else {
+			result.Diagnostic = err.Error()
+		}
 	}
 
 	return result, nil
@@ -60,4 +65,17 @@ func isChallengeError(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "cloudflare") || strings.Contains(msg, "challenge")
+}
+
+func isAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "cookie") ||
+		strings.Contains(msg, "401") ||
+		strings.Contains(msg, "403") ||
+		strings.Contains(msg, "unauthorized") ||
+		strings.Contains(msg, "forbidden") ||
+		strings.Contains(msg, "login")
 }

--- a/internal/sitelogin/probe_nexusphp_test.go
+++ b/internal/sitelogin/probe_nexusphp_test.go
@@ -162,14 +162,87 @@ func TestProbeNexusPHPCloudflareChallenge(t *testing.T) {
 }
 
 func TestProbeNexusPHPUnknown(t *testing.T) {
-	clock := newProbeClock(time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC))
-	site := &fakeSite{err: errors.New("weird")}
+	t.Run("unknown error preserves original message", func(t *testing.T) {
+		clock := newProbeClock(time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC))
+		site := &fakeSite{err: errors.New("weird")}
 
-	res, err := ProbeNexusPHP(context.Background(), site, clock, ProbeSourceHTTPCookie)
+		res, err := ProbeNexusPHP(context.Background(), site, clock, ProbeSourceHTTPCookie)
 
-	require.NoError(t, err)
-	require.NotNil(t, res)
-	assert.Equal(t, UNKNOWN, res.Status)
-	require.Error(t, res.RawError)
-	assert.Contains(t, res.RawError.Error(), "weird")
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.Equal(t, UNKNOWN, res.Status)
+		require.Error(t, res.RawError)
+		assert.Contains(t, res.RawError.Error(), "weird")
+		assert.Equal(t, "weird", res.Diagnostic)
+	})
+
+	t.Run("401 unauthorized error suggests cookie refresh", func(t *testing.T) {
+		clock := newProbeClock(time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC))
+		site := &fakeSite{err: errors.New("HTTP 401 Unauthorized")}
+
+		res, err := ProbeNexusPHP(context.Background(), site, clock, ProbeSourceHTTPCookie)
+
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.Equal(t, UNKNOWN, res.Status)
+		require.Error(t, res.RawError)
+		assert.Contains(t, res.Diagnostic, "Cookie")
+		assert.Contains(t, res.Diagnostic, "未配置或已失效")
+	})
+
+	t.Run("403 forbidden error suggests cookie refresh", func(t *testing.T) {
+		clock := newProbeClock(time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC))
+		site := &fakeSite{err: errors.New("HTTP 403 Forbidden")}
+
+		res, err := ProbeNexusPHP(context.Background(), site, clock, ProbeSourceHTTPCookie)
+
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.Equal(t, UNKNOWN, res.Status)
+		require.Error(t, res.RawError)
+		assert.Contains(t, res.Diagnostic, "Cookie")
+		assert.Contains(t, res.Diagnostic, "未配置或已失效")
+	})
+
+	t.Run("cookie in error message suggests refresh", func(t *testing.T) {
+		clock := newProbeClock(time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC))
+		site := &fakeSite{err: errors.New("invalid cookie format")}
+
+		res, err := ProbeNexusPHP(context.Background(), site, clock, ProbeSourceHTTPCookie)
+
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.Equal(t, UNKNOWN, res.Status)
+		require.Error(t, res.RawError)
+		assert.Contains(t, res.Diagnostic, "Cookie")
+		assert.Contains(t, res.Diagnostic, "未配置或已失效")
+	})
+
+	t.Run("unauthorized keyword suggests cookie refresh", func(t *testing.T) {
+		clock := newProbeClock(time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC))
+		site := &fakeSite{err: errors.New("Request unauthorized")}
+
+		res, err := ProbeNexusPHP(context.Background(), site, clock, ProbeSourceHTTPCookie)
+
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.Equal(t, UNKNOWN, res.Status)
+		require.Error(t, res.RawError)
+		assert.Contains(t, res.Diagnostic, "Cookie")
+		assert.Contains(t, res.Diagnostic, "未配置或已失效")
+	})
+
+	t.Run("login keyword suggests cookie refresh", func(t *testing.T) {
+		clock := newProbeClock(time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC))
+		site := &fakeSite{err: errors.New("please login first")}
+
+		res, err := ProbeNexusPHP(context.Background(), site, clock, ProbeSourceHTTPCookie)
+
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.Equal(t, UNKNOWN, res.Status)
+		require.Error(t, res.RawError)
+		assert.Contains(t, res.Diagnostic, "Cookie")
+		assert.Contains(t, res.Diagnostic, "未配置或已失效")
+	})
 }

--- a/models/config_models.go
+++ b/models/config_models.go
@@ -180,26 +180,27 @@ type CloakSettings struct {
 
 // SiteSetting 站点设置（统一表，合并原 DynamicSiteSetting）
 type SiteSetting struct {
-	ID               uint      `gorm:"primaryKey" json:"id"`
-	Name             string    `gorm:"uniqueIndex;size:64;not null" json:"name"`
-	DisplayName      string    `gorm:"size:128" json:"display_name"`
-	BaseURL          string    `gorm:"size:512" json:"base_url"`
-	Enabled          bool      `json:"enabled"`
-	AuthMethod       string    `gorm:"size:16;not null" json:"auth_method"`
-	Cookie           string    `gorm:"size:2048" json:"cookie,omitempty"`
-	CookieEncrypted  string    `gorm:"type:text" json:"cookie_encrypted,omitempty"`
-	APIKey           string    `gorm:"size:512" json:"api_key,omitempty"`
-	APIUrl           string    `gorm:"size:512" json:"api_url,omitempty"`
-	APIUrls          string    `gorm:"size:2048" json:"api_urls,omitempty"`
-	Passkey          string    `gorm:"size:512" json:"passkey,omitempty"`
-	DownloaderID     *uint     `gorm:"index" json:"downloader_id,omitempty"`
-	ParserConfig     string    `gorm:"type:text" json:"parser_config,omitempty"`
-	UploadLimitKBs   int       `gorm:"default:0" json:"upload_limit_kbs"`
-	DownloadLimitKBs int       `gorm:"default:0" json:"download_limit_kbs"`
-	IsBuiltin        bool      `json:"is_builtin"`
-	TemplateID       *uint     `gorm:"index" json:"template_id,omitempty"`
-	CreatedAt        time.Time `json:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
+	ID                uint      `gorm:"primaryKey" json:"id"`
+	Name              string    `gorm:"uniqueIndex;size:64;not null" json:"name"`
+	DisplayName       string    `gorm:"size:128" json:"display_name"`
+	BaseURL           string    `gorm:"size:512" json:"base_url"`
+	Enabled           bool      `json:"enabled"`
+	AuthMethod        string    `gorm:"size:16;not null" json:"auth_method"`
+	Cookie            string    `gorm:"size:2048" json:"cookie,omitempty"`
+	CookieEncrypted   string    `gorm:"type:text" json:"cookie_encrypted,omitempty"`
+	APIKey            string    `gorm:"size:512" json:"api_key,omitempty"`
+	APIUrl            string    `gorm:"size:512" json:"api_url,omitempty"`
+	APIUrls           string    `gorm:"size:2048" json:"api_urls,omitempty"`
+	Passkey           string    `gorm:"size:512" json:"passkey,omitempty"`
+	DownloaderID      *uint     `gorm:"index" json:"downloader_id,omitempty"`
+	ParserConfig      string    `gorm:"type:text" json:"parser_config,omitempty"`
+	UploadLimitKBs    int       `gorm:"default:0" json:"upload_limit_kbs"`
+	DownloadLimitKBs  int       `gorm:"default:0" json:"download_limit_kbs"`
+	SeedingCapacityGB float64   `gorm:"default:0" json:"seeding_capacity_gb"` // 单站点刷流容量上限(GB)，0=不限制 (#405)
+	IsBuiltin         bool      `json:"is_builtin"`
+	TemplateID        *uint     `gorm:"index" json:"template_id,omitempty"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
 }
 
 // RSS 订阅

--- a/models/config_models.go
+++ b/models/config_models.go
@@ -323,15 +323,16 @@ func (r *RSSConfig) GetEffectiveFilterMode(globalSettings *SettingsGlobal) Filte
 }
 
 type SiteConfig struct {
-	Enabled          *bool       `json:"enabled"`
-	AuthMethod       string      `json:"auth_method"`
-	Cookie           string      `json:"cookie"`
-	APIKey           string      `json:"api_key"`
-	APIUrl           string      `json:"api_url"`
-	Passkey          string      `json:"passkey"`
-	UploadLimitKBs   int         `json:"upload_limit_kbs"`
-	DownloadLimitKBs int         `json:"download_limit_kbs"`
-	RSS              []RSSConfig `json:"rss"`
+	Enabled           *bool       `json:"enabled"`
+	AuthMethod        string      `json:"auth_method"`
+	Cookie            string      `json:"cookie"`
+	APIKey            string      `json:"api_key"`
+	APIUrl            string      `json:"api_url"`
+	Passkey           string      `json:"passkey"`
+	UploadLimitKBs    int         `json:"upload_limit_kbs"`
+	DownloadLimitKBs  int         `json:"download_limit_kbs"`
+	SeedingCapacityGB float64     `json:"seeding_capacity_gb"`
+	RSS               []RSSConfig `json:"rss"`
 }
 type Config struct {
 	Global SettingsGlobal           `json:"global"`

--- a/web/frontend/src/api/index.ts
+++ b/web/frontend/src/api/index.ts
@@ -127,6 +127,7 @@ export interface SiteConfig {
   passkey?: string;
   upload_limit_kbs?: number;
   download_limit_kbs?: number;
+  seeding_capacity_gb?: number;
   rss: RSSConfig[];
   urls?: string[];
   web_url?: string;

--- a/web/frontend/src/views/SiteDetail.vue
+++ b/web/frontend/src/views/SiteDetail.vue
@@ -666,9 +666,7 @@ function toggleEditRssCustomPath() {
             :step="10"
             class="w-full"
             placeholder="0 表示不限制" />
-          <div class="form-tip">
-            该站点做种总容量达到此上限后将停止推送新种子。0 = 不限制。
-          </div>
+          <div class="form-tip">该站点做种总容量达到此上限后将停止推送新种子。0 = 不限制。</div>
         </el-form-item>
       </el-form>
     </el-card>

--- a/web/frontend/src/views/SiteDetail.vue
+++ b/web/frontend/src/views/SiteDetail.vue
@@ -42,6 +42,7 @@ const form = ref<SiteConfig>({
   passkey: "",
   upload_limit_kbs: 0,
   download_limit_kbs: 0,
+  seeding_capacity_gb: 0,
   rss: [],
 });
 const savedCookieHidden = computed(() => form.value.has_cookie === true && !form.value.cookie);
@@ -655,6 +656,18 @@ function toggleEditRssCustomPath() {
             placeholder="0 表示不限速" />
           <div class="form-tip">
             推送到下载器的每个种子自动应用此下载限速。0 = 不限制（使用下载器全局/默认设置）。
+          </div>
+        </el-form-item>
+
+        <el-form-item label="刷流容量上限 (GB)" class="speed-limit-item">
+          <el-input-number
+            v-model="form.seeding_capacity_gb"
+            :min="0"
+            :step="10"
+            class="w-full"
+            placeholder="0 表示不限制" />
+          <div class="form-tip">
+            该站点做种总容量达到此上限后将停止推送新种子。0 = 不限制。
           </div>
         </el-form-item>
       </el-form>

--- a/web/server.go
+++ b/web/server.go
@@ -629,6 +629,7 @@ type SiteConfigResponse struct {
 	Passkey            string             `json:"passkey"`
 	UploadLimitKBs     int                `json:"upload_limit_kbs"`
 	DownloadLimitKBs   int                `json:"download_limit_kbs"`
+	SeedingCapacityGB  float64            `json:"seeding_capacity_gb"`
 	RSS                []models.RSSConfig `json:"rss"`
 	URLs               []string           `json:"urls,omitempty"`
 	WebURL             string             `json:"web_url,omitempty"`
@@ -650,17 +651,18 @@ func (s *Server) apiSites(w http.ResponseWriter, r *http.Request) {
 		var sitesToDisable []models.SiteGroup
 		for sg, sc := range sites {
 			resp := SiteConfigResponse{
-				Enabled:          sc.Enabled,
-				AuthMethod:       sc.AuthMethod,
-				Cookie:           "",
-				CookieEncrypted:  "",
-				HasCookie:        strings.TrimSpace(sc.Cookie) != "",
-				APIKey:           sc.APIKey,
-				APIUrl:           sc.APIUrl,
-				Passkey:          sc.Passkey,
-				UploadLimitKBs:   sc.UploadLimitKBs,
-				DownloadLimitKBs: sc.DownloadLimitKBs,
-				RSS:              sc.RSS,
+				Enabled:           sc.Enabled,
+				AuthMethod:        sc.AuthMethod,
+				Cookie:            "",
+				CookieEncrypted:   "",
+				HasCookie:         strings.TrimSpace(sc.Cookie) != "",
+				APIKey:            sc.APIKey,
+				APIUrl:            sc.APIUrl,
+				Passkey:           sc.Passkey,
+				UploadLimitKBs:    sc.UploadLimitKBs,
+				DownloadLimitKBs:  sc.DownloadLimitKBs,
+				SeedingCapacityGB: sc.SeedingCapacityGB,
+				RSS:               sc.RSS,
 			}
 			if def, ok := defRegistry.Get(string(sg)); ok {
 				resp.URLs = def.URLs
@@ -775,6 +777,7 @@ func (s *Server) apiSiteDetail(w http.ResponseWriter, r *http.Request) {
 			Passkey:            sc.Passkey,
 			UploadLimitKBs:     sc.UploadLimitKBs,
 			DownloadLimitKBs:   sc.DownloadLimitKBs,
+			SeedingCapacityGB:  sc.SeedingCapacityGB,
 			RSS:                sc.RSS,
 		}
 		defRegistry := v2.GetDefinitionRegistry()


### PR DESCRIPTION
## Summary
修复三个用户反馈问题 + 一个额外发现的 mteam RSS bug。

## Changes
- **fix(rss)** 重复下载触发站点限制（#问题2，最危险）：下载阶段新增 `shouldSkipSiteDownload` 闸门——已推送/超最大重试/已下载且本地文件存在的种子不再每周期重抓站点 .torrent，避免触发 M-Team 等下载次数限制。两处下载循环均接入。
- **feat(site)+feat(web)** 单站点刷流容量限制（#405）：SiteSetting 新增 `SeedingCapacityGB`（0=不限制），推送前按下载器实时聚合该站点做种总量，超限拒绝推送（fail-closed）；站点配置页新增「刷流容量上限 (GB)」输入，端到端透传。
- **fix(site-login)** 探测 UNKNOWN 诊断细化（#问题1）：cookie/401/403 类错误给出「请用扩展同步 Cookie」可操作提示（Status 仍 UNKNOWN，仅文案）。
- **fix(rss)** mteam「种子数量>0 但总数=0」（额外发现）：API 型 RSS 下载链接在 `<link>` 而非 `<enclosure>`，原入队过滤静默丢弃；现兼容 Link fallback + 记录丢弃数量日志。

## Test
- `go build ./...` PASS，`go vet ./...` clean
- **全量单测 37 包全 PASS，无回归**
- 新增测试：重抓保护(7) + 容量(TorrentBelongsToSite 8/SumSiteSeedingSize 5/GetSiteSeedingSizeBytes 3) + RSS无enclosure(FallbackToLink/ComputeDiscarded) + probe UNKNOWN
- 前端 `vue-tsc --noEmit` EXIT 0，`oxlint` 0 errors
- gofumpt clean

## 备注
- #405 容量字段用 GORM AutoMigrate 加 additive 列（`seeding_capacity_gb`）