### PR TITLE
fix(docker): Alpine 运行镜像补装 tzdata 修复容器时区不生效

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,8 +94,9 @@ RUN echo -n "pt-tools-docker-build" > /app/.pt-tools-docker
 ENV GOSU_VERSION 1.17
 RUN set -eux; \
 	\
+	apk add --no-cache tzdata ca-certificates; \
+	\
 	apk add --no-cache --virtual .gosu-deps \
-	ca-certificates \
 	dpkg \
 	gnupg \
 	; \


### PR DESCRIPTION
## Summary
- Alpine 运行镜像补装 `tzdata`，修复仅设置 `TZ` 环境变量时区不生效的问题
- 将 `ca-certificates` 移出 `.gosu-deps` 虚拟包，避免随虚拟包一并删除

## Changes
- Alpine 默认不含 `tzdata`，即便设置 `TZ=Asia/Shanghai` 也无法生效；本次在运行阶段以持久层方式 `apk add --no-cache tzdata ca-certificates`，使时区数据常驻。
- 原先 `ca-certificates` 放在 `--virtual .gosu-deps` 虚拟包中，会在 gosu 安装完成后被 `apk del .gosu-deps` 删除；移出后保证运行时 HTTPS 证书常驻。

用户反馈 Docker 设置 TZ 时区不生效。