### PR TITLE
fix: 对齐 Dockerfile 构建镜像 Go 版本至 1.26.5 修复发布镜像构建失败

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 参数区分构建环境与基础镜像来源
-ARG BUILD_IMAGE=golang:1.26.4
+ARG BUILD_IMAGE=golang:1.26.5
 ARG BASE_IMAGE=alpine:3.20.3
 ARG NODE_IMAGE=node:25.2.0-alpine
 ARG BUILD_ENV=local

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ HTTPS_PROXY ?= $(https_proxy)
 NO_PROXY ?= $(no_proxy)
 
 # 默认基础镜像
-BUILD_IMAGE ?= golang:1.26.4
+BUILD_IMAGE ?= golang:1.26.5
 BASE_IMAGE ?= alpine:3.20.3
 NODE_IMAGE ?= node:25.2.0-alpine
 BUILD_ENV ?= remote


### PR DESCRIPTION
## Summary
- 修复 v0.40.4 发布流水线 Docker 构建失败：go.mod 要求 go 1.26.5，但 Dockerfile/Makefile 构建镜像仍固定为 golang:1.26.4，GOTOOLCHAIN=local 禁止自动升级导致构建报错。

## Changes
- `Dockerfile` line 2: `ARG BUILD_IMAGE=golang:1.26.4` → `golang:1.26.5`
- `Makefile` line 44: `BUILD_IMAGE ?= golang:1.26.4` → `golang:1.26.5`

两处均为 golang 版本 pin，与 go.mod 的 `go 1.26.5` 对齐，无其它改动。