### PR TITLE
fix(site): 修复 M-Team 商城免费活动已结束仍判定为免费

### DIFF
--- a/site/v2/mtorrent_driver.go
+++ b/site/v2/mtorrent_driver.go
@@ -189,6 +189,7 @@ type MTorrentPromotionRule struct {
 
 // MallSingleFree represents a mall single free from M-Team API
 type MallSingleFree struct {
+	Status    string `json:"status,omitempty"`
 	StartDate string `json:"startDate,omitempty"`
 	EndDate   string `json:"endDate,omitempty"`
 }
@@ -762,7 +763,7 @@ func parseMTorrentDiscountWithPromotionAndMallSingleFreeAt(baseDiscount, baseEnd
 				return promoLevel, promoEnd
 			}
 		}
-	} else if mallSingleFree != nil && mallSingleFree.StartDate != "" && mallSingleFree.EndDate != "" {
+	} else if mallSingleFree != nil && mallSingleFree.Status == "ONGOING" && mallSingleFree.StartDate != "" && mallSingleFree.EndDate != "" {
 		var singleFreeStart, singleFreeEnd time.Time
 		singleFreeStart, _ = ParseTimeInCST("2006-01-02 15:04:05", mallSingleFree.StartDate)
 		singleFreeEnd, _ = ParseTimeInCST("2006-01-02 15:04:05", mallSingleFree.EndDate)

--- a/site/v2/mtorrent_driver_test.go
+++ b/site/v2/mtorrent_driver_test.go
@@ -171,6 +171,44 @@ func TestMTorrentDriver_ParseSearch(t *testing.T) {
 	assert.Equal(t, "电影/SD", items[0].Category) // Should be mapped from 401
 }
 
+func TestMTorrentDriver_ParseSearch_MallSingleFreeRequiresOngoingStatus(t *testing.T) {
+	driver := NewMTorrentDriver(MTorrentDriverConfig{
+		BaseURL: "https://api.m-team.cc",
+		APIKey:  "test-api-key",
+	})
+
+	res := MTorrentResponse{
+		Code:    "0",
+		Message: "success",
+		Data: []byte(`{
+			"data": [{
+				"id": "1211993",
+				"name": "Hell 2025",
+				"size": "22967359242",
+				"status": {
+					"seeders": 53,
+					"leechers": 3,
+					"timesCompleted": 1,
+					"discount": "PERCENT_50",
+					"discountEndTime": "2026-07-21 05:26:41",
+					"mallSingleFree": {
+						"status": "ENDED",
+						"startDate": "2000-01-01 00:00:00",
+						"endDate": "2099-12-31 23:59:59"
+					}
+				},
+				"category": "401"
+			}],
+			"total": 1
+		}`),
+	}
+
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, DiscountPercent50, items[0].DiscountLevel)
+}
+
 func TestMTorrentDriver_ParseSearch_APIError(t *testing.T) {
 	driver := NewMTorrentDriver(MTorrentDriverConfig{
 		BaseURL: "https://api.m-team.cc",
@@ -383,6 +421,7 @@ func TestParseMTorrentDiscountWithMallSingleFree(t *testing.T) {
 			baseEndTime:  "2026-02-05 19:57:34",
 			promotion:    nil,
 			mallSingle: &MallSingleFree{
+				Status:    "ONGOING",
 				StartDate: "2026-02-03 00:00:00",
 				EndDate:   "2026-02-05 23:59:59",
 			},
@@ -395,6 +434,7 @@ func TestParseMTorrentDiscountWithMallSingleFree(t *testing.T) {
 			baseEndTime:  "2026-02-05 19:57:34",
 			promotion:    nil,
 			mallSingle: &MallSingleFree{
+				Status:    "ONGOING",
 				StartDate: "2026-02-06 00:00:00",
 				EndDate:   "2026-02-07 00:00:00",
 			},
@@ -411,6 +451,7 @@ func TestParseMTorrentDiscountWithMallSingleFree(t *testing.T) {
 				EndTime:   "2026-02-05 22:22:22",
 			},
 			mallSingle: &MallSingleFree{
+				Status:    "ONGOING",
 				StartDate: "2026-02-03 00:00:00",
 				EndDate:   "2026-02-05 23:59:59",
 			},


### PR DESCRIPTION
## Summary

- 修复 M-Team 站点将已结束的商城单种免费活动误判为免费，导致实际按 50% 计费产生下载量的问题

## 问题背景

用户反馈某 M-Team 种子在 pt-tools 中显示为「免费」，但站点实际标记为 50%，并产生了约 7.72GB 计费下载量。

现场取证确认：

- pt-tools 记录 `free_level=FREE`、`free_end_time=2026-07-21 05:26:41`
- 站点实际优惠为 `PERCENT_50`
- 种子在免费结束监控触发前已下载完成，排除监控器原因
- 时间戳全部为 `+08:00`，排除时区问题

## 根因

`MallSingleFree` 结构体只解析了 `startDate` / `endDate`，未解析 API 返回的 `status` 字段。

解析逻辑仅凭「当前时间落在活动区间内」就把基础优惠覆盖为 `FREE`。而 M-Team 的商城单种免费活动在 `status` 为 `ENDED` 时，`startDate` / `endDate` 仍可能是一个包含当前时间的宽区间，于是已结束的活动被错误应用。

## Changes

- `MallSingleFree` 增加 `Status` 字段
- 覆盖条件增加 `Status == "ONGOING"` 门禁，仅进行中的活动才覆盖基础优惠
- 新增回归测试：`status=ENDED` 时保留基础 `PERCENT_50`

行为影响范围：

| API 状态 | 结果 |
|---|---|
| `discount=FREE`，`mallSingleFree=null` | `FREE`（不变）|
| `discount=PERCENT_50`，`mallSingleFree.status=ONGOING` | `FREE`（不变）|
| `discount=PERCENT_50`，`mallSingleFree.status=ENDED` | `PERCENT_50`（修复）|

## Verification

- 新增回归测试在修复前稳定失败，修复后通过
- `go test ./site/v2 -count=1` 通过
- 目标测试 `-race` 通过
- `go build ./...` 通过
- `make lint-go` 0 issues