### PR TITLE
feat(extension): 修复 div 布局采集并新增 bilibili.download 支持

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,10 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm build
 
+      - name: Run extension tests
+        working-directory: tools/browser-extension
+        run: pnpm test
+
   ci-success:
     name: CI Success
     needs: [frontend-build, go-build-test, go-lint, go-security, format-check, extension-build]

--- a/tools/browser-extension/package.json
+++ b/tools/browser-extension/package.json
@@ -9,6 +9,7 @@
     "build": "vite build",
     "pack": "node --experimental-strip-types ../../scripts/check-sites.ts && vite build && cd dist && zip -r ../pt-tools-helper.zip .",
     "typecheck": "vue-tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf dist pt-tools-helper.zip"
   },
   "dependencies": {
@@ -17,9 +18,11 @@
   },
   "devDependencies": {
     "@types/chrome": "^0.1.31",
+    "@types/node": "^25.9.5",
     "@vitejs/plugin-vue": "^6.0.1",
     "typescript": "~5.9.3",
     "vite": "^7.1.12",
+    "vitest": "^4.1.10",
     "vue-tsc": "^3.1.1"
   },
   "packageManager": "pnpm@10.25.0"

--- a/tools/browser-extension/pnpm-lock.yaml
+++ b/tools/browser-extension/pnpm-lock.yaml
@@ -18,15 +18,21 @@ importers:
       '@types/chrome':
         specifier: ^0.1.31
         version: 0.1.36
+      '@types/node':
+        specifier: ^25.9.5
+        version: 25.9.5
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.4(vite@7.3.1)(vue@3.5.28(typescript@5.9.3))
+        version: 6.0.4(vite@7.3.1(@types/node@25.9.5))(vue@3.5.28(typescript@5.9.3))
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
       vite:
         specifier: ^7.1.12
-        version: 7.3.1
+        version: 7.3.1(@types/node@25.9.5)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.9.5)(vite@7.3.1(@types/node@25.9.5))
       vue-tsc:
         specifier: ^3.1.1
         version: 3.2.4(typescript@5.9.3)
@@ -350,8 +356,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/chrome@0.1.36':
     resolution: {integrity: sha512-BvHbuyGttYXnGt5Gpwa4769KIinKHY1iLjlAPrrMBS2GI9m/XNMPtdsq0NgQalyuUdxvlMN/0OyGw0shFVIoUQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -365,12 +380,44 @@ packages:
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
+  '@types/node@25.9.5':
+    resolution: {integrity: sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==}
+
   '@vitejs/plugin-vue@6.0.4':
     resolution: {integrity: sha512-uM5iXipgYIn13UUQCZNdWkYk+sysBeA97d5mHsAoAt1u/wpN3+zxOmsVJWosuzX+IMGRzeYUNytztrYznboIkQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
       vue: ^3.2.25
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@volar/language-core@2.4.27':
     resolution: {integrity: sha512-DjmjBWZ4tJKxfNC1F6HyYERNHPYS7L7OPFyCrestykNdUZMFYzI9WTyvwPcaNaHlrEUwESHYsfEw3isInncZxQ==}
@@ -416,6 +463,17 @@ packages:
   alien-signals@3.1.2:
     resolution: {integrity: sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -426,6 +484,9 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
@@ -433,6 +494,13 @@ packages:
 
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -474,11 +542,18 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -508,21 +583,44 @@ packages:
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -567,6 +665,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
@@ -583,6 +722,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
 snapshots:
 
@@ -756,10 +900,19 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/chrome@0.1.36':
     dependencies:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -771,11 +924,56 @@ snapshots:
 
   '@types/har-format@1.2.16': {}
 
-  '@vitejs/plugin-vue@6.0.4(vite@7.3.1)(vue@3.5.28(typescript@5.9.3))':
+  '@types/node@25.9.5':
+    dependencies:
+      undici-types: 7.24.6
+
+  '@vitejs/plugin-vue@6.0.4(vite@7.3.1(@types/node@25.9.5))(vue@3.5.28(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.2
-      vite: 7.3.1
+      vite: 7.3.1(@types/node@25.9.5)
       vue: 3.5.28(typescript@5.9.3)
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@7.3.1(@types/node@25.9.5))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.9.5)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@volar/language-core@2.4.27':
     dependencies:
@@ -855,11 +1053,19 @@ snapshots:
 
   alien-signals@3.1.2: {}
 
+  assertion-error@2.0.1: {}
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
   core-util-is@1.0.3: {}
 
   csstype@3.2.3: {}
 
   entities@7.0.1: {}
+
+  es-module-lexer@2.3.1: {}
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -891,6 +1097,12 @@ snapshots:
       '@esbuild/win32-x64': 0.27.3
 
   estree-walker@2.0.2: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.4.0: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -924,9 +1136,13 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  obug@2.1.4: {}
+
   pako@1.0.11: {}
 
   path-browserify@1.0.1: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -985,22 +1201,36 @@ snapshots:
 
   setimmediate@1.0.5: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyrainbow@3.1.0: {}
+
   typescript@5.9.3: {}
+
+  undici-types@7.24.6: {}
 
   util-deprecate@1.0.2: {}
 
-  vite@7.3.1:
+  vite@7.3.1(@types/node@25.9.5):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -1009,7 +1239,35 @@ snapshots:
       rollup: 4.57.1
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 25.9.5
       fsevents: 2.3.3
+
+  vitest@4.1.10(@types/node@25.9.5)(vite@7.3.1(@types/node@25.9.5)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.1(@types/node@25.9.5))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(@types/node@25.9.5)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.5
+    transitivePeerDependencies:
+      - msw
 
   vscode-uri@3.1.0: {}
 
@@ -1028,3 +1286,8 @@ snapshots:
       '@vue/shared': 3.5.28
     optionalDependencies:
       typescript: 5.9.3
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/tools/browser-extension/src/core/pt-sites.ts
+++ b/tools/browser-extension/src/core/pt-sites.ts
@@ -14,6 +14,7 @@ const NEXUSPHP_DOMAINS: string[] = [
   "baconbits.org",
   "bakabt.me",
   "beyond-hd.me",
+  "bilibili.download",
   "bt.byr.cn",
   "byr.pt",
   "cangbao.ge",

--- a/tools/browser-extension/src/modules/collector/auto-collector.test.ts
+++ b/tools/browser-extension/src/modules/collector/auto-collector.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { extractNexusPHPTorrentId } from "./auto-collector";
+
+describe("extractNexusPHPTorrentId", () => {
+  const cases: Array<{ name: string; html: string; expected: string | null }> = [
+    {
+      name: "prefers the free torrent in a table layout",
+      html: `
+        <table class="torrents">
+          <tr><td><a href="details.php?id=10001">First torrent</a></td></tr>
+          <tr><td><a href="details.php?id=10002">Free torrent</a><span class='free'>Free</span></td></tr>
+        </table>
+      `,
+      expected: "10002",
+    },
+    {
+      name: "returns the first torrent in a table layout without a free marker",
+      html: `
+        <table class="torrents">
+          <tr><td><a href="details.php?id=20001">First torrent</a></td></tr>
+          <tr><td><a href="details.php?id=20002">Second torrent</a></td></tr>
+        </table>
+      `,
+      expected: "20001",
+    },
+    {
+      name: "finds a free torrent in the div layout used by cspt",
+      html: `
+        <div class="torrents">
+          <div class="torrent-cat"><img alt="Movies" /></div>
+          <div class="torrent-title">
+            <a href="details.php?id=30001&amp;hit=1">First torrent</a>
+          </div>
+          <div class="torrent-info"><a href="details.php?id=30001&amp;dllist=1">4</a></div>
+          <div class="torrent-cat"><img alt="TV" /></div>
+          <div class="torrent-title">
+            <a href="details.php?id=30002&amp;hit=1">Free torrent</a>
+            <img class="pro_free" alt="Free" />
+          </div>
+        </div>
+      `,
+      expected: "30002",
+    },
+    {
+      name: "returns the first torrent in a div layout without a free marker",
+      html: `
+        <div class="torrents">
+          <div class="torrent-cat"><img alt="Movies" /></div>
+          <div class="torrent-title">
+            <a href="details.php?id=40001&amp;hit=1">First torrent</a>
+          </div>
+          <div class="torrent-title">
+            <a href="details.php?id=40002&amp;hit=1">Second torrent</a>
+          </div>
+        </div>
+      `,
+      expected: "40001",
+    },
+    {
+      name: "does not treat a userdetails link as a torrent link",
+      html: `<table><tr><td><a href="userdetails.php?id=12345">Anonymous user</a></td></tr></table>`,
+      expected: null,
+    },
+    {
+      name: "returns null for empty HTML",
+      html: "",
+      expected: null,
+    },
+    {
+      name: "returns null for empty and no-match HTML",
+      html: `<div class="torrents">No torrent links</div>`,
+      expected: null,
+    },
+  ];
+
+  it.each(cases)("$name", ({ html, expected }) => {
+    expect(extractNexusPHPTorrentId(html)).toBe(expected);
+  });
+});

--- a/tools/browser-extension/src/modules/collector/auto-collector.ts
+++ b/tools/browser-extension/src/modules/collector/auto-collector.ts
@@ -26,20 +26,39 @@ const SCHEMA_URL_MAP: Record<string, SchemaUrls> = {
 
       for (const rowMatch of rows) {
         const row = rowMatch[0];
-        const idMatch = row.match(/details\.php\?id=(\d+)/);
+        const idMatch = row.match(/(?:^|[^A-Za-z])details\.php\?id=(\d+)/);
         if (!idMatch) continue;
 
         if (!firstRowId) {
           firstRowId = idMatch[1];
         }
 
-        if (/pro_free|pro_free2up|class="free"/i.test(row)) {
+        if (/pro_free2up|pro_free|class=["']free["']/i.test(row)) {
           freeRowId = idMatch[1];
           break;
         }
       }
 
-      return freeRowId ?? firstRowId;
+      if (freeRowId ?? firstRowId) {
+        return freeRowId ?? firstRowId;
+      }
+
+      const torrentLinks = [...html.matchAll(/(?:^|[^A-Za-z])details\.php\?id=(\d+)/gi)];
+      let firstWindowId: string | null = null;
+
+      for (let index = 0; index < torrentLinks.length; index += 1) {
+        const link = torrentLinks[index];
+        firstWindowId ??= link[1];
+
+        const windowStart = link.index;
+        const windowEnd = torrentLinks[index + 1]?.index ?? html.length;
+        const window = html.slice(windowStart, windowEnd);
+        if (/pro_free2up|pro_free|class=["']free["']/i.test(window)) {
+          return link[1];
+        }
+      }
+
+      return firstWindowId;
     },
     extractUserId(html: string): string | null {
       const infoBlock = html.match(/<div\s+id=["']info_block["'][^>]*>[\s\S]*?<\/div>/i);
@@ -110,6 +129,10 @@ const SCHEMA_URL_MAP: Record<string, SchemaUrls> = {
 };
 
 SCHEMA_URL_MAP["Rousi"] = SCHEMA_URL_MAP["NexusPHP"];
+
+export function extractNexusPHPTorrentId(html: string): string | null {
+  return SCHEMA_URL_MAP["NexusPHP"].extractTorrentId(html);
+}
 
 function getSchemaUrls(schema: SiteSchema): SchemaUrls | null {
   return SCHEMA_URL_MAP[schema] ?? null;

--- a/tools/browser-extension/tsconfig.json
+++ b/tools/browser-extension/tsconfig.json
@@ -14,7 +14,7 @@
     "useDefineForClassFields": true,
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
-    "types": ["chrome", "vite/client"]
+    "types": ["chrome", "node", "vite/client"]
   },
   "include": ["src/**/*.ts", "src/**/*.vue", "vite.config.ts"],
   "references": []


### PR DESCRIPTION
## Summary

- 修复浏览器扩展在 `<div>` 布局 NexusPHP 站点上无法识别种子 ID，导致采集数据缺少详情页的问题（#476）
- 新增 `bilibili.download` 站点采集支持
- 为扩展补齐测试环境（首个测试）与类型环境，并接入 CI

## 问题背景

用户提交 `cspt.top` 站点请求（#476）时，导出的 ZIP 里没有 `detail.html`，导致无法编写详情页解析器。

根因在 `extractTorrentId`：它用 `<tr>` 正则逐行扫描搜索页。而 cspt.top 采用 Tailwind 风格皮肤，种子列表是 `<div class="torrents">` + `div.torrent-title`，**整页没有一个 `<tr>`**，于是循环从未执行，函数返回 `null`，`autoCollect` 静默跳过详情页采集。

该页面实际含 252 个 `details.php?id=` 与 97 个 `pro_free`，信息完全充足。

同时发现一个相关缺陷：正则 `details.php?id=` 会匹配到 `userdetails.php?id=`，可能把**用户 ID** 当作种子 ID。这正是 #449 早期采集拿到「没有该ID的种子」错误页的成因。

## Changes

**修复 `extractTorrentId`**（`auto-collector.ts`）
- `<tr>` 扫描路径逻辑完全不变，标准 NexusPHP 站点行为无回归
- 仅当 `<tr>` 扫描零命中时，回退到按 `details.php?id=` 出现位置切分窗口扫描
- 两条路径均加边界约束，排除 `userdetails.php?id=` 误匹配
- 免费标记匹配兼容单引号写法（`class='free'`）

**新增站点**（`pt-sites.ts`）
- `bilibili.download` 加入 `NEXUSPHP_DOMAINS`（保持字母序）
- 未改动 `KNOWN_SITES`：该数组由 `check-sites.ts` 与 Go 站点定义严格对齐，此站尚无 Go 定义

**测试与类型环境**
- 引入 `vitest`，新增 `test` 脚本，这是扩展包的首个测试
- 新增 7 条表驱动用例，覆盖表格布局、div 布局、`userdetails` 防误判、空输入
- 补 `@types/node` 并将 `node` 加入 `tsconfig.json` 的 `types`，修复既有的 4 个 `vite.config.ts` typecheck 报错
- CI 的 Extension Build 任务新增 `pnpm test` 步骤

## Verification

用真实采集数据验证修复前后行为：

| 输入 | 修复前 | 修复后 |
|---|---|---|
| cspt.top 真实 `search.html` | `null` | `219880` |
| keepfrds 真实 `search.html`（表格布局回归） | `2782256` | `2782256` |
| div 布局片段（含 `pro_free`） | `null` | 正确返回免费种子 |
| 仅含 `userdetails.php?id=12345` | `"12345"` | `null` |

修复后取到的 `219880` 已确认是页面内真实种子链接，且不等于该 ZIP 的用户 ID `10011266`。

其余检查：

- `pnpm test` → 1 file / 7 tests passed
- `pnpm typecheck` → exit 0（修复前有 4 个报错）
- `pnpm build` → 成功
- `node --experimental-strip-types scripts/check-sites.ts` → 站点一致性通过
- `make fmt-check` → 全部文件格式正确

## 备注

`bilibili.download` 的 NexusPHP 架构已由仓库维护者确认。本次仅让扩展能识别并采集该站点，Go 侧完整适配为后续工作。