### PR TITLE
feat(site): 扩展 NexusPHP 解析器以适配非标准页面

### DIFF
--- a/site/v2/nexusphp_driver.go
+++ b/site/v2/nexusphp_driver.go
@@ -71,6 +71,8 @@ type SiteSelectors struct {
 	HRIcon string `json:"hrIcon"`
 	// Subtitle selects the subtitle in search results
 	Subtitle string `json:"subtitle"`
+	// SubtitleSelector extracts subtitles that require HTML attributes or filters
+	SubtitleSelector *FieldSelector `json:"subtitleSelector,omitempty"`
 	// UserInfo selectors for user page
 	UserInfoUsername   string `json:"userInfoUsername"`
 	UserInfoUploaded   string `json:"userInfoUploaded"`
@@ -435,6 +437,8 @@ func (d *NexusPHPDriver) ParseSearch(res NexusPHPResponse) ([]TorrentItem, error
 			if subtitleElem.Length() > 0 {
 				item.Subtitle = strings.TrimSpace(subtitleElem.Text())
 			}
+		} else if d.Selectors.SubtitleSelector != nil {
+			item.Subtitle = d.extractFieldValueFromSelection(s, *d.Selectors.SubtitleSelector)
 		}
 
 		// Parse size
@@ -1119,12 +1123,16 @@ func (d *NexusPHPDriver) executeProcess(ctx context.Context, uiConfig *UserInfoC
 
 // extractFieldValue extracts a field value from the document using the selector config
 func (d *NexusPHPDriver) extractFieldValue(doc *goquery.Document, selector FieldSelector) string {
+	return d.extractFieldValueFromSelection(doc.Selection, selector)
+}
+
+func (d *NexusPHPDriver) extractFieldValueFromSelection(root *goquery.Selection, selector FieldSelector) string {
 	var value string
 	var matchedSelector string
 
 	// Try each selector until one matches
 	for _, sel := range selector.Selector {
-		elem := doc.Find(sel).First()
+		elem := root.Find(sel).First()
 		if elem.Length() == 0 {
 			if DebugUserInfo {
 				fmt.Printf("[DEBUG]   Selector %q: no match\n", sel)

--- a/site/v2/nexusphp_driver_test.go
+++ b/site/v2/nexusphp_driver_test.go
@@ -193,6 +193,64 @@ func TestNexusPHPDriver_ParseSearch(t *testing.T) {
 	assert.Equal(t, "Test Movie 2024", items[0].Title)
 }
 
+func TestNexusPHPDriver_ParseSearch_SubtitleExtraction(t *testing.T) {
+	tests := []struct {
+		name      string
+		html      string
+		configure func(*SiteSelectors)
+		want      string
+	}{
+		{
+			name: "structured HTML and regex extracts bare text node",
+			html: `<table class="torrents"><tbody><tr class="torrent-row"><td class="embedded browse_td_name_cell">
+				<a href="details.php?id=2781170"><b>惊变28年</b></a><img class="tag imdb_10548174"><br />
+				28 Years Later 2025 BluRay 1080p x265 10bit DDP7.1 MNHD-FRDS<b>[<div class="famfamfam-silk cup"></div>]</b>
+			</td></tr></tbody></table>`,
+			configure: func(s *SiteSelectors) {
+				s.SubtitleSelector = &FieldSelector{
+					Selector: []string{"td.embedded.browse_td_name_cell"},
+					Attr:     "html",
+					Filters: []Filter{{
+						Name: "regex",
+						Args: []any{`(?s)<br\s*/?>\s*([^<]+?)\s*<b>\[`},
+					}},
+				}
+			},
+			want: "28 Years Later 2025 BluRay 1080p x265 10bit DDP7.1 MNHD-FRDS",
+		},
+		{
+			name: "legacy string selector is unchanged",
+			html: `<table class="torrents"><tbody><tr class="torrent-row"><td>
+				<a href="details.php?id=12345">Test Movie</a><span class="subtitle">Legacy Subtitle</span>
+			</td></tr></tbody></table>`,
+			configure: func(s *SiteSelectors) {
+				s.Subtitle = ".subtitle"
+			},
+			want: "Legacy Subtitle",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selectors := SiteSelectors{
+				TableRows: ".torrent-row",
+				Title:     "a[href*='details.php']",
+			}
+			tt.configure(&selectors)
+			driver := NewNexusPHPDriver(NexusPHPDriverConfig{
+				BaseURL:   "https://example.com",
+				Selectors: &selectors,
+			})
+			doc := mustDoc(t, tt.html)
+
+			items, err := driver.ParseSearch(NexusPHPResponse{Document: doc})
+			require.NoError(t, err)
+			require.Len(t, items, 1)
+			assert.Equal(t, tt.want, items[0].Subtitle)
+		})
+	}
+}
+
 func TestNexusPHPDriver_ParseSearch_DiscountEndTimeFromOnmouseover(t *testing.T) {
 	driver := NewNexusPHPDriver(NexusPHPDriverConfig{
 		BaseURL: "https://hdsky.me",

--- a/site/v2/nexusphp_parser.go
+++ b/site/v2/nexusphp_parser.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/PuerkitoBio/goquery"
 )
@@ -24,17 +25,10 @@ type NexusPHPParserConfig struct {
 
 // DefaultNexusPHPParserConfig 返回默认配置，适用于大多数 NexusPHP 站点
 func DefaultNexusPHPParserConfig() NexusPHPParserConfig {
+	detailConfig := DefaultDetailParserConfig()
 	return NexusPHPParserConfig{
-		TimeLayout: "2006-01-02 15:04:05",
-		DiscountMapping: map[string]DiscountLevel{
-			"free":          DiscountFree,
-			"twoup":         Discount2xUp,
-			"twoupfree":     Discount2xFree,
-			"thirtypercent": DiscountPercent30,
-			"halfdown":      DiscountPercent50,
-			"twouphalfdown": Discount2x50,
-			"pro_custom":    DiscountNone,
-		},
+		TimeLayout:       detailConfig.TimeLayout,
+		DiscountMapping:  detailConfig.DiscountMapping,
 		HRKeywords:       []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
 		TitleSelector:    "input[name='torrent_name']",
 		IDSelector:       "input[name='detail_torrent_id']",
@@ -147,9 +141,93 @@ func NewNexusPHPParserFromDefinition(def *SiteDefinition) *NexusPHPParser {
 }
 
 func (p *NexusPHPParser) ParseTitleAndID(doc *goquery.Selection) (title, torrentID string) {
-	title, _ = doc.Find(p.config.TitleSelector).Attr("value")
-	torrentID, _ = doc.Find(p.config.IDSelector).Attr("value")
+	title = valueOrText(doc.Find(p.config.TitleSelector), p.config.DiscountMapping)
+	torrentID = valueOrText(doc.Find(p.config.IDSelector), nil)
 	return title, torrentID
+}
+
+func valueOrText(s *goquery.Selection, discountMapping map[string]DiscountLevel) string {
+	if value, exists := s.Attr("value"); exists {
+		return value
+	}
+
+	text := strings.TrimSpace(s.Text())
+	if discountMapping == nil {
+		return text
+	}
+
+	return stripTrailingPromotion(text, discountMapping)
+}
+
+func stripTrailingPromotion(text string, discountMapping map[string]DiscountLevel) string {
+	runes := []rune(text)
+	for start := 0; start < len(runes); {
+		if !unicode.IsSpace(runes[start]) {
+			start++
+			continue
+		}
+
+		end := start
+		for end < len(runes) && unicode.IsSpace(runes[end]) {
+			end++
+		}
+		suffix := strings.TrimSpace(string(runes[end:]))
+		if strings.HasPrefix(suffix, "[") && strings.HasSuffix(suffix, "]") &&
+			isKnownPromotionLabel(suffix[1:len(suffix)-1], discountMapping) {
+			return strings.TrimSpace(string(runes[:start]))
+		}
+		start = end
+	}
+
+	return text
+}
+
+func isKnownPromotionLabel(label string, discountMapping map[string]DiscountLevel) bool {
+	normalized := normalizePromotionLabel(label)
+	for key, level := range discountMapping {
+		if level == DiscountNone {
+			continue
+		}
+		if normalized == normalizePromotionLabel(key) {
+			return true
+		}
+		for _, alias := range renderedPromotionAliases(level) {
+			if normalized == normalizePromotionLabel(alias) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func normalizePromotionLabel(label string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return -1
+		}
+		return unicode.ToLower(r)
+	}, label)
+}
+
+// renderedPromotionAliases maps configured discount semantics to their common visible labels.
+// CSS class names remain sourced from DiscountMapping; these aliases cover rendered human text.
+func renderedPromotionAliases(level DiscountLevel) []string {
+	switch level {
+	case DiscountFree:
+		return []string{"免费", "free"}
+	case Discount2xUp:
+		return []string{"2x", "2xup"}
+	case Discount2xFree:
+		return []string{"2x免费", "2xfree"}
+	case DiscountPercent50:
+		return []string{"50%"}
+	case DiscountPercent30:
+		return []string{"30%"}
+	case Discount2x50:
+		return []string{"2x50%", "2x50"}
+	default:
+		return nil
+	}
 }
 
 func (p *NexusPHPParser) ParseDiscount(doc *goquery.Selection) (DiscountLevel, time.Time) {
@@ -201,11 +279,11 @@ func (p *NexusPHPParser) ParseSizeMB(doc *goquery.Selection) float64 {
 			return
 		}
 		switch strings.ToUpper(matches[2]) {
-		case "TB":
+		case "TB", "TIB":
 			size *= 1024 * 1024
-		case "GB":
+		case "GB", "GIB":
 			size *= 1024
-		case "KB":
+		case "KB", "KIB":
 			size /= 1024
 		}
 		sizeMB = size

--- a/site/v2/nexusphp_parser_test.go
+++ b/site/v2/nexusphp_parser_test.go
@@ -401,19 +401,162 @@ func TestNewNexusPHPParserFromDefinition_Nil(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestNexusPHPParser_ParseSizeMB_Units(t *testing.T) {
-	p := NewNexusPHPParser()
+	p := NewNexusPHPParserFromDefinition(&SiteDefinition{DetailParser: &DetailParserConfig{
+		SizeRegex: `大小：[^\d]*([\d.]+)\s*([KMGT]i?B)`,
+	}})
+	tests := []struct {
+		name   string
+		value  string
+		wantMB float64
+		delta  float64
+	}{
+		{name: "TB", value: "2.00 TB", wantMB: 2097152, delta: 1},
+		{name: "GB", value: "2.00 GB", wantMB: 2048, delta: 0.1},
+		{name: "MB", value: "2.00 MB", wantMB: 2, delta: 0.1},
+		{name: "KB", value: "512.00 KB", wantMB: 0.5, delta: 0.01},
+		{name: "TiB", value: "2.00 TiB", wantMB: 2097152, delta: 1},
+		{name: "GiB", value: "2.00 GiB", wantMB: 2048, delta: 0.1},
+		{name: "MiB", value: "2.00 MiB", wantMB: 2, delta: 0.1},
+		{name: "KiB", value: "512.00 KiB", wantMB: 0.5, delta: 0.01},
+	}
 
-	tb := `<html><body><table><tr><td class="rowhead">基本信息</td><td>大小：2.00 TB</td></tr></table></body></html>`
-	doc, _ := goquery.NewDocumentFromReader(strings.NewReader(tb))
-	assert.InDelta(t, 2.0*1024*1024, p.ParseSizeMB(doc.Selection), 1)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			html := `<html><body><table><tr><td class="rowhead">基本信息</td><td>大小：` + tt.value + `</td></tr></table></body></html>`
+			doc := parseHTML(t, html)
+			assert.InDelta(t, tt.wantMB, p.ParseSizeMB(doc), tt.delta)
+		})
+	}
 
-	kb := `<html><body><table><tr><td class="rowhead">基本信息</td><td>大小：512.00 KB</td></tr></table></body></html>`
-	doc2, _ := goquery.NewDocumentFromReader(strings.NewReader(kb))
-	assert.InDelta(t, 512.0/1024, p.ParseSizeMB(doc2.Selection), 0.01)
+	t.Run("no match", func(t *testing.T) {
+		doc := parseHTML(t, `<html><body><table><tr><td class="rowhead">基本信息</td><td>无</td></tr></table></body></html>`)
+		assert.Zero(t, p.ParseSizeMB(doc))
+	})
 
-	none := `<html><body><table><tr><td class="rowhead">基本信息</td><td>无</td></tr></table></body></html>`
-	doc3, _ := goquery.NewDocumentFromReader(strings.NewReader(none))
-	assert.Equal(t, float64(0), p.ParseSizeMB(doc3.Selection))
+	t.Run("default regex does not opt into binary units", func(t *testing.T) {
+		doc := parseHTML(t, `<html><body><table><tr><td class="rowhead">基本信息</td><td>大小：2.00 GiB</td></tr></table></body></html>`)
+		assert.Zero(t, NewNexusPHPParser().ParseSizeMB(doc))
+	})
+}
+
+func TestNexusPHPParser_ParseTitleAndID_ValueAndText(t *testing.T) {
+	tests := []struct {
+		name   string
+		html   string
+		want   string
+		wantID string
+	}{
+		{
+			name:   "falls back to element text and strips trailing promotion",
+			html:   `<h1 id="top">【十日拍拖手册/绝配冤家】10bit HEVC版本 国英双语 评论音轨&nbsp;&nbsp;&nbsp; <b>[<font class="free">免费</font>]</b></h1><span id="torrent-id">2782256</span>`,
+			want:   "【十日拍拖手册/绝配冤家】10bit HEVC版本 国英双语 评论音轨",
+			wantID: "2782256",
+		},
+		// These cases guard against stripping legitimate resolution and release-group brackets.
+		{
+			name:   "preserves resolution bracket after repeated spaces",
+			html:   `<h1 id="top">某剧集 第一季  [1080p BluRay]</h1>`,
+			want:   "某剧集 第一季  [1080p BluRay]",
+			wantID: "",
+		},
+		{
+			name:   "preserves release group bracket after repeated spaces",
+			html:   `<h1 id="top">Some Movie 2025  [FRDS]</h1>`,
+			want:   "Some Movie 2025  [FRDS]",
+			wantID: "",
+		},
+		{
+			name:   "preserves resolution bracket after one space",
+			html:   `<h1 id="top">某剧集 第一季 [1080p BluRay]</h1>`,
+			want:   "某剧集 第一季 [1080p BluRay]",
+			wantID: "",
+		},
+		{
+			name:   "preserves title without brackets",
+			html:   `<h1 id="top">普通标题 没有方括号</h1>`,
+			want:   "普通标题 没有方括号",
+			wantID: "",
+		},
+		{
+			name:   "value attribute wins over element text",
+			html:   `<div id="top" value="  Attribute Title  ">Text Title</div><div id="torrent-id" value="00777">888</div>`,
+			want:   "  Attribute Title  ",
+			wantID: "00777",
+		},
+		{
+			name:   "present empty value does not fall back",
+			html:   `<div id="top" value="">Text Title</div><div id="torrent-id" value="">888</div>`,
+			want:   "",
+			wantID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewNexusPHPParserFromDefinition(&SiteDefinition{DetailParser: &DetailParserConfig{
+				TitleSelector: "#top",
+				IDSelector:    "#torrent-id",
+			}})
+			title, torrentID := p.ParseTitleAndID(parseHTML(t, tt.html))
+			assert.Equal(t, tt.want, title)
+			assert.Equal(t, tt.wantID, torrentID)
+		})
+	}
+}
+
+func TestStripTrailingPromotion_KnownVocabulary(t *testing.T) {
+	discountMapping := DefaultDetailParserConfig().DiscountMapping
+	tests := []struct {
+		label string
+	}{
+		{label: "免费"},
+		{label: "FREE"},
+		{label: "50%"},
+		{label: "30%"},
+		{label: "2X"},
+		{label: "2x Free"},
+		{label: "2X 免费"},
+		{label: "2x 50%"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.label, func(t *testing.T) {
+			assert.Equal(t, "Title", stripTrailingPromotion("Title  ["+tt.label+"]", discountMapping))
+		})
+	}
+}
+
+func TestStripTrailingPromotion_RequestedCases(t *testing.T) {
+	discountMapping := DefaultDetailParserConfig().DiscountMapping
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "keepfrds promo", input: "...带章节名\u00a0\u00a0\u00a0 [免费]", want: "...带章节名"},
+		{name: "resolution with repeated spaces", input: "某剧集 第一季  [1080p BluRay]", want: "某剧集 第一季  [1080p BluRay]"},
+		{name: "release group", input: "Some Movie 2025  [FRDS]", want: "Some Movie 2025  [FRDS]"},
+		{name: "resolution with one space", input: "某剧集 第一季 [1080p BluRay]", want: "某剧集 第一季 [1080p BluRay]"},
+		{name: "no brackets", input: "普通标题 没有方括号", want: "普通标题 没有方括号"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := stripTrailingPromotion(tt.input, discountMapping)
+			t.Logf("in=%q out=%q", tt.input, actual)
+			assert.Equal(t, tt.want, actual)
+		})
+	}
+
+	t.Run("value attribute remains byte identical", func(t *testing.T) {
+		p := NewNexusPHPParserFromDefinition(&SiteDefinition{DetailParser: &DetailParserConfig{
+			TitleSelector: "#top",
+		}})
+		const want = "  Attribute Title  "
+		title, _ := p.ParseTitleAndID(parseHTML(t, `<div id="top" value="  Attribute Title  ">Text Title&nbsp;&nbsp; [免费]</div>`))
+		t.Logf("value=%q out=%q", want, title)
+		assert.Equal(t, want, title)
+	})
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

扩展 NexusPHP 共享解析层的三项能力，使页面结构偏离经典布局的 NexusPHP 站点可被适配。

这是两个 PR 中的第一个。后续 PR 将基于这些能力接入 `pt.keepfrds.com`（issue #449），本 PR 不含该站点。

## 背景：为什么先改共享层

issue #449 请求适配 `pt.keepfrds.com`。最初尝试仅新增站点定义文件，但该站真实页面同时命中三处能力缺口，纯配置无法适配：

- 标题位于 `h1#top`，页面**没有** `input[name='torrent_name']` 隐藏域
- 大小显示为 `8.47 GiB`（IEC 二进制单位）
- 副标题是 `<br />` 之后的**裸文本节点**，CSS 无法单独选中

在缺乏这些能力的情况下写定义，只能产出「手工调过的测试能过、真实页面解析不出来」的结果。因此先补齐共享层能力。

## Changes

**1. `ParseSizeMB` 支持二进制单位**

新增 `KiB`/`MiB`/`GiB`/`TiB` 换算。`GB` 保持原有语义（1024 MB），`TB`/`MB`/`KB` 数值行为完全不变。

**未扩大默认 `SizeRegex`** —— 现有定义的匹配范围不变，只有显式声明包含 IEC 单位的站点才会启用新能力。

**2. `ParseTitleAndID` 文本回退**

优先读 `value` 属性；仅在属性不存在时回退读取元素文本。`value=""` 视为属性存在，不触发回退，确保原路径字节级不变。

标题回退时按**已知优惠词表**剥离尾部促销标记，词表取自 `DefaultDetailParserConfig().DiscountMapping`，而非另建硬编码列表。

**3. `SiteSelectors` 新增 `SubtitleSelector`**

保留原 `Subtitle string` 字段及其执行路径；新增可选 `SubtitleSelector *FieldSelector`，复用既有 `FieldSelector` / `Attr` / `ApplyFilters` 机制，而非另造一套抽象。提取逻辑作用域限定在当前种子行，避免正则跨行匹配。仅当旧 `Subtitle` 为空时才使用新配置。

## 向后兼容性

全部 53 个站点定义、其中 49 个 NexusPHP 站点共用这段代码，三项改动均为纯增量：

| 关注点 | 保证方式 |
|---|---|
| 现有 `SizeRegex` | 默认正则未扩大，匹配范围与数值完全不变 |
| 现有详情页 | 均含隐藏域，走 `value` 路径，回退不触发 |
| 现有 `Subtitle` 选择器 | 字符串写法优先，行为不变 |

其中一条测试专门断言「默认正则不会擅自匹配 `GiB`」，用于锁定第一项保证。

## 促销标记剥离的取舍

初版实现按「双空白 + 任意 `[...]` 结尾」判断，经实测存在数据损坏：

| 输入 | 初版输出 | 问题 |
|---|---|---|
| `某剧集 第一季  [1080p BluRay]` | `某剧集 第一季` | 规格标记被切掉 |
| `Some Movie 2025  [FRDS]` | `Some Movie 2025` | 制作组标记被切掉 |

方括号后缀在 PT 标题中极为常见（分辨率、片源、制作组）。已改为按已知优惠词表匹配 —— 促销标记是有限枚举，而非任意方括号。两个用例已作为显式回归测试固化。

## Verification

- `go test ./... -count=1` → 40 个包全部通过，0 个 FAIL
- `go build ./...` → exit 0
- `make lint-go` → 0 issues
- `make fmt-check` → 全部文件格式正确
- 三处能力缺口均先写失败测试确认现象，再实现修复
- 补齐了此前缺失的 `GB` 单位测试用例