### PR TITLE
fix: 站点探测失败时展示状态与原因避免误报成功

### DIFF
--- a/web/api_site_login.go
+++ b/web/api_site_login.go
@@ -245,6 +245,7 @@ func (s *Server) handleLoginStateProbe(w http.ResponseWriter, r *http.Request, s
 		"ok":                true,
 		"last_probe_at":     timestampPtr(state.LastProbeAt),
 		"last_probe_status": state.LastProbeStatus,
+		"last_probe_error":  state.LastProbeError,
 	})
 }
 

--- a/web/frontend/src/api/index.ts
+++ b/web/frontend/src/api/index.ts
@@ -259,9 +259,12 @@ export const sitesApi = {
     }>,
   ) => api.put<void>(`/api/sites/${name}/login-state/config`, data),
   probeNow: (name: string) =>
-    api.post<{ ok: boolean; last_probe_at?: number; last_probe_status?: string }>(
-      `/api/sites/${name}/login-state/probe`,
-    ),
+    api.post<{
+      ok: boolean;
+      last_probe_at?: number;
+      last_probe_status?: string;
+      last_probe_error?: string;
+    }>(`/api/sites/${name}/login-state/probe`),
   testReminder: (name: string) =>
     api.post<{ success: boolean; message: string }>(`/api/sites/${name}/login-state/test-reminder`),
 };

--- a/web/frontend/src/utils/probeStatus.ts
+++ b/web/frontend/src/utils/probeStatus.ts
@@ -1,0 +1,62 @@
+/**
+ * 登录态探测状态（ProbeStatus）前端映射工具。
+ *
+ * 后端枚举定义于 internal/sitelogin/result.go，`probeNow` 接口返回的
+ * `last_probe_status` 为探测状态码而非成功标志：它可能是失败状态。
+ * 后端 handler（web/api_site_login.go）在探测执行后恒返回 `ok: true`
+ * （仅表示未发生锁冲突，探测已运行），因此 **`ok` 不是探测成功的可靠信号**，
+ * 判定探测是否成功必须以 `last_probe_status === "OK"` 为准。
+ */
+
+/** 探测状态严重级别，与 ElMessage 的类型一一对应。 */
+export type ProbeSeverity = "success" | "info" | "warning" | "error";
+
+interface ProbeStatusMeta {
+  /** 严重级别：仅 OK 为 success（绿色），真正的失败绝不为 success。 */
+  severity: ProbeSeverity;
+  /** 人类可读的中文标签。 */
+  label: string;
+}
+
+const PROBE_STATUS_MAP: Record<string, ProbeStatusMeta> = {
+  OK: { severity: "success", label: "正常" },
+  NOT_APPLICABLE: { severity: "info", label: "不适用" },
+  SESSION_EXPIRED: { severity: "warning", label: "会话已过期" },
+  CHALLENGE: { severity: "warning", label: "被反爬拦截" },
+  RATE_LIMITED: { severity: "warning", label: "请求过于频繁" },
+  KEY_ERROR: { severity: "warning", label: "密钥错误" },
+  NETWORK_ERROR: { severity: "error", label: "网络错误" },
+  PARSE_ERROR: { severity: "error", label: "解析失败" },
+  UNKNOWN: { severity: "error", label: "未知状态" },
+};
+
+/** 未识别 / 空状态统一按未知错误处理。 */
+const UNKNOWN_META: ProbeStatusMeta = { severity: "error", label: "未知状态" };
+
+function probeStatusMeta(status?: string): ProbeStatusMeta {
+  if (!status) return UNKNOWN_META;
+  return PROBE_STATUS_MAP[status] ?? UNKNOWN_META;
+}
+
+/**
+ * 判定探测是否真正成功。
+ * 以 `last_probe_status === "OK"` 为唯一权威信号（后端 `ok` 恒为 true，不可用于判定）。
+ */
+export function isProbeSuccess(status?: string): boolean {
+  return status === "OK";
+}
+
+/** 获取探测状态的严重级别，用于选择 ElMessage 类型。 */
+export function probeStatusSeverity(status?: string): ProbeSeverity {
+  return probeStatusMeta(status).severity;
+}
+
+/**
+ * 获取探测状态的展示文案，保留原始状态码以便排障，
+ * 例如 "解析失败 (PARSE_ERROR)"；空状态返回 "未知状态"。
+ */
+export function probeStatusLabel(status?: string): string {
+  const meta = probeStatusMeta(status);
+  if (!status) return meta.label;
+  return `${meta.label} (${status})`;
+}

--- a/web/frontend/src/views/SiteList.vue
+++ b/web/frontend/src/views/SiteList.vue
@@ -6,6 +6,7 @@ import { computed, onMounted, reactive, ref } from "vue";
 import { useRouter } from "vue-router";
 
 import { formatTimeAgo } from "@/utils/format";
+import { isProbeSuccess, probeStatusLabel, probeStatusSeverity } from "@/utils/probeStatus";
 import { useLoginState } from "@/composables/useLoginState";
 
 const router = useRouter();
@@ -96,7 +97,32 @@ async function probeSite(name: string) {
   probing[name] = true;
   try {
     const res = await sitesApi.probeNow(name);
-    ElMessage.success(`探测完成: ${res.last_probe_status || "ok"}`);
+    // 注意：后端 res.ok 恒为 true（仅表示探测已执行、未发生锁冲突），
+    // 判定探测是否成功必须以 last_probe_status === "OK" 为准。
+    const status = res.last_probe_status;
+    const label = probeStatusLabel(status);
+    // 后端 last_probe_error 为人类可读的失败原因（如 Cookie 未失效提示）；
+    // 仅在存在非空原因、且原因未重复状态码时展示，避免冗余。
+    const reason = res.last_probe_error?.trim();
+    if (isProbeSuccess(status)) {
+      ElMessage.success(`探测完成：${label}`);
+    } else {
+      const severity = probeStatusSeverity(status);
+      if (severity === "info") {
+        // NOT_APPLICABLE 等：探测已完成但不适用，若有原因一并展示。
+        ElMessage.info(reason ? `探测完成：${label} — ${reason}` : `探测完成：${label}`);
+      } else {
+        // warning/error：探测未通过，原因可能较长，改用可关闭、长驻留的提示。
+        const message = reason ? `探测未通过：${label} — ${reason}` : `探测未通过：${label}`;
+        ElMessage({
+          type: severity,
+          message,
+          showClose: true,
+          duration: severity === "error" ? 0 : 6000,
+        });
+      }
+    }
+    // 无论成功与否都刷新表格，使状态列反映最新的 last_probe_status / last_probe_at。
     await loadSites();
   } catch (e: unknown) {
     if (e instanceof ApiError && e.status === 409) {
@@ -148,8 +174,11 @@ async function probeAllEnabled() {
 
       probing[name] = true;
       try {
-        await sitesApi.probeNow(name);
-        success++;
+        const res = await sitesApi.probeNow(name);
+        // res.ok 恒为 true，仅以 last_probe_status === "OK" 判定真正成功；
+        // 其余状态（如 PARSE_ERROR，HTTP 200 但探测失败）计为失败。
+        if (isProbeSuccess(res.last_probe_status)) success++;
+        else failed++;
       } catch (e: unknown) {
         if (e instanceof ApiError && e.status === 409) skipped++;
         else failed++;


### PR DESCRIPTION
## 问题

站点登录状态即时探测（instant probe）此前把探测状态码当作成功标志，导致 PARSE_ERROR 等失败情况也显示绿色成功提示（如「探测完成: PARSE_ERROR」），造成用户误判。批量探测的成功计数也存在同样的误计问题。

## 修复

- 仅当 ProbeStatus 为 OK 时视为成功（绿色）；其余按严重级别显示 warning/error 提示。
- 新增 `web/frontend/src/utils/probeStatus.ts`：ProbeStatus → 严重级别 + 中文 label 映射。
- `probeNow` 接口补充返回 `last_probe_error`，前端展示具体失败原因（如「Cookie 未配置或已失效…」）。
- 批量探测改为按 `last_probe_status === "OK"` 统计成功数量，修正成功误计。

## 变更文件

- `web/api_site_login.go`：即时探测 JSON 响应新增 `last_probe_error`
- `web/frontend/src/api/index.ts`：`probeNow` 返回类型新增 `last_probe_error?`
- `web/frontend/src/utils/probeStatus.ts`（新增）
- `web/frontend/src/views/SiteList.vue`：按严重级别分级提示并展示失败原因