### PR TITLE
feat(site): 新增 pandapt/ptfans/kamept 三个 NexusPHP 站点适配

### DIFF
--- a/docs/sites.md
+++ b/docs/sites.md
@@ -1,8 +1,8 @@
 ## 支持站点
 
-当前已适配 **45** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
+当前已适配 **48** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
 
-### NexusPHP 系列（41）
+### NexusPHP 系列（44）
 
 | 站点                  | 认证方式 | 支持功能                      | 适配情况 | 备注                                                             |
 | --------------------- | -------- | ----------------------------- | -------- | ---------------------------------------------------------------- |
@@ -47,6 +47,9 @@
 | **lajidui**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
 | **PTLGS**             | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（ptlgs.org，issue #377）                                  |
 | **ZmPT**              | Cookie   | RSS、搜索、用户信息           | ✅       | 织梦（zmpt.cc，电力值=魔力值）                                   |
+| **PandaPT**           | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（pandapt.net，info_block 取上传/下载/魔力，issue #416）   |
+| **PTFans**            | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（ptfans.cc，含 H&R，info_block 取数据，issue #417）       |
+| **KamePT**            | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（kamept.com，info_block 含做种积分，issue #418）          |
 
 ### 其他架构（4）
 

--- a/site/v2/definitions/kamept.go
+++ b/site/v2/definitions/kamept.go
@@ -1,0 +1,184 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+// KamePTDefinition is the site definition for KamePT (kamept.com).
+// Standard NexusPHP site; user stats (上传量/下载量/分享率/魔力值/做种积分/做种/下载)
+// live in the #info_block div present on both index.php and userdetails.php, while
+// 等级/加入日期/最近动向 stay in the standard userdetails.php rows.
+var KamePTDefinition = &v2.SiteDefinition{
+	ID:             "kamept",
+	Name:           "KamePT",
+	Aka:            []string{"龟龟", "Kame"},
+	Description:    "综合性 PT 站点",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://kamept.com/"},
+	FaviconURL:     "https://kamept.com/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "seeding", "leeching", "bonus", "seedingBonus", "uploaded", "downloaded", "ratio"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields:        []string{"levelName", "joinTime", "lastAccessAt"},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			"id": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php'][class*='Name']",
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php']",
+				},
+				Attr:    "href",
+				Filters: []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php'][class*='Name'] b",
+					"#info_block a[href*='userdetails.php'][class*='Name']",
+					"#info_block a[href*='userdetails.php']",
+				},
+			},
+			"uploaded": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`上传量[:：]\s*</font>\s*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"downloaded": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`下载量[:：]\s*</font>\s*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"ratio": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`分享率[:：]\s*</font>\s*(?:<font[^>]*>)?([\d.,]+|∞|Inf)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"bonus": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`魔力值\s*</font>\s*\[[^\]]*\]\s*[:：]\s*([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			// 做种积分</font>: 24,496.5 (kamept exposes this in #info_block)
+			"seedingBonus": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`做种积分\s*</font>\s*[:：]\s*([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowup"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"levelName": {
+				Selector: []string{
+					"td.rowhead:contains('等级') + td img",
+					"td.rowhead:contains('等級') + td img",
+					"td.rowhead:contains('等级') + td",
+					"td.rowhead:contains('等級') + td",
+				},
+				Attr: "title",
+			},
+			"joinTime": {
+				Selector: []string{
+					"td.rowhead:contains('加入日期') + td",
+					"td.rowhead:contains('加入時間') + td",
+					"td.rowhead:contains('Join') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+			"lastAccessAt": {
+				Selector: []string{
+					"td.rowhead:contains('最近动向') + td",
+					"td.rowhead:contains('最近動向') + td",
+					"td.rowhead:contains('上次访问') + td",
+					"td.rowhead:contains('上次訪問') + td",
+					"td.rowhead:contains('Last access') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		TableRows:          "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:              "table.torrentname a[href*='details.php']",
+		TitleLink:          "table.torrentname a[href*='details.php']",
+		Subtitle:           "table.torrentname td.embedded > span:last-of-type, table.torrentname td.embedded > span",
+		Size:               "td.rowfollow:nth-child(5)",
+		Seeders:            "td.rowfollow:nth-child(6)",
+		Leechers:           "td.rowfollow:nth-child(7)",
+		Snatched:           "td.rowfollow:nth-child(8)",
+		DiscountIcon:       "img.pro_free, img.pro_free2up, img.pro_2up, img.pro_50pctdown, img.pro_50pctdown2up, img.pro_30pctdown",
+		HRIcon:             "img.hitandrun, img[alt*='H&R'], img[title*='H&R']",
+		Category:           "td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:         "td.rowfollow:nth-child(4) span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords:       []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		TitleSelector:    "input[name='torrent_name']",
+		IDSelector:       "input[name='detail_torrent_id']",
+		DiscountSelector: "h1 font.free, h1 font[class]",
+		EndTimeSelector:  "h1 span[title]",
+		SizeSelector:     "td.rowhead:contains('基本信息')",
+		SizeRegex:        `大小[：:]\s*([\d.]+)\s*(GB|MB|KB|TB)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(KamePTDefinition)
+}

--- a/site/v2/definitions/kamept_fixture_test.go
+++ b/site/v2/definitions/kamept_fixture_test.go
@@ -1,0 +1,217 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "kamept",
+		Search:   testKamePTSearch,
+		Detail:   testKamePTDetail,
+		UserInfo: testKamePTUserInfo,
+	})
+}
+
+const kameptSearchFixture = `<html><body>
+<table class="torrents"><tbody>
+<tr>
+  <td class="rowfollow nowrap"><a href="?cat=410"><img class="c_0" src="pic/cattrans.gif" alt="同人AV" title="同人AV" /></a></td>
+  <td class="rowfollow"><table class="torrentname"><tr><td class="embedded"><img src="pic/misc/spinner.svg" class="nexus-lazy-load" /></td>
+    <td class="embedded">
+      <img class="sticky" src="pic/trans.gif" alt="Sticky" title="一级置顶" />&nbsp;
+      <a title="Sample Cosplay Release 01" href="details.php?id=42507&amp;hit=1"><b>Sample Cosplay Release 01</b></a>
+      <b> (<font class='new'>新</font>)</b>
+      <img class="pro_free" src="pic/trans.gif" alt="Free" title="免费" />
+      <br /><span style="background-color:#483d8b" title="">原盘</span><span style="background-color:#ff0000" title="">禁转</span>样品 写真集
+    </td></tr></table></td>
+  <td class="rowfollow"><a href="comment.php?action=add&amp;pid=42507&amp;type=torrent">0</a></td>
+  <td class="rowfollow nowrap"><span title="2026-06-18 02:38:11">22时<br />5分钟</span></td>
+  <td class="rowfollow">6.55<br />GB</td>
+  <td class="rowfollow" align="center"><b><a href="details.php?id=42507&amp;dllist=1#seeders">95</a></b></td>
+  <td class="rowfollow"><b><a href="details.php?id=42507&amp;dllist=1#leechers">2</a></b></td>
+  <td class="rowfollow"><a href="viewsnatches.php?id=42507"><b>141</b></a></td>
+</tr>
+<tr>
+  <td class="rowfollow nowrap"><a href="?cat=410"><img class="c_0" src="pic/cattrans.gif" alt="同人AV" title="同人AV" /></a></td>
+  <td class="rowfollow"><table class="torrentname"><tr><td class="embedded"><img src="pic/misc/spinner.svg" class="nexus-lazy-load" /></td>
+    <td class="embedded">
+      <a title="Sample Cosplay Release 02" href="details.php?id=42506&amp;hit=1"><b>Sample Cosplay Release 02</b></a>
+      <b> (<font class='new'>新</font>)</b>
+      <br />样品 写真集
+    </td></tr></table></td>
+  <td class="rowfollow"><a href="comment.php?action=add&amp;pid=42506&amp;type=torrent">0</a></td>
+  <td class="rowfollow nowrap"><span title="2026-06-18 02:38:11">22时<br />5分钟</span></td>
+  <td class="rowfollow">2.76<br />GB</td>
+  <td class="rowfollow" align="center"><b><a href="details.php?id=42506&amp;dllist=1#seeders">95</a></b></td>
+  <td class="rowfollow"><b><a href="details.php?id=42506&amp;dllist=1#leechers">2</a></b></td>
+  <td class="rowfollow"><a href="viewsnatches.php?id=42506"><b>141</b></a></td>
+</tr>
+</tbody></table>
+</body></html>`
+
+const kameptDetailFixture = `<html><body>
+<h1>
+  <input type="hidden" name="torrent_name" value="Sample Cosplay Release 01" />
+  <input type="hidden" name="detail_torrent_id" value="42507" />
+  Sample Cosplay Release 01&nbsp;&nbsp;&nbsp; <b>[<font class='free' >免费</font>]</b>
+</h1>
+<table>
+  <tr><td class="rowhead nowrap">基本信息</td><td class="rowfollow"><b><b>大小：</b></b>6.55 GB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;同人AV</td></tr>
+  <tr><td class="rowhead nowrap">副标题</td><td class="rowfollow">样品 写真集</td></tr>
+</table>
+</body></html>`
+
+const kameptIndexFixture = `<html><body>
+<table id="info_block" cellpadding="4" cellspacing="0" border="0" width="100%"><tr><td>
+<span class="medium">
+欢迎回来, <span class="nowrap"><a href="https://kamept.com/userdetails.php?id=23379" class='User_Name'><b>testuser</b></a></span>
+[<a href="usercp.php">控制面板</a>]
+<font class = 'color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 9,371.4
+<font class = 'color_bonus'>做种积分</font>: 24,496.5
+<font class = 'color_invite'>邀请 </font>[<a href="invite.php?id=23379">发送</a>]: 0(0)
+<br />
+<font class="color_ratio">分享率:</font> 2.110
+<font class='color_uploaded'>上传量:</font> 211.03 GB
+<font class='color_downloaded'> 下载量:</font> 100.02 GB
+<font class='color_active'>当前活动:</font>
+<img class="arrowup" alt="Torrents seeding" title="当前做种" src="pic/trans.gif" />6
+<img class="arrowdown" alt="Torrents leeching" title="当前下载" src="pic/trans.gif" />0
+</span>
+</td></tr></table>
+</body></html>`
+
+const kameptUserdetailsFixture = `<html><body>
+<table id="info_block" cellpadding="4" cellspacing="0" border="0" width="100%"><tr><td>
+<span class="medium">
+欢迎回来, <span class="nowrap"><a href="https://kamept.com/userdetails.php?id=23379" class='User_Name'><b>testuser</b></a></span>
+<font class = 'color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 9,371.4
+<font class = 'color_bonus'>做种积分</font>: 24,496.5
+<br />
+<font class="color_ratio">分享率:</font> 2.110
+<font class='color_uploaded'>上传量:</font> 211.03 GB
+<font class='color_downloaded'> 下载量:</font> 100.02 GB
+<font class='color_active'>当前活动:</font>
+<img class="arrowup" src="pic/trans.gif" />6
+<img class="arrowdown" src="pic/trans.gif" />0
+</span>
+</td></tr></table>
+<table>
+  <tr><td class="rowhead nowrap">加入日期</td><td class="rowfollow">2026-02-16 09:09:17 (<span title="2026-02-16 09:09:17">4月2天前</span>, 18周)</td></tr>
+  <tr><td class="rowhead nowrap">最近动向</td><td class="rowfollow">2026-06-19 00:43:25 (<span title="2026-06-19 00:43:25">&lt; 1分钟前</span>)</td></tr>
+  <tr><td class="rowhead nowrap">等级</td><td class="rowfollow"><img alt="User" title="User" src="pic/user.gif" /> </td></tr>
+</table>
+</body></html>`
+
+func getKamePTDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("kamept")
+	require.True(t, ok, "kamept definition not found")
+	return def
+}
+
+func testKamePTSearch(t *testing.T) {
+	def := getKamePTDef(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(kameptSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{BaseURL: server.URL, Cookie: "test_cookie=1", Selectors: def.Selectors})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: "GET"})
+	require.NoError(t, err)
+
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+
+	assert.Equal(t, "42507", items[0].ID)
+	assert.Equal(t, "Sample Cosplay Release 01", items[0].Title)
+	assert.Equal(t, v2.DiscountFree, items[0].DiscountLevel)
+	assert.Equal(t, 95, items[0].Seeders)
+	assert.Equal(t, 2, items[0].Leechers)
+	assert.Equal(t, 141, items[0].Snatched)
+
+	assert.Equal(t, "42506", items[1].ID)
+	assert.Equal(t, v2.DiscountNone, items[1].DiscountLevel)
+}
+
+func testKamePTDetail(t *testing.T) {
+	def := getKamePTDef(t)
+	parser := v2.NewNexusPHPParserFromDefinition(def)
+
+	doc := FixtureDoc(t, "kamept_detail", kameptDetailFixture)
+	info := parser.ParseAll(doc.Selection)
+	assert.Equal(t, "42507", info.TorrentID)
+	assert.Equal(t, "Sample Cosplay Release 01", info.Title)
+	assert.Equal(t, v2.DiscountFree, info.DiscountLevel)
+	assert.InDelta(t, 6.55*1024, info.SizeMB, 0.1)
+	assert.False(t, info.HasHR)
+}
+
+func testKamePTUserInfo(t *testing.T) {
+	def := getKamePTDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	t.Run("IndexPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "kamept_index", kameptIndexFixture)
+		fields := map[string]string{
+			"id":           "23379",
+			"name":         "testuser",
+			"bonus":        "9371.4",
+			"seedingBonus": "24496.5",
+			"ratio":        "2.11",
+			"uploaded":     "226591737118",
+			"downloaded":   "107395657236",
+			"seeding":      "6",
+			"leeching":     "0",
+		}
+		for field, expected := range fields {
+			sel, ok := def.UserInfo.Selectors[field]
+			require.True(t, ok, "selector %q missing", field)
+			assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel), "field %q", field)
+		}
+	})
+
+	t.Run("UserdetailsPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "kamept_userdetails", kameptUserdetailsFixture)
+		expected := map[string]string{
+			"levelName":    "User",
+			"joinTime":     "1771204157",
+			"lastAccessAt": "1781801005",
+		}
+		for field, want := range expected {
+			sel, ok := def.UserInfo.Selectors[field]
+			require.True(t, ok, "selector %q missing", field)
+			assert.Equal(t, want, driver.ExtractFieldValuePublic(doc, sel), "field %q", field)
+		}
+		laSel := def.UserInfo.Selectors["lastAccessAt"]
+		assert.NotEmpty(t, driver.ExtractFieldValuePublic(doc, laSel))
+	})
+}
+
+func TestKamePT_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":      kameptSearchFixture,
+		"detail":      kameptDetailFixture,
+		"index":       kameptIndexFixture,
+		"userdetails": kameptUserdetailsFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			RequireNoSecrets(t, name, data)
+		})
+	}
+}

--- a/site/v2/definitions/pandapt.go
+++ b/site/v2/definitions/pandapt.go
@@ -1,0 +1,174 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+// PandaPTDefinition is the site definition for PandaPT (pandapt.net).
+// Standard NexusPHP site; user stats (上传量/下载量/分享率/魔力值/做种/下载) live in
+// the #info_block div present on both index.php and userdetails.php, while
+// 等级/加入日期/最近动向 stay in the standard userdetails.php rows.
+var PandaPTDefinition = &v2.SiteDefinition{
+	ID:             "pandapt",
+	Name:           "PandaPT",
+	Aka:            []string{"熊猫", "Panda"},
+	Description:    "综合性 PT 站点",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://pandapt.net/"},
+	FaviconURL:     "https://pandapt.net/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "seeding", "leeching", "bonus", "uploaded", "downloaded", "ratio"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields:        []string{"levelName", "joinTime", "lastAccessAt"},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			"id": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php'][class*='Name']",
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php']",
+				},
+				Attr:    "href",
+				Filters: []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php'][class*='Name'] b",
+					"#info_block a[href*='userdetails.php'][class*='Name']",
+					"#info_block a[href*='userdetails.php']",
+				},
+			},
+			"uploaded": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`上传量[:：]\s*</font>\s*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"downloaded": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`下载量[:：]\s*</font>\s*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"ratio": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`分享率[:：]\s*</font>\s*(?:<font[^>]*>)?([\d.,]+|∞|Inf)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"bonus": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`魔力值\s*</font>\s*\[[^\]]*\]\s*[:：]\s*([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowup"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"levelName": {
+				Selector: []string{
+					"td.rowhead:contains('等级') + td img",
+					"td.rowhead:contains('等級') + td img",
+					"td.rowhead:contains('等级') + td",
+					"td.rowhead:contains('等級') + td",
+				},
+				Attr: "title",
+			},
+			"joinTime": {
+				Selector: []string{
+					"td.rowhead:contains('加入日期') + td",
+					"td.rowhead:contains('加入時間') + td",
+					"td.rowhead:contains('Join') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+			"lastAccessAt": {
+				Selector: []string{
+					"td.rowhead:contains('最近动向') + td",
+					"td.rowhead:contains('最近動向') + td",
+					"td.rowhead:contains('上次访问') + td",
+					"td.rowhead:contains('上次訪問') + td",
+					"td.rowhead:contains('Last access') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		TableRows:          "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:              "table.torrentname a[href*='details.php']",
+		TitleLink:          "table.torrentname a[href*='details.php']",
+		Subtitle:           "table.torrentname td.embedded > span:last-of-type, table.torrentname td.embedded > span",
+		Size:               "td.rowfollow:nth-child(5)",
+		Seeders:            "td.rowfollow:nth-child(6)",
+		Leechers:           "td.rowfollow:nth-child(7)",
+		Snatched:           "td.rowfollow:nth-child(8)",
+		DiscountIcon:       "img.pro_free, img.pro_free2up, img.pro_2up, img.pro_50pctdown, img.pro_50pctdown2up, img.pro_30pctdown",
+		Category:           "td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:         "td.rowfollow:nth-child(4) span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords:       []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		TitleSelector:    "input[name='torrent_name']",
+		IDSelector:       "input[name='detail_torrent_id']",
+		DiscountSelector: "h1 font.free, h1 font[class]",
+		EndTimeSelector:  "h1 span[title]",
+		SizeSelector:     "td.rowhead:contains('基本信息')",
+		SizeRegex:        `大小[：:]\s*([\d.]+)\s*(GB|MB|KB|TB)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(PandaPTDefinition)
+}

--- a/site/v2/definitions/pandapt_fixture_test.go
+++ b/site/v2/definitions/pandapt_fixture_test.go
@@ -1,0 +1,215 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "pandapt",
+		Search:   testPandaPTSearch,
+		Detail:   testPandaPTDetail,
+		UserInfo: testPandaPTUserInfo,
+	})
+}
+
+const pandaptSearchFixture = `<html><body>
+<table class="torrents"><tbody>
+<tr>
+  <td class="rowfollow nowrap"><a href="?cat=402"><img class="c_tvseries" src="pic/cattrans.gif" alt="电视剧" title="电视剧" /></a></td>
+  <td class="rowfollow"><table class="torrentname"><tr><td class="embedded"><img src="pic/misc/spinner.svg" class="nexus-lazy-load" /></td>
+    <td class="embedded">
+      <img class="sticky" src="pic/trans.gif" alt="Sticky" title="一级置顶" />&nbsp;
+      <a title="Ashes to Crown 2026 S01E21 2160p WEB-DL" href="details.php?id=124750&amp;hit=1"><b>Ashes to Crown 2026 S01E21 2160p WEB-DL</b></a>
+      <img class="pro_free" src="pic/trans.gif" alt="Free" title="免费" />
+      <br /><span style="background-color:#0000ff" title="">官方</span><span style="background-color:#174143" title="">国语</span>翘楚 第1季 第21集
+    </td></tr></table></td>
+  <td class="rowfollow"><a href="comment.php?action=add&amp;pid=124750&amp;type=torrent">0</a></td>
+  <td class="rowfollow nowrap"><span title="2026-06-17 21:10:30">1时<br />28分钟</span></td>
+  <td class="rowfollow">1.04<br />GB</td>
+  <td class="rowfollow" align="center"><b><a href="details.php?id=124750&amp;dllist=1#seeders">27</a></b></td>
+  <td class="rowfollow"><b><a href="details.php?id=124750&amp;dllist=1#leechers">13</a></b></td>
+  <td class="rowfollow"><a href="viewsnatches.php?id=124750"><b>29</b></a></td>
+  <td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr>
+  <td class="rowfollow nowrap"><a href="?cat=405"><img class="c_anime" src="pic/cattrans.gif" alt="动漫" title="动漫" /></a></td>
+  <td class="rowfollow"><table class="torrentname"><tr><td class="embedded"><img src="pic/misc/spinner.svg" class="nexus-lazy-load" /></td>
+    <td class="embedded">
+      <a title="Coiled Dragon 2026 S01E10 2160p WEB-DL" href="details.php?id=124743&amp;hit=1"><b>Coiled Dragon 2026 S01E10 2160p WEB-DL</b></a>
+      <br />蟠龙 第1季 第10集
+    </td></tr></table></td>
+  <td class="rowfollow"><a href="comment.php?action=add&amp;pid=124743&amp;type=torrent">0</a></td>
+  <td class="rowfollow nowrap"><span title="2026-06-17 20:00:00">2时</span></td>
+  <td class="rowfollow">2.50<br />GB</td>
+  <td class="rowfollow" align="center"><b><a href="details.php?id=124743&amp;dllist=1#seeders">10</a></b></td>
+  <td class="rowfollow"><b><a href="details.php?id=124743&amp;dllist=1#leechers">2</a></b></td>
+  <td class="rowfollow"><a href="viewsnatches.php?id=124743"><b>5</b></a></td>
+  <td class="rowfollow"><i>匿名</i></td>
+</tr>
+</tbody></table>
+</body></html>`
+
+const pandaptDetailFixture = `<html><body>
+<h1>
+  <input type="hidden" name="torrent_name" value="Ashes to Crown 2026 S01E21 2160p WEB-DL" />
+  <input type="hidden" name="detail_torrent_id" value="124750" />
+  Ashes to Crown 2026 S01E21 2160p WEB-DL&nbsp;&nbsp;&nbsp; <b>[<font class='free' >免费</font>]</b>
+</h1>
+<table>
+  <tr><td class="rowhead nowrap">基本信息</td><td class="rowfollow"><b><b>大小：</b></b>1.04 GB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;电视剧</td></tr>
+  <tr><td class="rowhead nowrap">副标题</td><td class="rowfollow">翘楚 第1季 第21集</td></tr>
+</table>
+</body></html>`
+
+const pandaptIndexFixture = `<html><body>
+<table id="info_block" cellpadding="4" cellspacing="0" border="0" width="100%"><tr><td>
+<span class="medium">
+欢迎回来, <span class="nowrap"><a href="https://pandapt.net/userdetails.php?id=105818" class='User_Name'><b>testuser</b></a></span>
+[<a href="usercp.php">控制面板</a>]
+<font class='color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 651,449.7
+<font class='color_invite'>邀请 </font>[<a href="invite.php?id=105818">发送</a>]: 0(0)
+<br/>
+<font class="color_ratio">分享率:</font> 2.733
+<font class='color_uploaded'>上传量:</font> 293.24 GB
+<font class='color_downloaded'> 下载量:</font> 107.28 GB
+<font class='color_active'>当前活动:</font>
+<img class="arrowup" alt="Torrents seeding" title="当前做种" src="pic/trans.gif"/>11
+<img class="arrowdown" alt="Torrents leeching" title="当前下载" src="pic/trans.gif"/>1
+</span>
+</td></tr></table>
+</body></html>`
+
+const pandaptUserdetailsFixture = `<html><body>
+<table id="info_block" cellpadding="4" cellspacing="0" border="0" width="100%"><tr><td>
+<span class="medium">
+欢迎回来, <span class="nowrap"><a href="https://pandapt.net/userdetails.php?id=105818" class='User_Name'><b>testuser</b></a></span>
+<font class='color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 651,449.7
+<br/>
+<font class="color_ratio">分享率:</font> 2.733
+<font class='color_uploaded'>上传量:</font> 293.24 GB
+<font class='color_downloaded'> 下载量:</font> 107.28 GB
+<font class='color_active'>当前活动:</font>
+<img class="arrowup" src="pic/trans.gif"/>11
+<img class="arrowdown" src="pic/trans.gif"/>1
+</span>
+</td></tr></table>
+<table>
+  <tr><td class="rowhead nowrap">加入日期</td><td class="rowfollow">2025-05-01 23:11:25 (<span title="2025-05-01 23:11:25">1年1月前</span>, 58周)</td></tr>
+  <tr><td class="rowhead nowrap">最近动向</td><td class="rowfollow">2026-06-17 22:39:27 (<span title="2026-06-17 22:39:27">&lt; 1分钟前</span>)</td></tr>
+  <tr><td class="rowhead nowrap">等级</td><td class="rowfollow"><img alt="User" title="User" src="pic/user.gif" /> </td></tr>
+</table>
+</body></html>`
+
+func getPandaPTDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("pandapt")
+	require.True(t, ok, "pandapt definition not found")
+	return def
+}
+
+func testPandaPTSearch(t *testing.T) {
+	def := getPandaPTDef(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(pandaptSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{BaseURL: server.URL, Cookie: "test_cookie=1", Selectors: def.Selectors})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: "GET"})
+	require.NoError(t, err)
+
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+
+	assert.Equal(t, "124750", items[0].ID)
+	assert.Equal(t, "Ashes to Crown 2026 S01E21 2160p WEB-DL", items[0].Title)
+	assert.Equal(t, v2.DiscountFree, items[0].DiscountLevel)
+	assert.Equal(t, 27, items[0].Seeders)
+	assert.Equal(t, 13, items[0].Leechers)
+	assert.Equal(t, 29, items[0].Snatched)
+
+	assert.Equal(t, "124743", items[1].ID)
+	assert.Equal(t, v2.DiscountNone, items[1].DiscountLevel)
+}
+
+func testPandaPTDetail(t *testing.T) {
+	def := getPandaPTDef(t)
+	parser := v2.NewNexusPHPParserFromDefinition(def)
+
+	doc := FixtureDoc(t, "pandapt_detail", pandaptDetailFixture)
+	info := parser.ParseAll(doc.Selection)
+	assert.Equal(t, "124750", info.TorrentID)
+	assert.Equal(t, "Ashes to Crown 2026 S01E21 2160p WEB-DL", info.Title)
+	assert.Equal(t, v2.DiscountFree, info.DiscountLevel)
+	assert.InDelta(t, 1.04*1024, info.SizeMB, 0.1)
+	assert.False(t, info.HasHR)
+}
+
+func testPandaPTUserInfo(t *testing.T) {
+	def := getPandaPTDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	t.Run("IndexPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "pandapt_index", pandaptIndexFixture)
+		fields := map[string]string{
+			"id":         "105818",
+			"name":       "testuser",
+			"bonus":      "651449.7",
+			"ratio":      "2.733",
+			"uploaded":   "314864052469",
+			"downloaded": "115191022878",
+			"seeding":    "11",
+			"leeching":   "1",
+		}
+		for field, expected := range fields {
+			sel, ok := def.UserInfo.Selectors[field]
+			require.True(t, ok, "selector %q missing", field)
+			assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel), "field %q", field)
+		}
+	})
+
+	t.Run("UserdetailsPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "pandapt_userdetails", pandaptUserdetailsFixture)
+		expected := map[string]string{
+			"levelName":    "User",
+			"joinTime":     "1746112285",
+			"lastAccessAt": "1781707167",
+		}
+		for field, want := range expected {
+			sel, ok := def.UserInfo.Selectors[field]
+			require.True(t, ok, "selector %q missing", field)
+			assert.Equal(t, want, driver.ExtractFieldValuePublic(doc, sel), "field %q", field)
+		}
+		// 保号 probe requires LastAccess > 0
+		laSel := def.UserInfo.Selectors["lastAccessAt"]
+		assert.NotEmpty(t, driver.ExtractFieldValuePublic(doc, laSel))
+	})
+}
+
+func TestPandaPT_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":      pandaptSearchFixture,
+		"detail":      pandaptDetailFixture,
+		"index":       pandaptIndexFixture,
+		"userdetails": pandaptUserdetailsFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			RequireNoSecrets(t, name, data)
+		})
+	}
+}

--- a/site/v2/definitions/ptfans.go
+++ b/site/v2/definitions/ptfans.go
@@ -1,0 +1,180 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+// PTFansDefinition is the site definition for PTFans (ptfans.cc).
+// Standard NexusPHP site with H&R; user stats (上传量/下载量/分享率/魔力值/做种/下载)
+// live in the #info_block div present on both index.php and userdetails.php, while
+// 等级/加入日期/最近动向 stay in the standard userdetails.php rows. Username link uses
+// the PowerUser_Name class (matched via [class*='Name']).
+var PTFansDefinition = &v2.SiteDefinition{
+	ID:             "ptfans",
+	Name:           "PTFans",
+	Aka:            []string{"PTF", "PT粉丝"},
+	Description:    "综合性 PT 站点",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://ptfans.cc/"},
+	FaviconURL:     "https://ptfans.cc/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	HREnabled:      true,
+	// 本站资源开启 7 天 HR，请在 35 天内完成做种 7 天（168 小时）。
+	HRSeedTimeHours: 168,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "seeding", "leeching", "bonus", "uploaded", "downloaded", "ratio"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields:        []string{"levelName", "joinTime", "lastAccessAt"},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			"id": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php'][class*='Name']",
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php']",
+				},
+				Attr:    "href",
+				Filters: []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php'][class*='Name'] b",
+					"#info_block a[href*='userdetails.php'][class*='Name']",
+					"#info_block a[href*='userdetails.php']",
+				},
+			},
+			"uploaded": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`上传量[:：]\s*</font>\s*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"downloaded": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`下载量[:：]\s*</font>\s*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"ratio": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`分享率[:：]\s*</font>\s*(?:<font[^>]*>)?([\d.,]+|∞|Inf)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"bonus": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`魔力值\s*</font>\s*\[[^\]]*\]\s*[:：]\s*([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowup"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"levelName": {
+				Selector: []string{
+					"td.rowhead:contains('等级') + td img",
+					"td.rowhead:contains('等級') + td img",
+					"td.rowhead:contains('等级') + td",
+					"td.rowhead:contains('等級') + td",
+				},
+				Attr: "title",
+			},
+			"joinTime": {
+				Selector: []string{
+					"td.rowhead:contains('加入日期') + td",
+					"td.rowhead:contains('加入時間') + td",
+					"td.rowhead:contains('Join') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+			"lastAccessAt": {
+				Selector: []string{
+					"td.rowhead:contains('最近动向') + td",
+					"td.rowhead:contains('最近動向') + td",
+					"td.rowhead:contains('上次访问') + td",
+					"td.rowhead:contains('上次訪問') + td",
+					"td.rowhead:contains('Last access') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		TableRows:          "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:              "table.torrentname a[href*='details.php']",
+		TitleLink:          "table.torrentname a[href*='details.php']",
+		Subtitle:           "table.torrentname td.embedded > span:last-of-type, table.torrentname td.embedded > span",
+		Size:               "td.rowfollow:nth-child(5)",
+		Seeders:            "td.rowfollow:nth-child(6)",
+		Leechers:           "td.rowfollow:nth-child(7)",
+		Snatched:           "td.rowfollow:nth-child(8)",
+		DiscountIcon:       "img.pro_free, img.pro_free2up, img.pro_2up, img.pro_50pctdown, img.pro_50pctdown2up, img.pro_30pctdown",
+		DiscountEndTime:    "table.torrentname td.embedded font[color] span[title], table.torrentname td.embedded span[title]",
+		HRIcon:             "img.hitandrun, img[alt*='H&R'], img[title*='H&R']",
+		Category:           "td.rowfollow:nth-child(1) span[title], td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:         "td.rowfollow:nth-child(4) span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords:       []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		TitleSelector:    "input[name='torrent_name']",
+		IDSelector:       "input[name='detail_torrent_id']",
+		DiscountSelector: "h1 font.free, h1 font[class]",
+		EndTimeSelector:  "h1 span[title]",
+		SizeSelector:     "td.rowhead:contains('基本信息')",
+		SizeRegex:        `大小[：:]\s*([\d.]+)\s*(GB|MB|KB|TB)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(PTFansDefinition)
+}

--- a/site/v2/definitions/ptfans_fixture_test.go
+++ b/site/v2/definitions/ptfans_fixture_test.go
@@ -1,0 +1,220 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "ptfans",
+		Search:   testPTFansSearch,
+		Detail:   testPTFansDetail,
+		UserInfo: testPTFansUserInfo,
+	})
+}
+
+const ptfansSearchFixture = `<html><body>
+<table class="torrents"><tbody>
+<tr>
+  <td class="rowfollow nowrap"><a href="?cat=412"><span class="c_shukan" title="Book">.::</span></a></td>
+  <td class="rowfollow"><table class="torrentname"><tr><td class="embedded"><img src="pic/misc/spinner.svg" class="nexus-lazy-load" /></td>
+    <td class="embedded">
+      <img class="sticky" src="pic/trans.gif" alt="Sticky" title="一级置顶" />&nbsp;
+      <a title="从零开始玩PT入门到精通 V1.0 PDF" href="details.php?id=68&amp;hit=1"><b>从零开始玩PT入门到精通 V1.0 PDF</b></a>
+      <b>[<font class='hot'>热门</font>]</b>
+      <img class="pro_free" src="pic/trans.gif" alt="Free" title="免费" />
+      <img class="hitandrun" src="pic/trans.gif" alt="H&amp;R" title="H&amp;R" />
+      <br />本站资源开启7天HR，请在35天内完成做种7天
+    </td></tr></table></td>
+  <td class="rowfollow"><a href="comment.php?action=add&amp;pid=68&amp;type=torrent">0</a></td>
+  <td class="rowfollow nowrap"><span title="2026-06-16 08:39:42">1天<br />14时</span></td>
+  <td class="rowfollow">7.96<br />MB</td>
+  <td class="rowfollow" align="center"><b><a href="details.php?id=68&amp;dllist=1#seeders">42</a></b></td>
+  <td class="rowfollow"><b><a href="details.php?id=68&amp;dllist=1#leechers">3</a></b></td>
+  <td class="rowfollow"><a href="viewsnatches.php?id=68"><b>88</b></a></td>
+  <td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr>
+  <td class="rowfollow nowrap"><a href="?cat=401"><span class="c_movie" title="Movie">.::</span></a></td>
+  <td class="rowfollow"><table class="torrentname"><tr><td class="embedded"><img src="pic/misc/spinner.svg" class="nexus-lazy-load" /></td>
+    <td class="embedded">
+      <a title="命运注定 2026 1080p" href="details.php?id=7989&amp;hit=1"><b>命运注定 2026 1080p</b></a>
+      <img class="pro_free" src="pic/trans.gif" alt="Free" onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;free&quot;&gt;免费&lt;/font&gt;&lt;/b&gt;剩余时间：&lt;b&gt;&lt;span title=&quot;2026-06-23 08:39:42&quot;&gt;5天9时&lt;/span&gt;&lt;/b&gt;', 'trail', false);" />
+      <br />命中注定 野性
+    </td></tr></table></td>
+  <td class="rowfollow"><a href="comment.php?action=add&amp;pid=7989&amp;type=torrent">0</a></td>
+  <td class="rowfollow nowrap"><span title="2026-06-16 08:39:42">1天<br />14时</span></td>
+  <td class="rowfollow">7.96<br />GB</td>
+  <td class="rowfollow" align="center"><b><a href="details.php?id=7989&amp;dllist=1#seeders">12</a></b></td>
+  <td class="rowfollow"><b><a href="details.php?id=7989&amp;dllist=1#leechers">0</a></b></td>
+  <td class="rowfollow"><a href="viewsnatches.php?id=7989"><b>20</b></a></td>
+  <td class="rowfollow"><i>匿名</i></td>
+</tr>
+</tbody></table>
+</body></html>`
+
+const ptfansDetailFixture = `<html><body>
+<h1>
+  <input type="hidden" name="torrent_name" value="从零开始玩PT入门到精通 V1.0 PDF" />
+  <input type="hidden" name="detail_torrent_id" value="68" />
+  从零开始玩PT入门到精通 V1.0 PDF&nbsp;&nbsp;&nbsp; <b>[<font class='free' >免费</font>]</b>
+  <img class="hitandrun" src="pic/trans.gif" alt="H&amp;R" title="H&amp;R" />
+</h1>
+<table>
+  <tr><td class="rowhead nowrap">基本信息</td><td class="rowfollow"><b><b>大小：</b></b>2.26 MB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;Book</td></tr>
+  <tr><td class="rowhead nowrap">副标题</td><td class="rowfollow">本站资源开启7天HR，请在35天内完成做种7天</td></tr>
+</table>
+</body></html>`
+
+const ptfansIndexFixture = `<html><body>
+<table id="info_block" cellpadding="4" cellspacing="0" border="0" width="100%"><tr><td>
+<span class="medium">
+欢迎回来, <span class="nowrap"><a href="https://ptfans.cc/userdetails.php?id=17879" class='PowerUser_Name'><b>testuser</b></a></span>
+[<a href="logout.php">退出</a>]
+<font class = 'color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 166,546.4
+<font class = 'color_invite'>邀请 </font>[<a href="invite.php?id=17879">发送</a>]: 12(0)
+<br />
+<font class="color_ratio">分享率:</font> 3.983
+<font class='color_uploaded'>上传量:</font> 465.39 GB
+<font class='color_downloaded'> 下载量:</font> 116.85 GB
+<font class='color_active'>当前活动:</font>
+<img class="arrowup" alt="Torrents seeding" title="当前做种" src="pic/trans.gif" />3
+<img class="arrowdown" alt="Torrents leeching" title="当前下载" src="pic/trans.gif" />0
+</span>
+</td></tr></table>
+</body></html>`
+
+const ptfansUserdetailsFixture = `<html><body>
+<table id="info_block" cellpadding="4" cellspacing="0" border="0" width="100%"><tr><td>
+<span class="medium">
+欢迎回来, <span class="nowrap"><a href="https://ptfans.cc/userdetails.php?id=17879" class='PowerUser_Name'><b>testuser</b></a></span>
+<font class = 'color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 166,546.4
+<br />
+<font class="color_ratio">分享率:</font> 3.983
+<font class='color_uploaded'>上传量:</font> 465.39 GB
+<font class='color_downloaded'> 下载量:</font> 116.85 GB
+<font class='color_active'>当前活动:</font>
+<img class="arrowup" src="pic/trans.gif" />3
+<img class="arrowdown" src="pic/trans.gif" />0
+</span>
+</td></tr></table>
+<table>
+  <tr><td class="rowhead nowrap">加入日期</td><td class="rowfollow">2026-01-21 16:33:50 (<span title="2026-01-21 16:33:50">4月27天前</span>, 21周)</td></tr>
+  <tr><td class="rowhead nowrap">最近动向</td><td class="rowfollow">2026-06-17 22:19:08 (<span title="2026-06-17 22:19:08">22分钟前</span>)</td></tr>
+  <tr><td class="rowhead nowrap">等级</td><td class="rowfollow"><img alt="Power User" title="Power User" src="pic/poweruser.gif" /> </td></tr>
+</table>
+</body></html>`
+
+func getPTFansDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("ptfans")
+	require.True(t, ok, "ptfans definition not found")
+	return def
+}
+
+func testPTFansSearch(t *testing.T) {
+	def := getPTFansDef(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(ptfansSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{BaseURL: server.URL, Cookie: "test_cookie=1", Selectors: def.Selectors})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: "GET"})
+	require.NoError(t, err)
+
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+
+	assert.Equal(t, "68", items[0].ID)
+	assert.Equal(t, "从零开始玩PT入门到精通 V1.0 PDF", items[0].Title)
+	assert.Equal(t, v2.DiscountFree, items[0].DiscountLevel)
+	assert.Equal(t, 42, items[0].Seeders)
+	assert.Equal(t, 3, items[0].Leechers)
+	assert.Equal(t, 88, items[0].Snatched)
+
+	assert.Equal(t, "7989", items[1].ID)
+	assert.Equal(t, v2.DiscountFree, items[1].DiscountLevel)
+	// Discount end time embedded in onmouseover tooltip
+	assert.False(t, items[1].DiscountEndTime.IsZero(), "ptfans onmouseover end time should parse")
+}
+
+func testPTFansDetail(t *testing.T) {
+	def := getPTFansDef(t)
+	parser := v2.NewNexusPHPParserFromDefinition(def)
+
+	doc := FixtureDoc(t, "ptfans_detail", ptfansDetailFixture)
+	info := parser.ParseAll(doc.Selection)
+	assert.Equal(t, "68", info.TorrentID)
+	assert.Equal(t, "从零开始玩PT入门到精通 V1.0 PDF", info.Title)
+	assert.Equal(t, v2.DiscountFree, info.DiscountLevel)
+	assert.InDelta(t, 2.26, info.SizeMB, 0.01)
+	assert.True(t, info.HasHR)
+}
+
+func testPTFansUserInfo(t *testing.T) {
+	def := getPTFansDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	t.Run("IndexPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "ptfans_index", ptfansIndexFixture)
+		fields := map[string]string{
+			"id":         "17879",
+			"name":       "testuser",
+			"bonus":      "166546.4",
+			"ratio":      "3.983",
+			"uploaded":   "499708707471",
+			"downloaded": "125466732134",
+			"seeding":    "3",
+			"leeching":   "0",
+		}
+		for field, expected := range fields {
+			sel, ok := def.UserInfo.Selectors[field]
+			require.True(t, ok, "selector %q missing", field)
+			assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel), "field %q", field)
+		}
+	})
+
+	t.Run("UserdetailsPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "ptfans_userdetails", ptfansUserdetailsFixture)
+		expected := map[string]string{
+			"levelName":    "Power User",
+			"joinTime":     "1768984430",
+			"lastAccessAt": "1781705948",
+		}
+		for field, want := range expected {
+			sel, ok := def.UserInfo.Selectors[field]
+			require.True(t, ok, "selector %q missing", field)
+			assert.Equal(t, want, driver.ExtractFieldValuePublic(doc, sel), "field %q", field)
+		}
+		laSel := def.UserInfo.Selectors["lastAccessAt"]
+		assert.NotEmpty(t, driver.ExtractFieldValuePublic(doc, laSel))
+	})
+}
+
+func TestPTFans_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":      ptfansSearchFixture,
+		"detail":      ptfansDetailFixture,
+		"index":       ptfansIndexFixture,
+		"userdetails": ptfansUserdetailsFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			RequireNoSecrets(t, name, data)
+		})
+	}
+}

--- a/site/v2/definitions/real_html_validation_test.go
+++ b/site/v2/definitions/real_html_validation_test.go
@@ -73,6 +73,24 @@ func TestRealHTML_UserInfo(t *testing.T) {
 			indexFields:  []string{"id", "name", "bonus", "seeding", "leeching"},
 			detailFields: []string{"uploaded", "downloaded", "ratio", "joinTime"},
 		},
+		{
+			siteID:       "pandapt",
+			zipDir:       "/tmp/site-zips/pandapt",
+			indexFields:  []string{"id", "name", "bonus", "ratio", "uploaded", "downloaded", "seeding", "leeching"},
+			detailFields: []string{"levelName", "joinTime", "lastAccessAt"},
+		},
+		{
+			siteID:       "ptfans",
+			zipDir:       "/tmp/site-zips/ptfans",
+			indexFields:  []string{"id", "name", "bonus", "ratio", "uploaded", "downloaded", "seeding"},
+			detailFields: []string{"levelName", "joinTime", "lastAccessAt"},
+		},
+		{
+			siteID:       "kamept",
+			zipDir:       "/tmp/site-zips/kamept",
+			indexFields:  []string{"id", "name", "bonus", "seedingBonus", "ratio", "uploaded", "downloaded", "seeding"},
+			detailFields: []string{"levelName", "joinTime", "lastAccessAt"},
+		},
 	}
 
 	for _, tc := range sites {
@@ -152,6 +170,9 @@ func TestRealHTML_Search(t *testing.T) {
 		{"1ptba", "/tmp/site-zips/1ptba"},
 		{"ourbits", "/tmp/site-zips/ourbits"},
 		{"mua", "/tmp/site-zips/mua"},
+		{"pandapt", "/tmp/site-zips/pandapt"},
+		{"ptfans", "/tmp/site-zips/ptfans"},
+		{"kamept", "/tmp/site-zips/kamept"},
 	}
 
 	for _, tc := range sites {
@@ -205,6 +226,9 @@ func TestRealHTML_Detail(t *testing.T) {
 		{"1ptba", "/tmp/site-zips/1ptba"},
 		{"ourbits", "/tmp/site-zips/ourbits"},
 		{"mua", "/tmp/site-zips/mua"},
+		{"pandapt", "/tmp/site-zips/pandapt"},
+		{"ptfans", "/tmp/site-zips/ptfans"},
+		{"kamept", "/tmp/site-zips/kamept"},
 	}
 
 	for _, tc := range sites {

--- a/tools/browser-extension/src/core/constants.ts
+++ b/tools/browser-extension/src/core/constants.ts
@@ -427,6 +427,33 @@ export const KNOWN_SITES: KnownSite[] = [
     cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
     syncField: "cookie",
   },
+  {
+    id: "pandapt",
+    name: "PandaPT",
+    domains: ["pandapt.net"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
+  {
+    id: "ptfans",
+    name: "PTFans",
+    domains: ["ptfans.cc"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
+  {
+    id: "kamept",
+    name: "KamePT",
+    domains: ["kamept.com"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
 ];
 
 export const PAGE_PATTERNS: Array<{ pattern: RegExp; pageType: PageType }> = [


### PR DESCRIPTION
## Summary
- 新增三个 NexusPHP 站点适配：pandapt.net(#416)、ptfans.cc(#417)、kamept.com(#418)
- 均为 Cookie 鉴权；从 `#info_block` 解析用户数据，补充 `lastAccessAt` 支持保号探测

## Changes
### 站点定义 + fixture 测试
- `site/v2/definitions/pandapt.go` / `pandapt_fixture_test.go`
- `site/v2/definitions/ptfans.go` / `ptfans_fixture_test.go`（H&R 168h）
- `site/v2/definitions/kamept.go` / `kamept_fixture_test.go`（额外解析做种积分 seedingBonus）

### 关键技术点
- 与 btschool/springsunday 模板不同：三站将 上传量/下载量/分享率/魔力值/做种/下载 存于 `#info_block` div（而非「传输」行），故对 `#info_block` 做 `Attr=html` 正则提取
- 用户名链接 class 各异（`User_Name` / `PowerUser_Name`），统一用 `[class*='Name']` 匹配
- 分享率正则容忍 `</font>` 紧贴值及 `∞/Inf`

### 校验
- 新增 fixture 测试（Search/Detail/UserInfo/NoSecrets）全部通过
- 真实采集 HTML 校验：搜索(100/50/50 行)、详情(ID/标题/FREE/大小/HR 均正确，ptfans HasHR=true)、用户信息全字段非空正确
- 字段覆盖对比 11 个同架构站点：无缺失/误判字段（三站均含 `lastAccessAt`，覆盖优于多数参考站）
- `check-sites.ts` 一致性检查：48 站点 Go 定义与扩展同步

### 文档 + 扩展
- `docs/sites.md`：新增三行 + 总数 45→48 + NexusPHP 分类 41→44
- `tools/browser-extension/src/core/constants.ts`：KNOWN_SITES 新增三站

Closes #416
Closes #417
Closes #418