### PR TITLE
docs(log): 补充飞牛/群晖等 NAS 用户的容器日志轮转指引

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ services:
     volumes:
       - ./data:/app/.pt-tools
     restart: unless-stopped
+    # 限制容器日志大小，避免长期运行膨胀到数 GB（见下方「Docker 用户注意」）
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 ```
 
 > 如需通过代理访问站点，可设置环境变量：`HTTP_PROXY`、`HTTPS_PROXY`、`ALL_PROXY`、`NO_PROXY`。
@@ -196,6 +202,43 @@ services:
 > - [examples/docker-run.md](examples/docker-run.md) - Docker 单容器运行详解
 > - [examples/docker-compose.yml](examples/docker-compose.yml) - Docker Compose 编排
 > - [examples/binary-run.md](examples/binary-run.md) - 二进制运行和 systemd 配置
+
+### ⚙️ Docker 用户注意（日志膨胀）
+
+容器日志（`docker logs`）默认由 Docker 的 `json-file` 驱动管理，**默认没有大小限制**，长期运行可能增长到数 GB。pt-tools 自身的日志文件（`~/.pt-tools/logs/`）已自动滚动切割，但容器 stdout 日志需由 Docker 侧限制。建议开启日志轮转：
+
+- **Docker Compose**（推荐，所有平台通用）：在服务下添加 `logging` 块（见上方示例）
+
+  ```yaml
+  logging:
+    driver: json-file
+    options:
+      max-size: "10m"
+      max-file: "3"
+  ```
+
+- **`docker run`**：追加参数
+
+  ```bash
+  --log-opt max-size=10m --log-opt max-file=3
+  ```
+
+- **飞牛 NAS（fnOS）/ 群晖 DSM Container Manager / Unraid / Portainer**：
+
+  图形界面创建的容器，多数版本**未开放日志驱动配置**。建议改用 **Docker Compose** 部署并按上述方式配置 `logging`；若已用 GUI 创建，可 SSH 到 NAS 改用 Compose 重建容器。
+
+- **Linux 全局默认**（影响此后新建的所有容器）：编辑 `/etc/docker/daemon.json`
+
+  ```json
+  {
+    "log-driver": "json-file",
+    "log-opts": { "max-size": "10m", "max-file": "3" }
+  }
+  ```
+
+  然后 `sudo systemctl restart docker`。⚠️ 仅对**重新创建**的容器生效，已有容器需重建。
+
+> 完整日志说明（应用日志滚动、环境变量 `PT_TOOLS_LOG_LEVEL` / `PT_TOOLS_LOG_CONSOLE`）见 [docs/configuration.md](docs/configuration.md#日志管理)。
 
 ### 二进制运行
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -263,7 +263,21 @@ pt-tools 的日志由两部分组成，需分别管理：
 
 控制台输出默认开启（`PT_TOOLS_LOG_CONSOLE=true`），以便在飞牛/群晖等 NAS 的容器控制台直接查看日志；**因此务必**为容器配置日志上限，否则 stdout 会被 Docker 无限累积。如确实不需要控制台日志，可设 `PT_TOOLS_LOG_CONSOLE=false` 关闭。
 
-`docker run`：
+按部署方式选择对应配置：
+
+**Docker Compose（推荐，所有平台通用）**：在服务下添加 `logging` 块。
+
+```yaml
+services:
+  pt-tools:
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+```
+
+**`docker run`**：追加参数。
 
 ```bash
 docker run -d \
@@ -274,17 +288,19 @@ docker run -d \
   sunerpy/pt-tools:latest
 ```
 
-`docker-compose.yml`：
+**飞牛 NAS（fnOS）/ 群晖 DSM Container Manager / Unraid / Portainer**：
+图形界面创建的容器，多数版本**未开放日志驱动（log driver）配置**。推荐改用 **Docker Compose** 部署并按上述方式配置 `logging`；若已用 GUI 创建，可 SSH 到 NAS 改用 Compose 重建容器（数据目录已持久化，不会丢失）。不建议为单容器去改 `daemon.json`。
 
-```yaml
-services:
-  pt-tools:
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
+**Linux 全局默认**（影响此后新建的所有容器）：编辑 `/etc/docker/daemon.json`。
+
+```json
+{
+  "log-driver": "json-file",
+  "log-opts": { "max-size": "10m", "max-file": "3" }
+}
 ```
+
+然后执行 `sudo systemctl restart docker`。⚠️ 该配置**仅对重新创建的容器生效**，已存在的容器需重建后才会应用。
 
 清理已堆积的旧容器日志：`docker logs` 无法直接清空，可重建容器（`docker rm` 后重新 `run`，数据目录已持久化不会丢失）或截断对应的 `*-json.log` 文件。
 


### PR DESCRIPTION
## Summary
- 针对用户反馈：仅给 `docker run --log-opt` 对 NAS（飞牛/群晖/Unraid/Portainer）用户不够用
- README 与 configuration.md 增补「Docker 用户注意」小节，覆盖多种部署方式

## Changes
- **Docker Compose**：`logging.options.max-size/max-file`（推荐，所有平台通用）
- **`docker run`**：`--log-opt max-size/max-file`
- **飞牛 NAS(fnOS)/群晖 DSM Container Manager/Unraid/Portainer**：GUI 多数未开放日志驱动配置 → 建议改用 Compose 部署
- **Linux 全局默认**：`/etc/docker/daemon.json` + 重启 docker（仅对新建容器生效）

纯文档变更，已通过 oxfmt 格式化。