### PR TITLE
fix: 修复清理工作目录 RetainHours 误清零并增强已用空间展示与 Windows 兼容

### DIFF
--- a/core/config_store.go
+++ b/core/config_store.go
@@ -240,7 +240,26 @@ func (s *ConfigStore) GetGlobalSettings() (models.SettingsGlobal, error) {
 	return gs, nil
 }
 
+// GlobalSettingsPatch 表达全局设置的“部分更新”语义（方式 ii）。
+// 这些字段在 Web API 中通过指针区分“未提供”（nil → 保留 DB 现值）与
+// “显式提供（含 0）”（非 nil → 写入）。仅用于阻止 apiGlobal 漏传导致的静默清零，
+// 不改变 SaveGlobalSettings 对其余字段的全量赋值语义。
+type GlobalSettingsPatch struct {
+	DefaultEnabled     *bool
+	RetainHours        *int
+	MaxRetry           *int
+	DefaultConcurrency *int32
+}
+
 func (s *ConfigStore) SaveGlobalSettings(gs models.SettingsGlobal) error {
+	return s.SaveGlobalSettingsWithPatch(gs, nil)
+}
+
+// SaveGlobalSettingsWithPatch 在 SaveGlobalSettings 基础上增加部分更新通道。
+//   - patch == nil：与旧 SaveGlobalSettings 完全一致（4 字段从 gs 全量赋值），保持所有既有调用方语义。
+//   - patch != nil：DefaultEnabled/RetainHours/MaxRetry/DefaultConcurrency 仅在对应指针非 nil 时写入，
+//     nil 时保留 DB 现值（更新分支）或落合理默认（INSERT 分支）。
+func (s *ConfigStore) SaveGlobalSettingsWithPatch(gs models.SettingsGlobal, patch *GlobalSettingsPatch) error {
 	if strings.TrimSpace(gs.DownloadDir) == "" {
 		return errors.New("下载目录不能为空")
 	}
@@ -257,16 +276,32 @@ func (s *ConfigStore) SaveGlobalSettings(gs models.SettingsGlobal) error {
 	db := s.db.DB
 	if err := db.First(&cur).Error; err == nil {
 		cur.DefaultIntervalMinutes = gs.DefaultIntervalMinutes
-		cur.DefaultEnabled = gs.DefaultEnabled
 		cur.DownloadDir = gs.DownloadDir
 		cur.DownloadLimitEnabled = gs.DownloadLimitEnabled
 		cur.DownloadSpeedLimit = gs.DownloadSpeedLimit
 		cur.TorrentSizeGB = gs.TorrentSizeGB
 		cur.MinFreeMinutes = gs.MinFreeMinutes
 		cur.AutoStart = gs.AutoStart
-		cur.RetainHours = gs.RetainHours
-		cur.MaxRetry = gs.MaxRetry
-		cur.DefaultConcurrency = gs.DefaultConcurrency
+		// 以下 4 字段：patch 优先（区分 omitted/explicit），否则维持旧全量赋值语义。
+		if patch != nil {
+			if patch.DefaultEnabled != nil {
+				cur.DefaultEnabled = *patch.DefaultEnabled
+			}
+			if patch.RetainHours != nil {
+				cur.RetainHours = *patch.RetainHours
+			}
+			if patch.MaxRetry != nil {
+				cur.MaxRetry = *patch.MaxRetry
+			}
+			if patch.DefaultConcurrency != nil {
+				cur.DefaultConcurrency = *patch.DefaultConcurrency
+			}
+		} else {
+			cur.DefaultEnabled = gs.DefaultEnabled
+			cur.RetainHours = gs.RetainHours
+			cur.MaxRetry = gs.MaxRetry
+			cur.DefaultConcurrency = gs.DefaultConcurrency
+		}
 		cur.CleanupEnabled = gs.CleanupEnabled
 		cur.CleanupIntervalMin = gs.CleanupIntervalMin
 		cur.CleanupScope = gs.CleanupScope
@@ -296,12 +331,39 @@ func (s *ConfigStore) SaveGlobalSettings(gs models.SettingsGlobal) error {
 			return err
 		}
 	} else {
+		if patch != nil {
+			applyGlobalPatchOnInsert(&gs, patch)
+		}
 		if err := db.Create(&gs).Error; err != nil {
 			return err
 		}
 	}
 	events.Publish(events.Event{Type: events.ConfigChanged, Version: time.Now().UnixNano(), Source: "global", At: time.Now()})
 	return nil
+}
+
+// applyGlobalPatchOnInsert 在空 DB 首次保存（INSERT）时确保 4 个字段落合理默认：
+// patch 显式提供（含 0）→ 用之；否则 → 用 models 默认（retain=24/maxRetry=3/concurrency=3），
+// 避免 apiGlobal 漏传时把新行写成全 0（PA1）。
+func applyGlobalPatchOnInsert(gs *models.SettingsGlobal, patch *GlobalSettingsPatch) {
+	if patch.DefaultEnabled != nil {
+		gs.DefaultEnabled = *patch.DefaultEnabled
+	}
+	if patch.RetainHours != nil {
+		gs.RetainHours = *patch.RetainHours
+	} else {
+		gs.RetainHours = 24
+	}
+	if patch.MaxRetry != nil {
+		gs.MaxRetry = *patch.MaxRetry
+	} else {
+		gs.MaxRetry = 3
+	}
+	if patch.DefaultConcurrency != nil {
+		gs.DefaultConcurrency = *patch.DefaultConcurrency
+	} else {
+		gs.DefaultConcurrency = models.DefaultConcurrency
+	}
 }
 
 func (s *ConfigStore) SaveQbit(qb models.QbitSettings) error {

--- a/internal/maintenance/cleaner.go
+++ b/internal/maintenance/cleaner.go
@@ -6,6 +6,7 @@ package maintenance
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -53,11 +54,12 @@ type FileAction struct {
 
 // CategoryResult 汇总单个类别的清理结果。
 type CategoryResult struct {
-	Category   CleanCategory `json:"category"`
-	Deleted    []FileAction  `json:"deleted"` // DryRun 时为"将删除"项
-	FreedBytes int64         `json:"freedBytes"`
-	Skipped    []string      `json:"skipped"` // 命中红线/越界而被拒绝的路径（含原因）
-	Note       string        `json:"note"`    // 例如整类被拒绝的原因
+	Category     CleanCategory `json:"category"`
+	Deleted      []FileAction  `json:"deleted"` // DryRun 时为"将删除"项
+	FreedBytes   int64         `json:"freedBytes"`
+	DirUsedBytes int64         `json:"dirUsedBytes"` // 该类目录当前递归总占用（含不可删文件）
+	Skipped      []string      `json:"skipped"`      // 命中红线/越界而被拒绝的路径（含原因）
+	Note         string        `json:"note"`         // 例如整类被拒绝的原因
 }
 
 // CleanResult 汇总一次清理的全部结果。
@@ -142,6 +144,8 @@ func (c *Cleaner) cleanCategory(cat CleanCategory, resolvedHomeWork string, opts
 		return cr
 	}
 
+	cr.DirUsedBytes = dirTotalSize(resolvedRoot)
+
 	switch cat {
 	case CategoryLogs:
 		c.cleanLogs(resolvedRoot, opts.DryRun, cr)
@@ -174,19 +178,44 @@ func candidateInRoot(resolvedRoot, candidate string) (bool, string) {
 }
 
 // isRedLine 判定 basename 是否为硬编码红线文件（二次保险）。
+// 大小写不敏感（strings.EqualFold）：Windows FS 大小写不敏感，Torrents.DB / SECRET.KEY /
+// All.Log 等变体必须同样被拦截。
 func isRedLine(p string) bool {
-	switch filepath.Base(p) {
-	case models.DBFile, // torrents.db
+	base := filepath.Base(p)
+	for _, name := range []string{
+		models.DBFile, // torrents.db
 		models.DBFile + "-wal",
 		models.DBFile + "-shm",
 		"secret.key",
-		"all.log", "debug.log", "info.log", "error.log":
-		return true
+		"all.log", "debug.log", "info.log", "error.log",
+	} {
+		if strings.EqualFold(base, name) {
+			return true
+		}
 	}
 	return false
 }
 
+// dirTotalSize 递归累加 root 下所有普通文件的字节大小，用于报告该类目录当前总占用（E）。
+// 跨平台仅依赖 filepath.WalkDir + info.Size()，不做整盘 syscall；单文件 stat 错误忽略
+// （不影响清理与占用估算）。root 不存在返回 0。
+func dirTotalSize(root string) int64 {
+	var total int64
+	_ = filepath.WalkDir(root, func(_ string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if info, ierr := d.Info(); ierr == nil {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
 // withinRoot 报告 target 是否位于 root 之内（含 root 自身），基于 filepath.Rel。
+// 依赖 filepath.Rel + filepath.Separator 的平台相关语义，在 Windows 上同样成立；
+// Windows FS 大小写不敏感由 isRedLine 的 strings.EqualFold 覆盖。
 func withinRoot(root, target string) bool {
 	rel, err := filepath.Rel(root, target)
 	if err != nil {

--- a/internal/maintenance/cleaner_extra_test.go
+++ b/internal/maintenance/cleaner_extra_test.go
@@ -68,8 +68,9 @@ func TestCleaner_MissingCategoryRootSkipped(t *testing.T) {
 	assert.Empty(t, res.Categories, "根不存在应跳过，不产生结果")
 }
 
-// TestCleaner_StagingDisabledWhenRetainZero：RetainHours<=0 时 staging 清理禁用。
-func TestCleaner_StagingDisabledWhenRetainZero(t *testing.T) {
+// TestCleaner_StagingFallbackWhenRetainZero：RetainHours<=0 时手动清理改用兜底 24h 而非禁用，
+// 孤立种子（与 mtime 无关）仍应被删，Note 提示使用默认保留期。
+func TestCleaner_StagingFallbackWhenRetainZero(t *testing.T) {
 	home, db := setupCleanerHome(t)
 	require.NoError(t, core.NewConfigStore(db).SaveGlobalSettings(models.SettingsGlobal{
 		DownloadDir: t.TempDir(), RetainHours: 24, MaxRetry: 3,
@@ -81,8 +82,8 @@ func TestCleaner_StagingDisabledWhenRetainZero(t *testing.T) {
 	res, err := c.Clean(context.Background(), CleanOptions{Categories: []CleanCategory{CategoryStaging}})
 	require.NoError(t, err)
 	require.Len(t, res.Categories, 1)
-	assert.NotEmpty(t, res.Categories[0].Note)
-	assert.FileExists(t, orphanPath, "禁用时不删")
+	assert.Contains(t, res.Categories[0].Note, "默认保留期")
+	assert.NoFileExists(t, orphanPath, "retain<=0 兜底后孤立种子仍应删")
 }
 
 // TestCleaner_DeleteFailureRecorded：删除失败（候选是目录）记录到 Skipped。

--- a/internal/maintenance/dir_usage_test.go
+++ b/internal/maintenance/dir_usage_test.go
@@ -1,0 +1,119 @@
+// MIT License
+// Copyright (c) 2025 pt-tools
+
+package maintenance
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sunerpy/pt-tools/models"
+)
+
+// TE1：每个类别应报告其目录当前总占用 DirUsedBytes（含不可删的 base 文件），
+// 与 FreedBytes（仅已删）区分。logs / backups 均验证；dry-run 也应返回。
+func TestCleaner_ReportsDirUsedBytes(t *testing.T) {
+	home, db := setupCleanerHome(t)
+	logs := filepath.Join(home, models.WorkDir, "logs")
+	backups := filepath.Join(home, models.WorkDir, "backups")
+
+	base := filepath.Join(logs, "all.log")
+	require.NoError(t, os.WriteFile(base, make([]byte, 100), 0o644)) // 不可删 base：100B
+	oldBackup := filepath.Join(logs, "all-2020-01-01T00-00-00.000.log.gz")
+	require.NoError(t, os.WriteFile(oldBackup, make([]byte, 50), 0o644)) // 可删备份：50B
+	ancient := time.Now().Add(-400 * 24 * time.Hour)
+	require.NoError(t, os.Chtimes(oldBackup, ancient, ancient))
+
+	// backups：3 份各 30B，keep=5 → 均保留、freed=0，但 dir 占用应为 90B。
+	for _, n := range []string{"a", "b", "c"} {
+		require.NoError(t, os.WriteFile(filepath.Join(backups, "backup-"+n+".json"), make([]byte, 30), 0o644))
+	}
+
+	c := NewCleaner(home, db, defaultZap())
+
+	dry, err := c.Clean(context.Background(), CleanOptions{
+		Categories: []CleanCategory{CategoryLogs, CategoryBackups}, DryRun: true,
+	})
+	require.NoError(t, err)
+	dryLogs := findCategory(t, dry, CategoryLogs)
+	assert.Equal(t, int64(150), dryLogs.DirUsedBytes, "dry-run logs 目录占用应含 base+备份=150")
+
+	res, err := c.Clean(context.Background(), CleanOptions{
+		Categories: []CleanCategory{CategoryLogs, CategoryBackups}, DryRun: false,
+	})
+	require.NoError(t, err)
+
+	logsCat := findCategory(t, res, CategoryLogs)
+	assert.Equal(t, int64(150), logsCat.DirUsedBytes, "logs 目录总占用含不可删 base")
+	assert.Equal(t, int64(50), logsCat.FreedBytes, "freed 仅计已删备份")
+
+	backupsCat := findCategory(t, res, CategoryBackups)
+	assert.Equal(t, int64(90), backupsCat.DirUsedBytes, "backups 目录总占用 3*30")
+	assert.Equal(t, int64(0), backupsCat.FreedBytes, "keep=5 未删任何备份")
+}
+
+func findCategory(t *testing.T, res *CleanResult, cat CleanCategory) CategoryResult {
+	t.Helper()
+	for _, cr := range res.Categories {
+		if cr.Category == cat {
+			return cr
+		}
+	}
+	t.Fatalf("类别 %s 未出现在结果中", cat)
+	return CategoryResult{}
+}
+
+// TF1：红线判定必须大小写不敏感（Windows FS 大小写不敏感）。
+func TestIsRedLine_CaseInsensitive(t *testing.T) {
+	trueCases := []string{
+		"Torrents.DB", "TORRENTS.DB", "torrents.db",
+		"TORRENTS.DB-WAL", "Torrents.DB-Shm",
+		"SECRET.KEY", "Secret.Key",
+		"All.Log", "DEBUG.LOG", "Info.Log", "ERROR.LOG",
+	}
+	for _, p := range trueCases {
+		assert.True(t, isRedLine(p), "%s 应命中红线（大小写不敏感）", p)
+		assert.True(t, isRedLine(filepath.Join("/some/dir", p)), "%s 带路径也应命中", p)
+	}
+	falseCases := []string{
+		"all-2020-01-01T00-00-00.000.log.gz",
+		"backup-a.json",
+		"springsunday-x.torrent",
+	}
+	for _, p := range falseCases {
+		assert.False(t, isRedLine(p), "%s 不应命中红线", p)
+	}
+}
+
+// TF2：单个候选 os.Remove 失败时记录到 Skipped、不 panic、不中断其余候选删除。
+// 构造第一个候选为非空目录（os.Remove 拒绝），第二个为可删文件。
+func TestApplyDelete_RemoveFailureSkippedNotAbort(t *testing.T) {
+	home, db := setupCleanerHome(t)
+	logs := filepath.Join(home, models.WorkDir, "logs")
+
+	badDir := filepath.Join(logs, "all-2020-01-01T00-00-00.000.log.gz")
+	require.NoError(t, os.MkdirAll(filepath.Join(badDir, "child"), 0o755)) // 非空目录 → os.Remove 失败
+	goodFile := filepath.Join(logs, "all-2021-02-02T00-00-00.000.log.gz")
+	require.NoError(t, os.WriteFile(goodFile, make([]byte, 42), 0o644))
+
+	c := NewCleaner(home, db, defaultZap())
+	resolvedRoot, err := evalSymlinksExisting(logs)
+	require.NoError(t, err)
+
+	cr := &CategoryResult{Category: CategoryLogs}
+	assert.NotPanics(t, func() {
+		c.applyDelete(resolvedRoot, badDir, "fail-candidate", false, cr)
+		c.applyDelete(resolvedRoot, goodFile, "ok-candidate", false, cr)
+	})
+
+	assert.NotEmpty(t, cr.Skipped, "删除失败候选应记入 Skipped")
+	assert.True(t, containsPath(cr.Deleted, goodFile), "其余候选仍应被删除")
+	assert.Equal(t, int64(42), cr.FreedBytes, "FreedBytes 仅计成功删除的候选")
+	assert.NoFileExists(t, goodFile)
+}

--- a/internal/maintenance/staging_clean.go
+++ b/internal/maintenance/staging_clean.go
@@ -18,13 +18,19 @@ import (
 // 扫描根固定为 ~/.pt-tools/downloads（白名单内），绝不读取 DownloadDir 配置——
 // 若用户把 DownloadDir 配成 .pt-tools 之外的绝对路径，本特性一律不碰那个目录（§2.4）。
 //
+// defaultStagingRetainHours 是手动清理（特性 D）在 RetainHours<=0（未配置/被清零）时
+// 使用的兜底保留期。手动清理是用户明确意图，不应被"自动清理阈值"整类卡死。
+const defaultStagingRetainHours = 24
+
 // 判定复用 shouldSweepAnySite（与 #450 shouldSweep 相同规则，但按 hash 跨站点查 DB）。
-// RetainHours/MaxRetry 从 ConfigStore 读取；RetainHours<=0 时禁用 staging 清理（保持旧语义）。
+// RetainHours/MaxRetry 从 ConfigStore 读取；RetainHours<=0 时改用兜底 24h 继续清理（孤立/
+// 已推送/达最大重试与 mtime 无关，仍应清；超期未推送用兜底判定），而非整类禁用。
+// 注意：#450 的 internal.sweepStagingDir（RSS 自动 sweep）保持 retain<=0 → 禁用的旧语义不变。
 func (c *Cleaner) cleanStaging(resolvedRoot string, dryRun bool, cr *CategoryResult) {
 	retainHours, maxRetry := c.stagingRetention()
 	if retainHours <= 0 {
-		cr.Note = "staging 清理已禁用（RetainHours<=0）"
-		return
+		retainHours = defaultStagingRetainHours
+		cr.Note = "使用默认保留期 24h（未配置 RetainHours）"
 	}
 	for _, file := range collectTorrentFiles(resolvedRoot) {
 		if !shouldSweepAnySite(c.db, file, retainHours, maxRetry) {

--- a/internal/maintenance/staging_clean_fallback_test.go
+++ b/internal/maintenance/staging_clean_fallback_test.go
@@ -1,0 +1,64 @@
+// MIT License
+// Copyright (c) 2025 pt-tools
+
+package maintenance
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sunerpy/pt-tools/core"
+	"github.com/sunerpy/pt-tools/models"
+)
+
+// TB1：RetainHours<=0 时，手动清理（特性 D）不再整类禁用，而是用兜底保留期 24h 继续清理。
+//   - 孤立 / 已推送 与 mtime 无关 → 仍应删除
+//   - 超兜底保留期（>24h）未推送 → 用 24h 兜底判定后删除
+//   - 新鲜（<24h）未推送 → 保留
+//   - Note 提示使用默认保留期，而非"已禁用"
+func TestCleanStaging_FallbackWhenRetainZero(t *testing.T) {
+	home, db := setupCleanerHome(t)
+	// RetainHours=0（禁用自动 sweep 的合法值），MaxRetry=3。
+	require.NoError(t, core.NewConfigStore(db).SaveGlobalSettings(models.SettingsGlobal{
+		DownloadDir: t.TempDir(), RetainHours: 24, MaxRetry: 3,
+	}))
+	// GORM 的 default:24 会在 INSERT 零值时写 24，故显式 UPDATE 成 0 模拟被清零的脏数据。
+	require.NoError(t, db.DB.Model(&models.SettingsGlobal{}).Where("1 = 1").Update("retain_hours", 0).Error)
+	tag := filepath.Join(home, models.WorkDir, "downloads", "mytag")
+	require.NoError(t, os.MkdirAll(tag, 0o755))
+
+	pushedPath, pushedHash := writeTorrent(t, tag, "springsunday-pushed.torrent", "pushed-z")
+	seedTorrent(t, db, pushedHash, true, 0) // 已推送 → 删（与 mtime 无关）
+
+	orphanPath, _ := writeTorrent(t, tag, "springsunday-orphan.torrent", "orphan-z") // 无 DB → 删
+
+	agedPath, agedHash := writeTorrent(t, tag, "springsunday-aged.torrent", "aged-z")
+	seedTorrent(t, db, agedHash, false, 0)
+	old := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(agedPath, old, old)) // 超兜底 24h 未推送 → 删
+
+	freshPath, freshHash := writeTorrent(t, tag, "springsunday-fresh.torrent", "fresh-z")
+	seedTorrent(t, db, freshHash, false, 0) // 新鲜未推送 → 保留
+
+	c := NewCleaner(home, db, defaultZap())
+	res, err := c.Clean(context.Background(), CleanOptions{Categories: []CleanCategory{CategoryStaging}, DryRun: false})
+	require.NoError(t, err)
+
+	assert.NoFileExists(t, pushedPath, "已推送应删（retain=0 也不禁用）")
+	assert.NoFileExists(t, orphanPath, "孤立应删（retain=0 也不禁用）")
+	assert.NoFileExists(t, agedPath, "超兜底保留期未推送应删")
+	assert.FileExists(t, freshPath, "新鲜未推送应保留")
+
+	require.Len(t, res.Categories, 1)
+	note := res.Categories[0].Note
+	assert.NotContains(t, note, "已禁用", "retain<=0 不应再显示已禁用")
+	assert.Contains(t, note, "默认保留期", "应提示使用默认兜底保留期")
+	_ = strings.TrimSpace(note)
+}

--- a/web/api_global_retain_test.go
+++ b/web/api_global_retain_test.go
@@ -1,0 +1,156 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sunerpy/pt-tools/global"
+	"github.com/sunerpy/pt-tools/models"
+)
+
+// postGlobal 向 apiGlobal 发送 POST，body 为给定 map（缺失字段模拟旧前端/omitted）。
+func postGlobal(t *testing.T, srv *Server, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/global", bytes.NewReader(raw))
+	srv.apiGlobal(w, req)
+	return w
+}
+
+// TA1：POST 漏传 4 个字段（default_enabled/retain_hours/max_retry/default_concurrency）
+// 时，不得将 DB 中已有的值清零。这是核心回归用例。
+func TestAPIGlobal_OmittedFieldsNotClobbered(t *testing.T) {
+	srv := setupServer(t)
+	// 先写入已有配置：RetainHours=24 / MaxRetry=3 / DefaultConcurrency=3 / DefaultEnabled=true
+	require.NoError(t, srv.store.SaveGlobalSettings(models.SettingsGlobal{
+		DownloadDir:        t.TempDir(),
+		RetainHours:        24,
+		MaxRetry:           3,
+		DefaultConcurrency: 3,
+		DefaultEnabled:     true,
+	}))
+
+	// POST body 完全不含这 4 个字段（模拟旧前端）。
+	w := postGlobal(t, srv, map[string]any{
+		"default_interval_minutes": 20,
+		"download_dir":             t.TempDir(),
+		"torrent_size_gb":          200,
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	got, err := srv.store.GetGlobalSettings()
+	require.NoError(t, err)
+	assert.Equal(t, 24, got.RetainHours, "RetainHours 不应被清零")
+	assert.Equal(t, 3, got.MaxRetry, "MaxRetry 不应被清零")
+	assert.Equal(t, int32(3), got.DefaultConcurrency, "DefaultConcurrency 不应被清零")
+	assert.True(t, got.DefaultEnabled, "DefaultEnabled 不应被清零")
+}
+
+// TA2：显式提供的值应正确写入。
+func TestAPIGlobal_ExplicitValuesApplied(t *testing.T) {
+	srv := setupServer(t)
+	require.NoError(t, srv.store.SaveGlobalSettings(models.SettingsGlobal{
+		DownloadDir:        t.TempDir(),
+		RetainHours:        24,
+		MaxRetry:           3,
+		DefaultConcurrency: 3,
+		DefaultEnabled:     true,
+	}))
+
+	w := postGlobal(t, srv, map[string]any{
+		"default_interval_minutes": 20,
+		"download_dir":             t.TempDir(),
+		"retain_hours":             48,
+		"max_retry":                5,
+		"default_concurrency":      4,
+		"default_enabled":          false,
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	got, err := srv.store.GetGlobalSettings()
+	require.NoError(t, err)
+	assert.Equal(t, 48, got.RetainHours)
+	assert.Equal(t, 5, got.MaxRetry)
+	assert.Equal(t, int32(4), got.DefaultConcurrency)
+	assert.False(t, got.DefaultEnabled)
+}
+
+// TA3：显式 0 必须被保留（指针能区分 omitted 与 explicit-0）。
+// RetainHours=0 = 禁用自动 sweep，MaxRetry=0 = 不按重试删除，均为合法值。
+func TestAPIGlobal_ExplicitZeroPreserved(t *testing.T) {
+	srv := setupServer(t)
+	require.NoError(t, srv.store.SaveGlobalSettings(models.SettingsGlobal{
+		DownloadDir:        t.TempDir(),
+		RetainHours:        24,
+		MaxRetry:           3,
+		DefaultConcurrency: 3,
+	}))
+
+	w := postGlobal(t, srv, map[string]any{
+		"default_interval_minutes": 20,
+		"download_dir":             t.TempDir(),
+		"retain_hours":             0,
+		"max_retry":                0,
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	got, err := srv.store.GetGlobalSettings()
+	require.NoError(t, err)
+	assert.Equal(t, 0, got.RetainHours, "显式 retain_hours=0 应被保留")
+	assert.Equal(t, 0, got.MaxRetry, "显式 max_retry=0 应被保留")
+	// 未传的 default_concurrency 保持原值
+	assert.Equal(t, int32(3), got.DefaultConcurrency)
+}
+
+// TA4：空 DB 首次保存时，漏传的 4 字段应落合理默认（retain=24/maxRetry=3/concurrency=3）。
+func TestAPIGlobal_EmptyDBFirstSaveDefaults(t *testing.T) {
+	srv := setupServer(t)
+	// 清空全局设置行，模拟真正的空 DB 首保存。
+	require.NoError(t, global.GlobalDB.DB.Where("1 = 1").Delete(&models.SettingsGlobal{}).Error)
+
+	w := postGlobal(t, srv, map[string]any{
+		"default_interval_minutes": 20,
+		"download_dir":             t.TempDir(),
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	got, err := srv.store.GetGlobalSettings()
+	require.NoError(t, err)
+	assert.Equal(t, 24, got.RetainHours)
+	assert.Equal(t, 3, got.MaxRetry)
+	assert.Equal(t, int32(3), got.DefaultConcurrency)
+}
+
+// TC1：retain_hours/max_retry/default_concurrency 保存后可 round-trip（GET 返回相同值）。
+func TestAPIGlobal_RetainRoundTrip(t *testing.T) {
+	srv := setupServer(t)
+	require.NoError(t, srv.store.SaveGlobalSettings(models.SettingsGlobal{DownloadDir: t.TempDir()}))
+
+	w := postGlobal(t, srv, map[string]any{
+		"default_interval_minutes": 20,
+		"download_dir":             t.TempDir(),
+		"retain_hours":             36,
+		"max_retry":                5,
+		"default_concurrency":      4,
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	getW := httptest.NewRecorder()
+	getReq := httptest.NewRequest(http.MethodGet, "/api/global", nil)
+	srv.apiGlobal(getW, getReq)
+	require.Equal(t, http.StatusOK, getW.Code)
+
+	var resp models.SettingsGlobal
+	require.NoError(t, json.Unmarshal(getW.Body.Bytes(), &resp))
+	assert.Equal(t, 36, resp.RetainHours)
+	assert.Equal(t, 5, resp.MaxRetry)
+	assert.Equal(t, int32(4), resp.DefaultConcurrency)
+}

--- a/web/api_maintenance.go
+++ b/web/api_maintenance.go
@@ -27,6 +27,8 @@ type cleanCategoryDTO struct {
 	DeletedCount int    `json:"deletedCount"`
 	FreedBytes   int64  `json:"freedBytes"`
 	FreedHuman   string `json:"freedHuman"`
+	DirUsedBytes int64  `json:"dirUsedBytes"`
+	DirUsedHuman string `json:"dirUsedHuman"`
 	SkippedCount int    `json:"skippedCount"`
 	Note         string `json:"note,omitempty"`
 }
@@ -94,6 +96,8 @@ func toCleanResultDTO(res *maintenance.CleanResult) cleanResultDTO {
 			DeletedCount: len(cr.Deleted),
 			FreedBytes:   cr.FreedBytes,
 			FreedHuman:   humanBytes(cr.FreedBytes),
+			DirUsedBytes: cr.DirUsedBytes,
+			DirUsedHuman: humanBytes(cr.DirUsedBytes),
 			SkippedCount: len(cr.Skipped),
 			Note:         cr.Note,
 		})

--- a/web/frontend/src/api/index.ts
+++ b/web/frontend/src/api/index.ts
@@ -1486,6 +1486,8 @@ export interface CleanCategoryResult {
   deletedCount: number;
   freedBytes: number;
   freedHuman: string;
+  dirUsedBytes: number;
+  dirUsedHuman: string;
   skippedCount: number;
   note?: string;
 }

--- a/web/frontend/src/api/index.ts
+++ b/web/frontend/src/api/index.ts
@@ -66,6 +66,10 @@ export interface GlobalSettings {
   torrent_size_gb: number;
   min_free_minutes: number;
   auto_start: boolean;
+  retain_hours: number;
+  max_retry: number;
+  default_concurrency: number;
+  default_enabled: boolean;
   cleanup_enabled?: boolean;
   cleanup_interval_min?: number;
   cleanup_scope?: string;

--- a/web/frontend/src/views/AutoCleanup.vue
+++ b/web/frontend/src/views/AutoCleanup.vue
@@ -251,10 +251,14 @@ async function executeClean() {
       dryRun: false,
       keepBackups: keepBackups.value,
     });
-    cleanPreview.value = null;
     ElMessage.success(
       `清理完成，共删除 ${cleanResult.value.totalDeleted} 项，释放 ${cleanResult.value.totalFreedHuman}`,
     );
+    try {
+      cleanPreview.value = await maintenanceApi.preview();
+    } catch {
+      cleanPreview.value = null;
+    }
   } catch (e: unknown) {
     ElMessage.error((e as Error).message || "清理失败");
   } finally {
@@ -663,6 +667,7 @@ async function executeClean() {
         <el-table-column label="清理项" min-width="120">
           <template #default="{ row }">{{ categoryLabel(row.name) }}</template>
         </el-table-column>
+        <el-table-column prop="dirUsedHuman" label="当前已用空间" width="120" align="center" />
         <el-table-column prop="deletedCount" label="可删除数量" width="110" align="center" />
         <el-table-column prop="freedHuman" label="可释放空间" width="120" align="center" />
         <el-table-column label="状态" min-width="160">
@@ -690,6 +695,7 @@ async function executeClean() {
           <el-table-column label="清理项" min-width="120">
             <template #default="{ row }">{{ categoryLabel(row.name) }}</template>
           </el-table-column>
+          <el-table-column prop="dirUsedHuman" label="当前已用空间" width="120" align="center" />
           <el-table-column prop="deletedCount" label="已删除" width="90" align="center" />
           <el-table-column prop="freedHuman" label="释放空间" width="120" align="center" />
           <el-table-column label="状态" min-width="160">

--- a/web/frontend/src/views/GlobalSettings.vue
+++ b/web/frontend/src/views/GlobalSettings.vue
@@ -16,6 +16,10 @@ const form = ref<GlobalSettings>({
   torrent_size_gb: 200,
   min_free_minutes: 30,
   auto_start: false,
+  retain_hours: 24,
+  max_retry: 3,
+  default_concurrency: 3,
+  default_enabled: false,
   auto_delete_on_free_end: false,
   free_end_advance_minutes: 0,
   default_filter_mode: "auto_free",
@@ -234,6 +238,40 @@ async function save() {
                   :step="5"
                   class="w-full" />
                 <div class="form-tip">免费剩余时间少于此值的种子将被跳过，0 表示不限制</div>
+              </el-form-item>
+            </el-col>
+          </el-row>
+        </div>
+
+        <!-- 种子文件保留 / 暂存种子清理 -->
+        <div class="form-section settings-section">
+          <div class="form-section-title">
+            <el-icon><Folder /></el-icon>
+            种子文件保留 / 暂存种子清理
+          </div>
+          <el-row :gutter="40">
+            <el-col :md="12" :sm="24">
+              <el-form-item label="暂存种子保留时长(小时)">
+                <el-input-number
+                  v-model="form.retain_hours"
+                  :min="0"
+                  :max="8760"
+                  :step="1"
+                  class="w-full" />
+                <div class="form-tip">
+                  暂存种子文件保留时长(小时)；超期未推送将被自动清理。0 = 关闭自动清理
+                </div>
+              </el-form-item>
+            </el-col>
+            <el-col :md="12" :sm="24">
+              <el-form-item label="最大重试次数">
+                <el-input-number
+                  v-model="form.max_retry"
+                  :min="0"
+                  :max="100"
+                  :step="1"
+                  class="w-full" />
+                <div class="form-tip">推送失败达到此次数后清理暂存种子；0 = 不按重试次数删除</div>
               </el-form-item>
             </el-col>
           </el-row>

--- a/web/server.go
+++ b/web/server.go
@@ -518,6 +518,10 @@ func (s *Server) apiGlobal(w http.ResponseWriter, r *http.Request) {
 			PeerRatioIntervalMin   int     `json:"peer_ratio_interval_min"`
 			PeerRatioRemoveData    bool    `json:"peer_ratio_remove_data"`
 			DefaultFilterMode      string  `json:"default_filter_mode"`
+			DefaultEnabled         *bool   `json:"default_enabled"`
+			RetainHours            *int    `json:"retain_hours"`
+			MaxRetry               *int    `json:"max_retry"`
+			DefaultConcurrency     *int32  `json:"default_concurrency"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -568,7 +572,13 @@ func (s *Server) apiGlobal(w http.ResponseWriter, r *http.Request) {
 			PeerRatioRemoveData:    req.PeerRatioRemoveData,
 			DefaultFilterMode:      models.NormalizeFilterMode(models.FilterMode(req.DefaultFilterMode)),
 		}
-		if err := s.store.SaveGlobalSettings(gs); err != nil {
+		patch := &core.GlobalSettingsPatch{
+			DefaultEnabled:     req.DefaultEnabled,
+			RetainHours:        req.RetainHours,
+			MaxRetry:           req.MaxRetry,
+			DefaultConcurrency: req.DefaultConcurrency,
+		}
+		if err := s.store.SaveGlobalSettingsWithPatch(gs, patch); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}


### PR DESCRIPTION
## Summary
- 修复保存全局设置时误将 `RetainHours`/`MaxRetry`/`DefaultConcurrency`/`DefaultEnabled` 清零导致「清理工作目录」被禁用的问题
- 清理工作目录界面增加「当前已用空间」列，清理后自动刷新预览
- 手动清理补充 24h 默认回退，兼容 Windows 大小写不敏感红线判断

## Changes
### 1. 保存全局设置不再清零关键字段（根因修复）
- `apiGlobal` 改为指针补丁式更新，仅覆盖请求中显式传入的字段，避免把 `RetainHours` 等清零为 0（这是「清理已禁用」的根因）
- 全局设置 UI 暴露 `retain_hours` / `max_retry` 配置项

### 2. 手动清理 24h 回退
- 手动触发清理时若未配置 `RetainHours` 使用 24 小时默认值兜底

### 3. 当前已用空间展示 + 清理后刷新 + Windows 兼容
- 清理工作目录列表新增「当前已用空间」列
- 清理完成后自动刷新预览数据
- Windows 路径按大小写不敏感匹配红线目录

用户本地已验证：清理功能恢复正常，已用空间列正确展示，清理后预览即时刷新。