### PR TITLE
feat(site): 新增 DiscFan、TCCF、TLFBits 三个站点适配

### DIFF
--- a/docs/sites.md
+++ b/docs/sites.md
@@ -1,8 +1,8 @@
 ## 支持站点
 
-当前已适配 **54** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
+当前已适配 **57** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
 
-### NexusPHP 系列（50）
+### NexusPHP 系列（53）
 
 | 站点                  | 认证方式 | 支持功能                      | 适配情况 | 备注                                                             |
 | --------------------- | -------- | ----------------------------- | -------- | ---------------------------------------------------------------- |
@@ -56,6 +56,9 @@
 | **TangPT**            | Cookie   | RSS、搜索、用户信息           | ✅       | 糖果（www.tangpt.top，CHD 模板，issue #456）                     |
 | **T-Baozi**           | Cookie   | RSS、搜索、用户信息           | ✅       | 包子（p.t-baozi.cc，info_block 取数据，issue #457）              |
 | **PT@KEEPFRDS**       | Cookie   | RSS、搜索、用户信息           | ✅       | 朋友/FRDS（pt.keepfrds.com，issue #449）                         |
+| **DiscFan**           | Cookie   | RSS、搜索、用户信息           | ✅       | 碟粉（discfan.net，繁体界面，issue #494）                        |
+| **TCCF**              | Cookie   | RSS、搜索、用户信息           | ✅       | TorrentCCF（et8.org，种子列表含进度列，issue #496）              |
+| **TLFBits**           | Cookie   | RSS、搜索、用户信息           | ✅       | TLF / The Last Fantasy（pt.eastgame.org，issue #502）            |
 
 ### 其他架构（4）
 

--- a/site/v2/definitions/discfan.go
+++ b/site/v2/definitions/discfan.go
@@ -1,0 +1,255 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+// DiscFanDefinition 描述 DiscFan（碟粉）站点。
+//
+// 该站点为标准 NexusPHP 架构，但整站使用**繁体中文**界面，所有标签与常见简体站点不同，
+// 选择器需要专门适配：
+//  1. 用户详情页的传输行标签是「傳送」，既不是简体「传输」也不是繁体「傳輸」；
+//     行内为嵌套 table 的合并单元格（分享率/上傳量/下載量/實際上傳量/實際下載量），需以 html + regex 拆分。
+//  2. 详情页体积行标签是「基本資訊」（非「基本信息」），且 ParseSizeMB 取的是标签单元格的
+//     下一个兄弟节点，因此 SizeSelector 必须指向标签列本身。
+//  3. 搜索页副标题是 <br /> 之后的裸文本节点，前面可能还有若干语言标签 <span>，
+//     无法用普通 CSS 选择器命中，需要走 SubtitleSelector（html + regex 跳过标签块）。
+//  4. 促销结束时间没有独立可选中的稳定元素，仅存在于促销图标的 onmouseover 提示中
+//     （HTML 实体编码），交由驱动的 parseDiscountEndTimeFromOnmouseover 兜底解析。
+var DiscFanDefinition = &v2.SiteDefinition{
+	ID:             "discfan",
+	Name:           "DiscFan",
+	Aka:            []string{"碟粉"},
+	Description:    "以华语影视为主的综合 PT 站点（繁体界面）",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://discfan.net/"},
+	FaviconURL:     "https://discfan.net/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "seeding", "leeching", "bonus"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields: []string{
+					"uploaded", "downloaded", "ratio",
+					"trueUploaded", "trueDownloaded",
+					"levelName", "joinTime", "lastAccessAt",
+				},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			// #info_block 必须优先：用户详情页正文里还有「邀請人」等其他 userdetails.php 链接
+			"id": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php'][class*='Name']",
+					"a[href*='userdetails.php']",
+				},
+				Attr:    "href",
+				Filters: []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php'][class*='Name']",
+				},
+			},
+			// 做种/下载数：数字是 arrowup/arrowdown 图标之后的裸文本节点。
+			// 正则用 [^>]*> 而非 [^>]*/>，兼容渲染器是否输出自闭合斜杠
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowup"[^>]*>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowdown"[^>]*>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			// 魔力值：<font class='color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 5,616,620.9
+			"bonus": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`魔力值\s*</font>\s*\[[^\]]*\]\s*[:：]\s*([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			// 传输行标签为繁体「傳送」；同时保留「傳輸」/「传输」兜底以适配站点改版
+			"uploaded": {
+				Selector: []string{
+					"td.rowhead:contains('傳送') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('传输') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>上傳量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"downloaded": {
+				Selector: []string{
+					"td.rowhead:contains('傳送') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('传输') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>下載量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			// <strong>分享率</strong> 不会误命中 <strong>實際分享率</strong>（前缀不同）
+			"ratio": {
+				Selector: []string{
+					"td.rowhead:contains('傳送') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('传输') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>分享率</strong>[：:\s]*(?:<font[^>]*>)?([\d.,]+|∞|Inf)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"trueUploaded": {
+				Selector: []string{
+					"td.rowhead:contains('傳送') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('传输') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>實際上傳量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"trueDownloaded": {
+				Selector: []string{
+					"td.rowhead:contains('傳送') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('传输') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>實際下載量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"levelName": {
+				Selector: []string{
+					"td.rowhead:contains('等級') + td img",
+					"td.rowhead:contains('等级') + td img",
+				},
+				Attr: "title",
+			},
+			"joinTime": {
+				Selector: []string{
+					"td.rowhead:contains('加入日期') + td",
+					"td.rowhead:contains('Join') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+			// 保号探测只读取 UserInfo.LastAccess，缺失会导致线上探测解析失败。
+			// 「最近動向」行在文档顺序上先于「最近動向(地點)」行，取 First() 即为时间行
+			"lastAccessAt": {
+				Selector: []string{
+					"td.rowhead:contains('最近動向') + td",
+					"td.rowhead:contains('最近动向') + td",
+					"td.rowhead:contains('最後活動') + td",
+					"td.rowhead:contains('上次訪問') + td",
+					"td.rowhead:contains('Last access') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		TableRows: "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:     "table.torrentname a[href*='details.php']",
+		TitleLink: "table.torrentname a[href*='details.php']",
+		// 副标题是 <br /> 之后的裸文本节点，其前可能存在若干语言标签 <span>（粵語/國語 等），
+		// 因此正则先跳过连续的完整 <span>...</span> 块，再截取剩余纯文本
+		SubtitleSelector: &v2.FieldSelector{
+			Selector: []string{
+				"table.torrentname td.embedded:has(a[href*='details.php'])",
+				"table.torrentname td.embedded",
+			},
+			Attr: "html",
+			Filters: []v2.Filter{
+				{Name: "regex", Args: []any{`(?s)<br\s*/?>(?:\s*<span[^>]*>[^<]*</span>)*\s*([^<]+)`}},
+				// 走 html 取值会保留实体编码，需手动还原；&amp; 必须最后替换以避免二次解码
+				{Name: "replace", Args: []any{"&#39;", "'"}},
+				{Name: "replace", Args: []any{"&quot;", `"`}},
+				{Name: "replace", Args: []any{"&lt;", "<"}},
+				{Name: "replace", Args: []any{"&gt;", ">"}},
+				{Name: "replace", Args: []any{"&nbsp;", " "}},
+				{Name: "replace", Args: []any{"&amp;", "&"}},
+				{Name: "trim"},
+			},
+		},
+		// 列序取自 colhead：類型 / 標題 / 評論數 / 存活時間 / 大小 / 種子數 / 下載數 / 完成數 / 發佈者
+		Size:     "td.rowfollow:nth-child(5)",
+		Seeders:  "td.rowfollow:nth-child(6)",
+		Leechers: "td.rowfollow:nth-child(7)",
+		Snatched: "td.rowfollow:nth-child(8)",
+		// 实际抓取到 pro_free / pro_free2up / pro_2up / pro_50pctdown / pro_30pctdown，
+		// 其余为 NexusPHP 通用促销图标类名。不设置 DiscountMapping，交由驱动内置规则判定，
+		// 避免自定义 map 迭代顺序导致 pro_free2up 被 "free" 抢先命中
+		DiscountIcon: "img.pro_free, img.pro_free2up, img.pro_2up, img.pro_50pctdown, img.pro_50pctdown2up, img.pro_30pctdown",
+		// 不设置 DiscountEndTime：站内促销剩余时间的稳定来源是促销图标的 onmouseover 提示，
+		// 由驱动的 parseDiscountEndTimeFromOnmouseover 兜底解析
+		Category:           "td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:         "td.rowfollow:nth-child(4) span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下載') + td a[href*='download.php'], td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副標題') + td, td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords: []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		// 详情页存在隐藏域（字幕上传表单内），直接取 value，无需回退 h1 文本
+		TitleSelector: "input[name='torrent_name']",
+		IDSelector:    "input[name='detail_torrent_id']",
+		// h1#top 内可能同时出现非促销的 <font class='hot'>，ParseDiscount 会跳过未映射的类名
+		DiscountSelector: "h1#top font[class]",
+		EndTimeSelector:  "h1#top span[title]",
+		// ParseSizeMB 取该元素的下一个兄弟节点文本，所以必须指向标签列而非内容列；
+		// 站点使用繁体「基本資訊」+ 全角冒号「大小：」+ 十进制单位（GB）
+		SizeSelector: "td.rowhead:contains('基本資訊'), td.rowhead:contains('基本信息')",
+		SizeRegex:    `大小[：:]\s*([\d.]+)\s*(GB|MB|KB|TB)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(DiscFanDefinition)
+}

--- a/site/v2/definitions/discfan_fixture_test.go
+++ b/site/v2/definitions/discfan_fixture_test.go
@@ -1,0 +1,315 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "discfan",
+		Search:   testDiscfanSearch,
+		Detail:   testDiscfanDetail,
+		UserInfo: testDiscfanUserInfo,
+	})
+}
+
+// --- Fixtures ---
+//
+// 结构复刻真实采集页面（繁体界面、9 列种子表、傳送 合并单元格、基本資訊 体积行），
+// 用户名/用户 ID/种子 ID/图片地址均为虚构值。
+
+// 搜索页：3 行——限时免费（图标带 onmouseover）、2X 免费（无 onmouseover，即永久促销无结束时间）、
+// 无促销（副标题前带语言标签 <span>）。
+const discfanSearchFixture = `<html><body>
+<table class="torrents" cellspacing="0" cellpadding="5" width="100%">
+<tr>
+<td class="colhead" style="padding: 0px">類型</td>
+<td class="colhead"><a href="?sort=1&amp;type=asc">標題</a></td>
+<td class="colhead"><img class="comments" alt="comments" title="評論數" /></td>
+<td class="colhead"><img class="time" alt="time" title="存活時間" /></td>
+<td class="colhead"><img class="size" alt="size" title="大小" /></td>
+<td class="colhead"><img class="seeders" alt="seeders" title="種子數" /></td>
+<td class="colhead"><img class="leechers" alt="leechers" title="下載數" /></td>
+<td class="colhead"><img class="snatched" alt="snatched" title="完成數" /></td>
+<td class="colhead"><a href="?sort=9&amp;type=desc">發佈者</a></td>
+</tr>
+<tr style="background-color: #aadbf3">
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=411"><img class="c_sacd" src="pic/cattrans.gif" alt="剧集" title="剧集" /></a><img src="pic/cattrans.gif" alt="WEB_DL" title="WEB_DL" /></td>
+<td class="rowfollow" width="100%" align="left" style='padding: 0px'><table class="torrentname" width="100%"><tr><td class="embedded" style="text-align: center;width: 46px;height: 46px"><img src="pic/misc/spinner.svg" data-src="https://img.example.invalid/poster-a.jpg" class="nexus-lazy-load" /></td><td class="embedded" style='padding-left: 5px'><img class="sticky" src="pic/trans.gif" alt="Sticky" title="二級置頂" />&nbsp;<a title="Sample.Series.2016.V2.WEB-DL.4k.H265.AAC-DEMO"  href="details.php?id=10001&amp;hit=1"><b>Sample.Series.2016.V2.WEB-DL.4k.H265.AAC-DEMO</b></a> <img class="pro_free" src="pic/trans.gif" alt="Free"  onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;free&quot;&gt;免費&lt;/font&gt;&lt;/b&gt;剩餘時間：&lt;b&gt;&lt;span title=&quot;2026-08-01 23:42:19&quot;&gt;5天8時&lt;/span&gt;&lt;/b&gt;', 'trail', false, 'delay',500);" /> <font color='#0000FF'>剩餘時間：<span title="2026-08-01 23:42:19">5天8時</span></font><br />範例劇集/示例剧集 全34集|主演：甲乙丙  丁戊己 高码率版本</td><td class="embedded" style="text-align: right; width: 40px;padding: 4px"><div><img src="pic/imdb2.png" alt="imdb" title="imdb" /><span data-imdbid="tt0000001">N/A</span></div></td><td width="20" class="embedded" style="text-align: right;padding-right: 5px" valign="middle"><a href="download.php?id=10001"><img class="download" src="pic/trans.gif" alt="download" title="下載本種" /></a><br /><a id="bookmark0"  href="javascript: bookmark(10001,0);" ><img class="delbookmark" src="pic/trans.gif" alt="Unbookmarked" title="收藏" /></a></td>
+</tr></table></td>
+<td class="rowfollow"><a href="comment.php?action=add&amp;pid=10001&amp;type=torrent" title="添加評論">0</a></td>
+<td class="rowfollow nowrap"><span title="2021-02-09 14:42:19">5年<br />6月</span></td>
+<td class="rowfollow">188.30<br />GB</td>
+<td class="rowfollow" align="center"><b><a href="details.php?id=10001&amp;hit=1&amp;dllist=1#seeders">3</a></b></td>
+<td class="rowfollow">0</td>
+<td class="rowfollow"><a href="viewsnatches.php?id=10001"><b>23</b></a></td>
+<td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr>
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=404"><img class="c_movies" src="pic/cattrans.gif" alt="电影 - 中国香港" title="电影 - 中国香港" /></a></td>
+<td class="rowfollow" width="100%" align="left" style='padding: 0px'><table class="torrentname" width="100%"><tr><td class="embedded" style="text-align: center;width: 46px;height: 46px"><img src="pic/misc/spinner.svg" data-src="" class="nexus-lazy-load" /></td><td class="embedded" style='padding-left: 5px'><a title="Sample.Collection.1987-1991.1080p.Blu-ray.AVC-DEMO"  href="details.php?id=10002&amp;hit=1"><b>Sample.Collection.1987-1991.1080p.Blu-ray.AVC-DEMO</b></a> <img class="pro_free2up" src="pic/trans.gif" alt="2X Free" /><br />範例合集1+2 | 主演：庚辛壬 癸子丑 [国粤中字]</td><td width="20" class="embedded" style="text-align: right;padding-right: 5px" valign="middle"><a href="download.php?id=10002"><img class="download" src="pic/trans.gif" alt="download" title="下載本種" /></a><br /><a id="bookmark1"  href="javascript: bookmark(10002,0);" ><img class="delbookmark" src="pic/trans.gif" alt="Unbookmarked" title="收藏" /></a></td>
+</tr></table></td>
+<td class="rowfollow"><a href="comment.php?action=add&amp;pid=10002&amp;type=torrent" title="添加評論">5</a></td>
+<td class="rowfollow nowrap"><span title="2017-04-22 20:36:34">9年<br />3月</span></td>
+<td class="rowfollow">44.48<br />GB</td>
+<td class="rowfollow" align="center"><b><a href="details.php?id=10002&amp;hit=1&amp;dllist=1#seeders">1</a></b></td>
+<td class="rowfollow">2</td>
+<td class="rowfollow"><a href="viewsnatches.php?id=10002"><b>90</b></a></td>
+<td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr>
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=401"><img class="c_doc" src="pic/cattrans.gif" alt="电影 - 中国大陆" title="电影 - 中国大陆" /></a></td>
+<td class="rowfollow" width="100%" align="left" style='padding: 0px'><table class="torrentname" width="100%"><tr><td class="embedded" style="text-align: center;width: 46px;height: 46px"><img src="pic/misc/spinner.svg" data-src="" class="nexus-lazy-load" /></td><td class="embedded" style='padding-left: 5px'><a title="Sample.Movie.1979.1080p.USA.Blu-ray.AVC.DTS-HD.MA.2.0"  href="details.php?id=10003&amp;hit=1"><b>Sample.Movie.1979.1080p.USA.Blu-ray.AVC.DTS-HD.MA.2.0</b></a> <b>[<font class='hot'>熱門</font>]</b><br /><span style="background-color:#FF1493;color:#ffffff;font-size:12px;padding:1px 2px" title="">粤语</span><span style="background-color:#6a3906;color:#ffffff;font-size:12px;padding:1px 2px" title="">国语</span>範例電影</td><td width="20" class="embedded" style="text-align: right;padding-right: 5px" valign="middle"><a href="download.php?id=10003"><img class="download" src="pic/trans.gif" alt="download" title="下載本種" /></a><br /><a id="bookmark2"  href="javascript: bookmark(10003,0);" ><img class="delbookmark" src="pic/trans.gif" alt="Unbookmarked" title="收藏" /></a></td>
+</tr></table></td>
+<td class="rowfollow"><a href="comment.php?action=add&amp;pid=10003&amp;type=torrent" title="添加評論">2</a></td>
+<td class="rowfollow nowrap"><span title="2026-07-25 18:20:00">1天<br />6時</span></td>
+<td class="rowfollow">17.86<br />GB</td>
+<td class="rowfollow" align="center"><b><a href="details.php?id=10003&amp;hit=1&amp;dllist=1#seeders">6</a></b></td>
+<td class="rowfollow">1</td>
+<td class="rowfollow"><a href="viewsnatches.php?id=10003"><b>10</b></a></td>
+<td class="rowfollow"><i>匿名</i></td>
+</tr>
+</table>
+</body></html>`
+
+// 详情页：h1#top 内为标题文本 + [免費] 促销标记 + 剩餘時間；
+// 标题/种子 ID 取自字幕上传表单内的隐藏域；体积行标签为繁体「基本資訊」。
+const discfanDetailFixture = `<html><body>
+<h1 align="center" id="top">Sample.Series.2016.V2.WEB-DL.4k.H265.AAC-DEMO&nbsp;&nbsp;&nbsp; <b>[<font class='free' >免費</font>]</b> <font color='#0000FF'>剩餘時間：<span title="2026-08-01 23:42:19">5天8時</span></font></h1>
+<table width="97%" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead" width="13%">下載</td><td class="rowfollow" width="87%" align="left"><a class="index" href="download.php?id=10001">[DiscFan].Sample.Series.2016.V2.WEB-DL.4k.H265.AAC-DEMO.torrent</a>&nbsp;&nbsp;&nbsp;由&nbsp;<i>匿名</i>發布于<span title="2021-02-09 14:42:19">5年6月前</span></td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">副標題</td><td class="rowfollow" valign="top" align="left">範例劇集/示例剧集 全34集|主演：甲乙丙  丁戊己 高码率版本</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">基本資訊</td><td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>188.30 GB&nbsp;&nbsp;&nbsp;<b>類別:</b>&nbsp;剧集&nbsp;&nbsp;&nbsp;<b>來源: </b>Web-DL</td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Sample.Series.2016.V2.WEB-DL.4k.H265.AAC-DEMO" /><input type="hidden" name="detail_torrent_id" value="10001" /><input type="hidden" name="in_detail" value="in_detail" /><input type="submit" value="上傳字幕" /></form></td></tr>
+</table>
+</body></html>`
+
+// 详情页（含 H&R 标记，且无促销）：验证 HRKeywords 与「未映射 font class 被跳过」两条路径。
+const discfanDetailHRFixture = `<html><body>
+<h1 align="center" id="top">Sample.Movie.2020.1080p.Blu-ray.AVC-DEMO&nbsp;&nbsp;&nbsp; <b>[<font class='hot'>熱門</font>]</b></h1>
+<table width="97%" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead nowrap" valign="top" align="right">基本資訊</td><td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>8.50 GB&nbsp;&nbsp;&nbsp;<b>類別:</b>&nbsp;电影</td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Sample.Movie.2020.1080p.Blu-ray.AVC-DEMO" /><input type="hidden" name="detail_torrent_id" value="10004" /></form></td></tr>
+</table>
+<img src="pic/hit_run.gif" alt="Hit and Run" />
+</body></html>`
+
+// index.php 顶部 #info_block（每页共用）。
+const discfanIndexFixture = `<html><body>
+<table id="info_block" cellpadding="4" cellspacing="0" border="0" width="100%"><tr>
+	<td><table width="100%" cellspacing="0" cellpadding="0" border="0"><tr>
+		<td class="bottom" align="left">
+			<span class="medium">
+				歡迎回來, <span class="nowrap"><a  href="https://discfan.net/userdetails.php?id=99001" class='UltimateUser_Name'><b>ptuser01</b></a></span>                [<a href="logout.php">退出</a>]
+				<font class = 'color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 1,234,567.8                 <a href="medal.php">[勛章]</a>
+				<font class = 'color_invite'>邀請 </font>[<a href="invite.php?id=99001">發送</a>]: 3(0)                                <br />
+				<font class="color_ratio">分享率：</font> 2.000                <font class='color_uploaded'>上傳量：</font> 2.500 TB                <font class='color_downloaded'> 下載量：</font> 1.250 TB                <font class='color_active'>當前活動：</font> <img class="arrowup" alt="Torrents seeding" title="當前做種" src="pic/trans.gif" />42  <img class="arrowdown" alt="Torrents leeching" title="當前下載" src="pic/trans.gif" />3&nbsp;&nbsp;
+			</span>
+		</td>
+	</tr></table></td>
+</tr></table>
+</body></html>`
+
+// userdetails.php 正文：注意传输行标签是繁体「傳送」，且为嵌套 table 的合并单元格；
+// 「最近動向」与「最近動向(地點)」两行同时存在，取 First() 必须命中时间行。
+const discfanUserdetailsFixture = `<html><body>
+<h1 style='margin:0px'><span class="nowrap"><b>SampleUser</b></span></h1>
+<table width="100%" border="1" cellspacing="0" cellpadding="5">
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">用戶ID/UID</td><td width="99%" class="rowfollow" valign="top" align="left">99001</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">邀請人</td><td width="99%" class="rowfollow" valign="top" align="left"><span class="nowrap"><a  href="https://discfan.net/userdetails.php?id=99002" class='Moderator_Name'><b>inviter01</b></a></span></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">加入日期</td><td width="99%" class="rowfollow" valign="top" align="left">2023-05-06 07:08:09 (<span title="2023-05-06 07:08:09">3年2月前</span>, 116.9周)</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">最近動向</td><td width="99%" class="rowfollow" valign="top" align="left">2026-07-27 05:15:44 (<span title="2026-07-27 05:15:44">9時52分前</span>)</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">最近動向(地點)</td><td width="99%" class="rowfollow" valign="top" align="left">torrents</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">傳送</td><td width="99%" class="rowfollow" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>分享率</strong>:  <font color="#770000">2.000</font>（<strong>實際分享率</strong>：0.667）</td><td class="embedded">&nbsp;&nbsp;<img src="pic/smilies/34.gif" alt="" /></td></tr><tr><td class="embedded"><strong>上傳量</strong>:  2.500 TB</td><td class="embedded">&nbsp;&nbsp;<strong>下載量</strong>:  1.250 TB</td></tr><tr><td class="embedded"><strong>實際上傳量</strong>:  500.00 GB</td><td class="embedded">&nbsp;&nbsp;<strong>實際下載量</strong>:  750.00 GB</td><td class="embedded text-muted">&nbsp;&nbsp;實際上傳/下載量 (僅用於記錄, 不參與分享率計算)</td></tr></table></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">等級</td><td width="99%" class="rowfollow" valign="top" align="left"><img alt="Power User" title="Power User" src="pic/user.gif" /> </td></tr>
+</table>
+</body></html>`
+
+// --- Helpers ---
+
+func getDiscfanDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("discfan")
+	require.True(t, ok, "discfan definition not found")
+	return def
+}
+
+// --- Suite: Search ---
+
+func testDiscfanSearch(t *testing.T) {
+	def := getDiscfanDef(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(discfanSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{
+		BaseURL:   server.URL,
+		Cookie:    "test_cookie=1",
+		Selectors: def.Selectors,
+	})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: "GET"})
+	require.NoError(t, err)
+
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 3, "should parse 3 torrent rows (colhead row excluded)")
+
+	free := items[0]
+	assert.Equal(t, "10001", free.ID)
+	assert.Equal(t, "Sample.Series.2016.V2.WEB-DL.4k.H265.AAC-DEMO", free.Title)
+	assert.Equal(t, "範例劇集/示例剧集 全34集|主演：甲乙丙  丁戊己 高码率版本", free.Subtitle)
+	assert.Equal(t, v2.DiscountFree, free.DiscountLevel)
+	// 促销结束时间只能从促销图标的 onmouseover 提示中解析
+	require.False(t, free.DiscountEndTime.IsZero(), "discount end time should come from onmouseover tooltip")
+	assert.Equal(t, "2026-08-01 23:42:19", free.DiscountEndTime.Format("2006-01-02 15:04:05"))
+	assert.Equal(t, int64(202185585459), free.SizeBytes) // 188.30 GB（size 单元格被 <br /> 分成两行）
+	assert.Equal(t, 3, free.Seeders)
+	assert.Equal(t, 0, free.Leechers)
+	assert.Equal(t, 23, free.Snatched)
+	assert.Equal(t, "剧集", free.Category)
+	assert.Equal(t, int64(1612881739), free.UploadedAt)
+
+	twoXFree := items[1]
+	assert.Equal(t, "10002", twoXFree.ID)
+	assert.Equal(t, v2.Discount2xFree, twoXFree.DiscountLevel)
+	assert.Equal(t, "範例合集1+2 | 主演：庚辛壬 癸子丑 [国粤中字]", twoXFree.Subtitle)
+	// 永久促销没有 onmouseover 提示，结束时间未知
+	assert.True(t, twoXFree.DiscountEndTime.IsZero(), "permanent promotion has no end time")
+	assert.Equal(t, 1, twoXFree.Seeders)
+	assert.Equal(t, 2, twoXFree.Leechers)
+	assert.Equal(t, 90, twoXFree.Snatched)
+
+	plain := items[2]
+	assert.Equal(t, "10003", plain.ID)
+	assert.Equal(t, v2.DiscountNone, plain.DiscountLevel, "[熱門] 不是促销标记")
+	// 副标题前有两个语言标签 <span>，需被正则跳过
+	assert.Equal(t, "範例電影", plain.Subtitle)
+	assert.Equal(t, 6, plain.Seeders)
+	assert.Equal(t, 1, plain.Leechers)
+	assert.Equal(t, 10, plain.Snatched)
+}
+
+// --- Suite: Detail ---
+
+func testDiscfanDetail(t *testing.T) {
+	def := getDiscfanDef(t)
+
+	t.Run("Free", func(t *testing.T) {
+		doc := FixtureDoc(t, "discfan_detail", discfanDetailFixture)
+		parser := v2.NewNexusPHPParserFromDefinition(def)
+		info := parser.ParseAll(doc.Selection)
+
+		assert.Equal(t, "10001", info.TorrentID)
+		assert.Equal(t, "Sample.Series.2016.V2.WEB-DL.4k.H265.AAC-DEMO", info.Title)
+		assert.Equal(t, v2.DiscountFree, info.DiscountLevel)
+		require.False(t, info.DiscountEnd.IsZero(), "discount end time should be parsed")
+		assert.Equal(t, "2026-08-01 23:42:19", info.DiscountEnd.Format("2006-01-02 15:04:05"))
+		// 繁体「基本資訊」标签列 + 全角冒号「大小：」+ 十进制 GB
+		assert.InDelta(t, 188.30*1024, info.SizeMB, 0.1)
+		assert.False(t, info.HasHR)
+	})
+
+	t.Run("WithHRAndNonPromotionFont", func(t *testing.T) {
+		doc := FixtureDoc(t, "discfan_detail_hr", discfanDetailHRFixture)
+		parser := v2.NewNexusPHPParserFromDefinition(def)
+		info := parser.ParseAll(doc.Selection)
+
+		assert.Equal(t, "10004", info.TorrentID)
+		assert.Equal(t, "Sample.Movie.2020.1080p.Blu-ray.AVC-DEMO", info.Title)
+		assert.True(t, info.HasHR, "should detect HR from hit_run.gif")
+		assert.Equal(t, v2.DiscountNone, info.DiscountLevel, "font.hot 未映射，应保持无促销")
+		assert.InDelta(t, 8.50*1024, info.SizeMB, 0.1)
+	})
+}
+
+// --- Suite: UserInfo ---
+
+func testDiscfanUserInfo(t *testing.T) {
+	def := getDiscfanDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	t.Run("IndexPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "discfan_index", discfanIndexFixture)
+		fields := map[string]string{
+			"id":       "99001",
+			"name":     "ptuser01",
+			"seeding":  "42",
+			"leeching": "3",
+			"bonus":    "1.2345678e+06",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+	})
+
+	t.Run("UserdetailsPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "discfan_userdetails", discfanUserdetailsFixture)
+		fields := map[string]string{
+			"uploaded":       "2748779069440",
+			"downloaded":     "1374389534720",
+			"ratio":          "2",
+			"trueUploaded":   "536870912000",
+			"trueDownloaded": "805306368000",
+			"levelName":      "Power User",
+			"joinTime":       "1683328089",
+			"lastAccessAt":   "1785100544",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+	})
+}
+
+// --- Standalone Tests ---
+
+// 保号探测只读取 UserInfo.LastAccess，缺失或解析失败会导致线上探测报错。
+func TestDiscfan_UserInfo_LastAccessParsed(t *testing.T) {
+	def := getDiscfanDef(t)
+	driver := newTestNexusPHPDriver(def)
+	doc := FixtureDoc(t, "discfan_userdetails", discfanUserdetailsFixture)
+
+	sel, ok := def.UserInfo.Selectors["lastAccessAt"]
+	require.True(t, ok, "lastAccessAt selector is required for the login-state probe")
+
+	raw := driver.ExtractFieldValuePublic(doc, sel)
+	ts, err := strconv.ParseInt(raw, 10, 64)
+	require.NoError(t, err, "lastAccessAt should be a unix timestamp, got %q", raw)
+	assert.Greater(t, ts, int64(0), "lastAccessAt must be > 0")
+}
+
+func TestDiscfan_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":      discfanSearchFixture,
+		"detail":      discfanDetailFixture,
+		"detail_hr":   discfanDetailHRFixture,
+		"index":       discfanIndexFixture,
+		"userdetails": discfanUserdetailsFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			RequireNoSecrets(t, name, data)
+		})
+	}
+}

--- a/site/v2/definitions/eastgame.go
+++ b/site/v2/definitions/eastgame.go
@@ -1,0 +1,215 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+// EastgameDefinition 描述 TLFBits（pt.eastgame.org）站点。
+//
+// 站点为标准 NexusPHP 架构（BlueGene 皮肤 + tlfbits2020 分类图标），详情页保留了
+// input[name='torrent_name'] / input[name='detail_torrent_id'] 隐藏域，体积为十进制单位，
+// 因此绝大多数选择器与 btschool 一致。仅两处需要单独适配：
+//  1. 搜索页副标题是 <br /> 之后的裸文本节点（无包裹元素），必须走 SubtitleSelector。
+//  2. userdetails.php 的「传输」行把上传量写成合并标签
+//     <strong>总上传量/奖励上传量/纯上传量</strong>: 5.405 TB/120.00 GB/5.288 TB，
+//     btschool 的 <strong>上传量</strong> 正则无法命中，需要专用正则。
+var EastgameDefinition = &v2.SiteDefinition{
+	ID:             "eastgame",
+	Name:           "TLFBits",
+	Aka:            []string{"TLF", "The Last Fantasy"},
+	Description:    "简单的分享，简单的快乐（综合性 PT 站点）",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://pt.eastgame.org/"},
+	FaviconURL:     "https://pt.eastgame.org/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "seeding", "leeching", "bonus"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields: []string{
+					"uploaded", "downloaded", "ratio", "trueUploaded",
+					"levelName", "joinTime", "lastAccessAt",
+				},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			"id": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php'][class*='Name']",
+					"a[href*='userdetails.php']",
+				},
+				Attr:    "href",
+				Filters: []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php'][class*='Name']",
+				},
+			},
+			// 传输行是合并单元格（内嵌 table），需以 html + regex 拆分。
+			// 上传量标签为「总上传量/奖励上传量/纯上传量」，取第一个数值（总上传量）。
+			"uploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>(?:总上传量/奖励上传量/纯上传量|上传量)</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			// 纯上传量：合并标签中的第三个数值
+			"trueUploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>总上传量/奖励上传量/纯上传量</strong>[：:\s]*[\d.,]+\s*[KMGTP]?i?B\s*/\s*[\d.,]+\s*[KMGTP]?i?B\s*/\s*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"downloaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>下载量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"ratio": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>分享率</strong>[：:\s]*(?:<font[^>]*>)?([\d.,]+|∞|Inf)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"levelName": {
+				Selector: []string{"td.rowhead:contains('等级') + td img", "td.rowhead:contains('等級') + td img"},
+				Attr:     "title",
+			},
+			// 魔力值只出现在 #info_block：<font class='color_bonus'>魔力值 </font>[使用]: 101,003.0
+			"bonus": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`魔力值\s*</font>\s*\[[^\]]*\]\s*[:：]\s*([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowup"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"joinTime": {
+				Selector: []string{
+					"td.rowhead:contains('加入日期') + td",
+					"td.rowhead:contains('Join') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+			// 保号探测只读取 UserInfo.LastAccess，缺失会导致线上探测解析失败。
+			// 注意「最近动向(地点)」行同样命中 :contains('最近动向')，但取值走 First()，
+			// 文档顺序上「最近动向」在前，因此不会误取空的地点行。
+			"lastAccessAt": {
+				Selector: []string{
+					"td.rowhead:contains('最近动向') + td",
+					"td.rowhead:contains('最近動向') + td",
+					"td.rowhead:contains('上次访问') + td",
+					"td.rowhead:contains('Last access') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		TableRows: "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:     "table.torrentname a[href*='details.php']",
+		TitleLink: "table.torrentname a[href*='details.php']",
+		// 副标题是 <br /> 之后的裸文本节点，前面可能穿插多个 img.sticky、
+		// <b>(新)</b>、<b>[热门]</b>、促销图标和 [剩余时间：...]，无法用普通 CSS 选择器命中，
+		// 因此取名称单元格（torrentname 内第一个 td.embedded）的 html 后用正则截取。
+		SubtitleSelector: &v2.FieldSelector{
+			Selector: []string{"table.torrentname td.embedded"},
+			Attr:     "html",
+			Filters: []v2.Filter{
+				{Name: "regex", Args: []any{`(?s)<br\s*/?>(?:\s*<span[^>]*>)?\s*([^<]+)`}},
+				// 走 html 取值会保留实体编码，需手动还原；&amp; 必须最后替换以避免二次解码
+				{Name: "replace", Args: []any{"&#39;", "'"}},
+				{Name: "replace", Args: []any{"&quot;", `"`}},
+				{Name: "replace", Args: []any{"&lt;", "<"}},
+				{Name: "replace", Args: []any{"&gt;", ">"}},
+				{Name: "replace", Args: []any{"&nbsp;", " "}},
+				{Name: "replace", Args: []any{"&amp;", "&"}},
+				{Name: "trim"},
+			},
+		},
+		// 列序（colhead）：1 类型 2 标题 3 评论数 4 存活时间 5 大小 6 种子数 7 下载数 8 完成数 9 发布者
+		Size:     "td.rowfollow:nth-child(5)",
+		Seeders:  "td.rowfollow:nth-child(6)",
+		Leechers: "td.rowfollow:nth-child(7)",
+		Snatched: "td.rowfollow:nth-child(8)",
+		// 实际抓取到的仅有 pro_free，其余为 NexusPHP 通用促销图标类名
+		DiscountIcon: "img.pro_free, img.pro_free2up, img.pro_2up, img.pro_50pctdown, img.pro_50pctdown2up, img.pro_30pctdown",
+		// 促销结束时间在名称单元格里以 [剩余时间：<span title="...">] 真实渲染，
+		// 限定在 table.torrentname 内查找可避免误取第 4 列的发布时间 span；
+		// 若站点某些页面不渲染该 span，驱动会回退解析促销图标的 onmouseover 提示。
+		DiscountEndTime:    "table.torrentname span[title]",
+		Category:           "td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:         "td.rowfollow:nth-child(4) span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下载直链') + td a[href*='download.php'], td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords: []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		// 详情页保留隐藏域，标题/ID 直接取 value
+		TitleSelector:    "input[name='torrent_name']",
+		IDSelector:       "input[name='detail_torrent_id']",
+		DiscountSelector: "h1 font.free, h1 font[class]",
+		EndTimeSelector:  "h1 span[title]",
+		// ParseSizeMB 读取 SizeSelector 元素的 .Next() 兄弟节点，因此必须指向标签单元格；
+		// 体积为十进制单位且使用全角冒号（大小：1.95 GB）
+		SizeSelector: "td.rowhead:contains('基本信息')",
+		SizeRegex:    `大小[：:]\s*([\d.]+)\s*(GB|MB|KB|TB)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(EastgameDefinition)
+}

--- a/site/v2/definitions/eastgame_fixture_test.go
+++ b/site/v2/definitions/eastgame_fixture_test.go
@@ -1,0 +1,296 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "eastgame",
+		Search:   testEastgameSearch,
+		Detail:   testEastgameDetail,
+		UserInfo: testEastgameUserInfo,
+	})
+}
+
+// --- Fixtures ---
+//
+// 结构照搬真实页面（BlueGene 皮肤），但所有标题、副标题、种子 ID、用户名和用户 ID 均已替换为虚构值。
+//
+// 搜索页需要覆盖的真实特征：
+//   - 名称单元格前缀可能带多个 img.sticky、<b>(新)</b>、<b>[热门]</b>
+//   - 促销结束时间同时出现在 img.pro_free 的 onmouseover 提示与 [剩余时间：<span title>] 中
+//   - 副标题是 <br /> 之后的裸文本节点
+//   - 大小列是 "1.95<br />GB"（数字与单位被 <br /> 分开）
+//   - 名称子表内还有豆瓣/IMDb 评分单元格与下载单元格（均为 td.embedded）
+
+const eastgameSearchFixture = `<html><body>
+<table class="torrents" cellspacing="0" cellpadding="5" width="100%">
+<tr>
+<td class="colhead" style="padding: 0px">类型</td>
+<td class="colhead"><a href="?sort=1&amp;type=asc">标题</a></td>
+<td class="colhead"><img class="comments" src="pic/trans.gif" alt="comments" title="评论数" /></td>
+<td class="colhead"><img class="time" src="pic/trans.gif" alt="time" title="存活时间" /></td>
+<td class="colhead"><img class="size" src="pic/trans.gif" alt="size" title="大小" /></td>
+<td class="colhead"><img class="seeders" src="pic/trans.gif" alt="seeders" title="种子数" /></td>
+<td class="colhead"><img class="leechers" src="pic/trans.gif" alt="leechers" title="下载数" /></td>
+<td class="colhead"><img class="snatched" src="pic/trans.gif" alt="snatched" title="完成数" /></td>
+<td class="colhead">发布者</td>
+</tr>
+<tr class='triple_sticky'>
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=438"><img class="c_movie" src="pic/cattrans.gif" alt="电影 (Movie)" title="电影 (Movie)" /></a></td>
+<td class="rowfollow" width="100%" align="left"><table class="torrentname" width="100%"><tr class='triple_sticky'><td class="embedded"><img class="sticky" src="pic/trans.gif" alt="Sticky" title="置顶" /><img class="sticky" src="pic/trans.gif" alt="Sticky" title="置顶" /><img class="sticky" src="pic/trans.gif" alt="Sticky" title="置顶" />&nbsp;<a title="Fixture.Movie.2026.BluRay.720p.x264.AC3-FIXTURE"  href="details.php?id=99001&amp;hit=1"><b>Fixture.Movie.2026.BluRay.720p.x264.AC3-FIXTURE</b></a><b> (<font class='new'>新</font>)</b> <b>[<font class='hot'>热门</font>]</b> <img class="pro_free" src="pic/trans.gif" alt="Free"  onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;free&quot;&gt;免费&lt;/font&gt;&lt;/b&gt;剩余时间：&lt;b&gt;&lt;span title=&quot;2026-07-28 03:01:34&quot;&gt;19时45分&lt;/span&gt;&lt;/b&gt;', 'trail', false, 'delay',500,'lifetime',3000);" />[剩余时间：<span title="2026-07-28 03:01:34">19时45分</span>]<br />虚构副标题一</td>        <td class="embedded" style="vertical-align: middle; text-align: right; width: 48px;">
+            <img src='pic/douban.png' alt='douban' style="vertical-align: middle;"/>
+            <span class="rating">5.7</span>
+            <br>
+            <img src='pic/imdb.png' alt='imdb' style="vertical-align: middle;"/>
+            <span class="rating"><span style='color: silver'>N/A</span></span>
+        </td>
+        <td width="20" class="embedded" style="text-align: right; " valign="middle"><a href="download.php?id=99001"><img class="download" src="pic/trans.gif" alt="download" title="下载本种" /></a><br /><a id="bookmark0"  href="javascript: bookmark(99001,0);" ><img class="delbookmark" src="pic/trans.gif" alt="Unbookmarked" title="收藏" /></a></td>
+</tr></table></td><td class="rowfollow"><a href="comment.php?action=add&amp;pid=99001&amp;type=torrent" title="添加评论">0</a></td><td class="rowfollow nowrap"><span title="2026-07-26 03:01:33">1天<br />4时</span></td><td class="rowfollow">1.95<br />GB</td><td class="rowfollow" align="center"><b><a href="details.php?id=99001&amp;hit=1&amp;dllist=1#seeders">33</a></b></td>
+<td class="rowfollow"><b><a href="details.php?id=99001&amp;hit=1&amp;dllist=1#leechers">2</a></b></td>
+<td class="rowfollow"><a href="viewsnatches.php?id=99001"><b>112</b></a></td>
+<td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr>
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=449"><img class="c_study" src="pic/cattrans.gif" alt="资料（E-Learning）" title="资料（E-Learning）" /></a></td>
+<td class="rowfollow" width="100%" align="left"><table class="torrentname" width="100%"><tr><td class="embedded"><a title="Fixture.Guide.v2.0-FIXTURE"  href="details.php?id=99002&amp;hit=1"><b>Fixture.Guide.v2.0-FIXTURE</b></a><br />虚构副标题二</td>        <td class="embedded" style="vertical-align: middle; text-align: right; width: 48px;">
+            <img src='pic/douban.png' alt='douban' style="vertical-align: middle;"/>
+            <span class="rating"><span style='color: silver'>N/A</span></span>
+        </td>
+        <td width="20" class="embedded" style="text-align: right; " valign="middle"><a href="download.php?id=99002"><img class="download" src="pic/trans.gif" alt="download" title="下载本种" /></a></td>
+</tr></table></td><td class="rowfollow"><a href="comment.php?action=add&amp;pid=99002&amp;type=torrent" title="添加评论">3</a></td><td class="rowfollow nowrap"><span title="2026-05-01 12:00:00">2月<br />26天</span></td><td class="rowfollow">816.30<br />MB</td><td class="rowfollow" align="center"><b><a href="details.php?id=99002&amp;hit=1&amp;dllist=1#seeders">206</a></b></td>
+<td class="rowfollow"><b><a href="details.php?id=99002&amp;hit=1&amp;dllist=1#leechers">1</a></b></td>
+<td class="rowfollow"><a href="viewsnatches.php?id=99002"><b>0</b></a></td>
+<td class="rowfollow"><i>匿名</i></td>
+</tr>
+</table>
+</body></html>`
+
+// 详情页：标题/ID 来自 <form> 内的隐藏域（本站保留），h1 中的促销标记同时带 onmouseover 与真实
+// [剩余时间：<span title>]；「基本信息」行使用全角冒号与十进制单位。
+const eastgameDetailFixture = `<html><body>
+<h1 align="center" id="top">Fixture.Movie.2026.BluRay.720p.x264.AC3-FIXTURE&nbsp;&nbsp;&nbsp; <b>[<font class='free'  onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;free&quot;&gt;免费&lt;/font&gt;&lt;/b&gt;剩余时间：&lt;b&gt;&lt;span title=&quot;2026-07-28 03:01:34&quot;&gt;19时45分&lt;/span&gt;&lt;/b&gt;', 'trail', false, 'delay',500);">免费</font>]</b>[剩余时间：<span title="2026-07-28 03:01:34">19时45分</span>]</h1>
+<table width="1040" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead" width="13%">下载</td><td class="rowfollow" width="87%" align="left"><a class="index" href="download.php?id=99001">Fixture.Movie.2026.BluRay.720p.x264.AC3-FIXTURE.mkv.torrent</a>&nbsp;&nbsp;&nbsp;由&nbsp;<i>匿名</i>发布于<span title="2026-07-26 03:01:33">1天4时前</span></td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">副标题</td><td class="rowfollow" valign="top" align="left">虚构副标题一</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">基本信息</td><td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>1.95 GB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;电影 (Movie)&nbsp;&nbsp;&nbsp;<b>媒介:&nbsp;</b>Encode&nbsp;&nbsp;&nbsp;<b>分辨率:&nbsp;</b>720p</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">行为</td><td class="rowfollow" valign="top" align="left"><a title="下载种子" href="download.php?id=99001"><img class="dt_download" src="pic/trans.gif" alt="download" />&nbsp;<b><font class="small">下载种子</font></b></a></td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><table border="0" cellspacing="0"><tr><td class="embedded"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Fixture.Movie.2026.BluRay.720p.x264.AC3-FIXTURE" /><input type="hidden" name="detail_torrent_id" value="99001" /></form></td></tr></table></td></tr>
+</table>
+</body></html>`
+
+const eastgameDetailWithHRFixture = `<html><body>
+<h1 align="center" id="top">Fixture.HR.Show.S01.WEB-DL.1080p-FIXTURE</h1>
+<table width="1040" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead nowrap" valign="top" align="right">基本信息</td><td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>8.50 GB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;电视剧 (TV Series)</td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Fixture.HR.Show.S01.WEB-DL.1080p-FIXTURE" /><input type="hidden" name="detail_torrent_id" value="99003" /></form></td></tr>
+</table>
+<img src="pic/hit_run.gif" alt="Hit and Run" />
+</body></html>`
+
+// index.php 顶部 #info_block：id / name / 魔力值 / 做种下载数均取自这里。
+// 注意 class 属性带空格（class = 'color_bonus'），与真实页面一致。
+const eastgameIndexFixture = `<html><body>
+<table id="info_block" cellpadding="4" cellspacing="0" border="0" width="100%"><tr>
+	<td><table width="100%" cellspacing="0" cellpadding="0" border="0"><tr>
+		<td class="bottom" align="left"><span class="medium">欢迎回来, <span class="nowrap"><a  href="userdetails.php?id=90001" class='User_Name'><b>fixture_user</b></a></span>  [<a href="logout.php">退出</a>] <font class = 'color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 101,003.0 <font class = 'color_invite'>邀请 </font>[<a href="invite.php?id=90001">发送</a>]: 0<br />
+	<font class="color_ratio">分享率：</font> 无限  <font class='color_uploaded'>上传量：</font> 229.18 GB<font class='color_downloaded'> 下载量：</font> 0.00 KB  <font class='color_active'>当前活动：</font> <img class="arrowup" alt="Torrents seeding" title="当前做种" src="pic/trans.gif" />99  <img class="arrowdown" alt="Torrents leeching" title="当前下载" src="pic/trans.gif" />0&nbsp;&nbsp;<font class='color_connectable'>可连接：</font><b><font color="green">是</font></b></span></td>
+	</tr></table></td>
+</tr></table>
+</body></html>`
+
+// userdetails.php 正文表格：注意「传输」行把上传量写成
+// <strong>总上传量/奖励上传量/纯上传量</strong>，而「最近动向」之后紧跟同样命中
+// :contains('最近动向') 的「最近动向(地点)」空行。
+const eastgameUserdetailsFixture = `<html><body>
+<h1 style='margin:0px'><span class="nowrap"><b>fixture_target</b></span></h1>
+<table width="100%" border="1" cellspacing="0" cellpadding="5">
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">邀请</td><td width="99%" class="rowfollow" valign="top" align="left">没有邀请资格</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">加入日期</td><td width="99%" class="rowfollow" valign="top" align="left">2025-01-17 05:22:29 (<span title="2025-01-17 05:22:29">1年6月前</span>)</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">最近动向</td><td width="99%" class="rowfollow" valign="top" align="left">2026-07-25 01:57:00 (<span title="2026-07-25 01:57:00">2天5时前</span>)</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">最近动向(地点)</td><td width="99%" class="rowfollow" valign="top" align="left"></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">BT客户端</td><td width="99%" class="rowfollow" valign="top" align="left">qBittorrent/5.0.4</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">传输</td><td width="99%" class="rowfollow" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>分享率</strong>:  <font color="">38.040</font></td><td class="embedded">&nbsp;&nbsp;<img src="pic/smilies/163.gif" alt="" /></td></tr><tr><td class="embedded"><strong>总上传量/奖励上传量/纯上传量</strong>:  5.405 TB/120.00 GB/5.288 TB</td><td class="embedded">&nbsp;&nbsp;<strong>下载量</strong>:  145.50 GB</td></tr></table></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">BT时间</td><td width="99%" class="rowfollow" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>做种时间</strong>:  870天02:47:36</td><td class="embedded">&nbsp;&nbsp;<strong>下载时间</strong>:  383天17:58:19</td></tr></table></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">等级</td><td width="99%" class="rowfollow" valign="top" align="left"><img alt="Elite User" title="Elite User" src="pic/elite.gif" /> </td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">种子评论</td><td width="99%" class="rowfollow" valign="top" align="left">6</td></tr>
+</table>
+</body></html>`
+
+// --- Helpers ---
+
+func getEastgameDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("eastgame")
+	require.True(t, ok, "eastgame definition not found")
+	return def
+}
+
+// --- Suite: Search ---
+
+func testEastgameSearch(t *testing.T) {
+	def := getEastgameDef(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(eastgameSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{
+		BaseURL:   server.URL,
+		Cookie:    "test_cookie=1",
+		Selectors: def.Selectors,
+	})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: "GET"})
+	require.NoError(t, err)
+
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 2, "should parse 2 torrent rows")
+
+	free := items[0]
+	assert.Equal(t, "99001", free.ID)
+	assert.Equal(t, "Fixture.Movie.2026.BluRay.720p.x264.AC3-FIXTURE", free.Title)
+	// 副标题是 <br /> 之后的裸文本，需要 SubtitleSelector 才能取到
+	assert.Equal(t, "虚构副标题一", free.Subtitle)
+	assert.Equal(t, v2.DiscountFree, free.DiscountLevel)
+	// 大小列为 "1.95<br />GB"，parseSize 去空白后按十进制单位换算
+	assert.Equal(t, int64(2093796556), free.SizeBytes)
+	assert.Equal(t, 33, free.Seeders)
+	assert.Equal(t, 2, free.Leechers)
+	assert.Equal(t, 112, free.Snatched)
+	assert.Equal(t, "电影 (Movie)", free.Category)
+	// 促销结束时间取名称单元格内 [剩余时间：<span title>]，不能误取第 4 列的发布时间
+	require.False(t, free.DiscountEndTime.IsZero(), "discount end time should be parsed")
+	assert.Equal(t, 2026, free.DiscountEndTime.Year())
+	assert.Equal(t, 7, int(free.DiscountEndTime.Month()))
+	assert.Equal(t, 28, free.DiscountEndTime.Day())
+	assert.Positive(t, free.UploadedAt)
+
+	normal := items[1]
+	assert.Equal(t, "99002", normal.ID)
+	assert.Equal(t, "Fixture.Guide.v2.0-FIXTURE", normal.Title)
+	assert.Equal(t, "虚构副标题二", normal.Subtitle)
+	assert.Equal(t, v2.DiscountNone, normal.DiscountLevel)
+	assert.True(t, normal.DiscountEndTime.IsZero(), "no discount -> no end time")
+	assert.Equal(t, int64(855952588), normal.SizeBytes)
+	assert.Equal(t, 206, normal.Seeders)
+	assert.Equal(t, 1, normal.Leechers)
+	assert.Equal(t, 0, normal.Snatched)
+}
+
+// --- Suite: Detail ---
+
+func testEastgameDetail(t *testing.T) {
+	def := getEastgameDef(t)
+
+	t.Run("Free", func(t *testing.T) {
+		doc := FixtureDoc(t, "eastgame_detail", eastgameDetailFixture)
+		info := v2.NewNexusPHPParserFromDefinition(def).ParseAll(doc.Selection)
+
+		assert.Equal(t, "99001", info.TorrentID)
+		assert.Equal(t, "Fixture.Movie.2026.BluRay.720p.x264.AC3-FIXTURE", info.Title)
+		assert.Equal(t, v2.DiscountFree, info.DiscountLevel)
+		require.False(t, info.DiscountEnd.IsZero(), "discount end time should be parsed")
+		assert.Equal(t, 2026, info.DiscountEnd.Year())
+		assert.Equal(t, 7, int(info.DiscountEnd.Month()))
+		assert.Equal(t, 28, info.DiscountEnd.Day())
+		// 「基本信息」标签单元格 + .Next() 兄弟节点，全角冒号 + 十进制 GB
+		assert.InDelta(t, 1.95*1024, info.SizeMB, 0.1)
+		assert.False(t, info.HasHR)
+	})
+
+	t.Run("WithHR", func(t *testing.T) {
+		doc := FixtureDoc(t, "eastgame_detail_hr", eastgameDetailWithHRFixture)
+		info := v2.NewNexusPHPParserFromDefinition(def).ParseAll(doc.Selection)
+
+		assert.Equal(t, "99003", info.TorrentID)
+		assert.Equal(t, "Fixture.HR.Show.S01.WEB-DL.1080p-FIXTURE", info.Title)
+		assert.Equal(t, v2.DiscountNone, info.DiscountLevel)
+		assert.InDelta(t, 8.5*1024, info.SizeMB, 0.1)
+		assert.True(t, info.HasHR, "should detect HR from hit_run.gif")
+	})
+}
+
+// --- Suite: UserInfo ---
+
+func testEastgameUserInfo(t *testing.T) {
+	def := getEastgameDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	t.Run("IndexPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "eastgame_index", eastgameIndexFixture)
+		fields := map[string]string{
+			"id":       "90001",
+			"name":     "fixture_user",
+			"seeding":  "99",
+			"leeching": "0",
+			"bonus":    "101003",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+	})
+
+	t.Run("UserdetailsPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "eastgame_userdetails", eastgameUserdetailsFixture)
+		fields := map[string]string{
+			// 5.405 TB / 5.288 TB / 145.50 GB 按 1024 进制换算为字节
+			"uploaded":     "5942860348129",
+			"trueUploaded": "5814217487679",
+			"downloaded":   "156229435392",
+			"ratio":        "38.04",
+			"levelName":    "Elite User",
+			// parseTime 按站点 TimezoneOffset(+0800) 解析
+			"joinTime":     "1737062549",
+			"lastAccessAt": "1784915820",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+
+		// 保号探测只读取 UserInfo.LastAccess，必须为正的 Unix 秒
+		sel := def.UserInfo.Selectors["lastAccessAt"]
+		got := driver.ExtractFieldValuePublic(doc, sel)
+		require.NotEmpty(t, got, "lastAccessAt must be parsed for the login probe")
+		assert.Regexp(t, `^\d+$`, got)
+		assert.Greater(t, got, "0")
+	})
+}
+
+// --- Standalone Tests ---
+
+func TestEastgame_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":      eastgameSearchFixture,
+		"detail":      eastgameDetailFixture,
+		"detail_hr":   eastgameDetailWithHRFixture,
+		"index":       eastgameIndexFixture,
+		"userdetails": eastgameUserdetailsFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			RequireNoSecrets(t, name, data)
+		})
+	}
+}

--- a/site/v2/definitions/et8.go
+++ b/site/v2/definitions/et8.go
@@ -1,0 +1,183 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+// Et8Definition 站点 et8.org（页面 <title> 自称 TCCF，种子标题常见 [TorrentCCF首发] 前缀）。
+//
+// 与标准 NexusPHP 的差异：
+//   - 种子列表多出一列「进度」，位于「完成数」之后、「发布者」之前（共 10 列）；
+//     由于该列排在 size/seeders/leechers/snatched 之后，nth-child(5~8) 不受影响。
+//   - 副标题是 <br /> 之后的裸文本节点，无标签包裹，纯 CSS 选不中，
+//     故改用 SubtitleSelector 取 td.embedded 的 innerHTML 后正则截取。
+//   - 优惠剩余时间同时存在于优惠图标的 onmouseover tooltip 与单元格可见文本中，
+//     这里不设置 DiscountEndTime，交由驱动的 onmouseover 兜底解析，
+//     避免 CSS 选择器误命中同行的发布时间 span。
+var Et8Definition = &v2.SiteDefinition{
+	ID:             "et8",
+	Name:           "TCCF",
+	Aka:            []string{"TorrentCCF"},
+	Description:    "综合性 PT 站点，影视 / 纪录片 / 电子学习资源较多",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://et8.org/"},
+	FaviconURL:     "https://et8.org/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "seeding", "leeching", "bonus"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields:        []string{"uploaded", "downloaded", "ratio", "levelName", "joinTime", "lastAccessAt"},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			"id": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php'][class*='Name']",
+					"a[href*='userdetails.php']",
+				},
+				Attr:    "href",
+				Filters: []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php'][class*='Name']",
+				},
+			},
+			// 「传输」行为嵌套小表格：<strong>分享率</strong>/<strong>上传量</strong>/<strong>下载量</strong>
+			"uploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>上传量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"downloaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>下载量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"ratio": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>分享率</strong>[：:\s]*(?:<font[^>]*>)?([\d.,]+|∞|Inf)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"levelName": {
+				Selector: []string{"td.rowhead:contains('等级') + td img", "td.rowhead:contains('等級') + td img"},
+				Attr:     "title",
+			},
+			// info_block 中形如：<font class = 'color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 1,219,747.6
+			"bonus": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`魔力值\s*</font>\s*\[[^\]]*\]\s*[:：]\s*([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"joinTime": {
+				Selector: []string{"td.rowhead:contains('加入日期') + td", "td.rowhead:contains('Join') + td"},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+			// 保号探测依赖该字段；et8 的「最近动向」在「最近动向(地点)」之前，First() 取到的是真实时间行
+			"lastAccessAt": {
+				Selector: []string{
+					"td.rowhead:contains('最近动向') + td",
+					"td.rowhead:contains('最近動向') + td",
+					"td.rowhead:contains('上次访问') + td",
+					"td.rowhead:contains('Last access') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowup"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		TableRows: "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:     "table.torrentname a[href*='details.php']",
+		TitleLink: "table.torrentname a[href*='details.php']",
+		// 副标题为 <br /> 之后的裸文本节点，需要走 innerHTML + 正则
+		SubtitleSelector: &v2.FieldSelector{
+			Selector: []string{"table.torrentname td.embedded"},
+			Attr:     "html",
+			Filters: []v2.Filter{
+				{Name: "regex", Args: []any{`<br\s*/?>\s*([^<]+)`}},
+				{Name: "trim"},
+			},
+		},
+		// 「进度」列排在第 9 位，不影响以下 5~8 列
+		Size:               "td.rowfollow:nth-child(5)",
+		Seeders:            "td.rowfollow:nth-child(6)",
+		Leechers:           "td.rowfollow:nth-child(7)",
+		Snatched:           "td.rowfollow:nth-child(8)",
+		DiscountIcon:       "img.pro_free, img.pro_free2up, img.pro_50pctdown, img.pro_30pctdown, img.pro_2up, img.pro_50pctdown2up",
+		Category:           "td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:         "td.rowfollow:nth-child(4) span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords: []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		// 详情页存在隐藏 input，标题/ID 直接读 value
+		TitleSelector:    "input[name='torrent_name']",
+		IDSelector:       "input[name='detail_torrent_id']",
+		DiscountSelector: "h1 font[class]",
+		EndTimeSelector:  "h1 span[title]",
+		// ParseSizeMB 取该元素的 Next() 兄弟节点文本，因此必须指向标签单元格本身
+		SizeSelector: "td.rowhead:contains('基本信息')",
+		SizeRegex:    `大小[：:][^\d]*([\d.]+)\s*(GB|MB|KB|TB)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(Et8Definition)
+}

--- a/site/v2/definitions/et8_fixture_test.go
+++ b/site/v2/definitions/et8_fixture_test.go
@@ -1,0 +1,321 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "et8",
+		Search:   testEt8Search,
+		Detail:   testEt8Detail,
+		UserInfo: testEt8UserInfo,
+	})
+}
+
+// --- Fixtures ---
+//
+// 结构取自 et8.org 真实页面（浏览器扩展采集），所有用户名 / ID / 标题均已改为虚构值。
+// 列表页共 10 列，第 9 列为 et8 特有的「进度」列（真实页面中该单元格无 rowfollow class）。
+
+// 真实页面上只有限时优惠（2X 免费）才带 onmouseover tooltip 与可见「剩余时间」；
+// pro_free / pro_50pctdown / pro_30pctdown / pro_2up 均为长期优惠，无结束时间。
+const et8SearchFixture = `<html><body>
+<table class="torrents" cellspacing="0" cellpadding="5" width="100%" id="torrenttable">
+<tr>
+<td class="colhead" style="padding: 0px">类型</td>
+<td class="colhead"><a href="?sort=1&amp;type=asc">标题</a></td>
+<td class="colhead"><img class="comments" alt="comments" title="评论数" /></td>
+<td class="colhead"><img class="time" alt="time" title="存活时间" /></td>
+<td class="colhead"><img class="size" alt="size" title="大小" /></td>
+<td class="colhead"><img class="seeders" alt="seeders" title="种子数" /></td>
+<td class="colhead"><img class="leechers" alt="leechers" title="下载数" /></td>
+<td class="colhead"><img class="snatched" alt="snatched" title="完成数" /></td>
+<td class="colhead">进度</td>
+<td class="colhead"><a href="?sort=9&amp;type=desc">发布者</a></td>
+</tr>
+<tr>
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=622" title="Movies.电影"><img class="movies" src="pic/cattrans.gif" alt="Movies.电影" /></a></td>
+<td class="rowfollow" width="100%" align="left"><table class="torrentname" width="100%"><tr><td class="embedded"><font color=red>[置顶++]</font>&nbsp;<a title="[TCCF首发]Example.Movie.1936.BluRay.1080p.DD1.0.x264-EXGRP"  href="details.php?id=90001&amp;hit=1"><b>[TCCF首发]Example.Movie.1936.BluRay.1080p.DD1.0.x264-EXGRP</b></a><b> (<font class='new'>新</font>)</b> <b>[<font class='hot'>热门</font>]</b> <img class="pro_free2up" src="pic/trans.gif" alt="2X Free"  onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;twoupfree&quot;&gt;2X免费&lt;/font&gt;&lt;/b&gt;剩余时间：&lt;b&gt;&lt;span title=&quot;2026-07-29 14:25:51&quot;&gt;1天23时&lt;/span&gt;&lt;/b&gt;', 'trail', false, 'delay',500,'lifetime',3000,'fade','both','styleClass','niceTitle', 'fadeMax',87, 'maxWidth', 300);" />&nbsp;剩余时间：<b><span title="2026-07-29 14:25:51">1天23时</span></b><br />示例电影[全新修复完整版|原盘压制|简英字幕]</td><td width="20" class="embedded" style="text-align: right; " valign="middle"><a href="download.php?id=90001"><img class="download" src="pic/trans.gif" alt="download" title="下载本种" /></a></td>
+</tr></table></td><td class="rowfollow"><a href="comment.php?action=add&amp;pid=90001&amp;type=torrent" title="添加评论">0</a></td><td class="rowfollow nowrap"><span title="2026-07-27 14:25:51">45分</span></td><td class="rowfollow">4.17<br />GB</td><td class="rowfollow" align="center"><b><a href="details.php?id=90001&amp;hit=1&amp;dllist=1#seeders"><font color="">22</font></a></b></td>
+<td class="rowfollow"><b><a href="details.php?id=90001&amp;hit=1&amp;dllist=1#leechers">6</a></b></td>
+<td class="rowfollow"><a href="viewsnatches.php?id=90001"><b>23</b></a></td>
+<td align="center">-</td><td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr>
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=633" title="Elearning - 电子书/非小说"><img class="elearning" src="pic/cattrans.gif" alt="Elearning - 电子书/非小说" /></a></td>
+<td class="rowfollow" width="100%" align="left"><table class="torrentname" width="100%"><tr><td class="embedded"><a title="Example.Cartoon.Idioms.Collection"  href="details.php?id=90002&amp;hit=1"><b>Example.Cartoon.Idioms.Collection</b></a> <img class="pro_free" src="pic/trans.gif" alt="Free" title="免费" /><br />示例成語動畫</td><td width="20" class="embedded" style="text-align: right; " valign="middle"><a href="download.php?id=90002"><img class="download" src="pic/trans.gif" alt="download" title="下载本种" /></a></td>
+</tr></table></td><td class="rowfollow"><a href="comment.php?action=add&amp;pid=90002&amp;type=torrent" title="添加评论">0</a></td><td class="rowfollow nowrap"><span title="2026-07-20 09:12:00">7天<br />5时</span></td><td class="rowfollow">88.5<br />MB</td><td class="rowfollow" align="center"><b><a href="details.php?id=90002&amp;hit=1&amp;dllist=1#seeders"><font color="">5</font></a></b></td>
+<td class="rowfollow">1</td>
+<td class="rowfollow"><a href="viewsnatches.php?id=90002"><b>12</b></a></td>
+<td align="center">-</td><td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr>
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=624" title="Documentaries.纪录片"><img class="documentaries" src="pic/cattrans.gif" alt="Documentaries.纪录片" /></a></td>
+<td class="rowfollow" width="100%" align="left"><table class="torrentname" width="100%"><tr><td class="embedded"><a title="Example.Nature.2026.E205.1080p.HDTV.H264.AAC-EXEDU"  href="details.php?id=90003&amp;hit=1"><b>Example.Nature.2026.E205.1080p.HDTV.H264.AAC-EXEDU</b></a> <img class="pro_50pctdown" src="pic/trans.gif" alt="50%" title="50%" /><br />示例纪录片 | 2026年 第205期 | [国语/中字]</td><td width="20" class="embedded" style="text-align: right; " valign="middle"><a href="download.php?id=90003"><img class="download" src="pic/trans.gif" alt="download" title="下载本种" /></a></td>
+</tr></table></td><td class="rowfollow"><a href="comment.php?action=add&amp;pid=90003&amp;type=torrent" title="添加评论">0</a></td><td class="rowfollow nowrap"><span title="2026-07-26 22:00:29">17时<br />11分</span></td><td class="rowfollow">2.79<br />GB</td><td class="rowfollow" align="center"><b><a href="details.php?id=90003&amp;hit=1&amp;dllist=1#seeders"><font color="">18</font></a></b></td>
+<td class="rowfollow">0</td>
+<td class="rowfollow"><a href="viewsnatches.php?id=90003"><b>30</b></a></td>
+<td align="center">-</td><td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr>
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=633" title="Elearning - 杂项学习 "><img class="elearning" src="pic/cattrans.gif" alt="Elearning - 杂项学习 " /></a></td>
+<td class="rowfollow" width="100%" align="left"><table class="torrentname" width="100%"><tr><td class="embedded"><a title="Example.Textbook.Grade2.Chinese"  href="details.php?id=90004&amp;hit=1"><b>Example.Textbook.Grade2.Chinese</b></a><br />示例國小國語2上電子教科書</td><td width="20" class="embedded" style="text-align: right; " valign="middle"><a href="download.php?id=90004"><img class="download" src="pic/trans.gif" alt="download" title="下载本种" /></a></td>
+</tr></table></td><td class="rowfollow"><a href="comment.php?action=add&amp;pid=90004&amp;type=torrent" title="添加评论">0</a></td><td class="rowfollow nowrap"><span title="2026-07-13 07:09:27">14天<br />8时</span></td><td class="rowfollow">11.12<br />GB</td><td class="rowfollow" align="center"><b><a href="details.php?id=90004&amp;hit=1&amp;dllist=1#seeders"><font color="">4</font></a></b></td>
+<td class="rowfollow">0</td>
+<td class="rowfollow"><a href="viewsnatches.php?id=90004"><b>9</b></a></td>
+<td align="center">-</td><td class="rowfollow"><i>匿名</i></td>
+</tr>
+</table>
+</body></html>`
+
+const et8IndexFixture = `<html><body>
+<table id="info_block" cellpadding="4" cellspacing="0" border="0" width="100%"><tr>
+<td><table width="100%" cellspacing="0" cellpadding="0" border="0"><tr>
+<td class="bottom" align="left"><span class="medium">欢迎回来, <span class="nowrap"><a  href="userdetails.php?id=10086" class='VeteranUser_Name'><b>fixture_user</b></a></span>  [<a href="logout.php">退出</a>]  [<a href="torrents.php?inclbookmarked=1&amp;allsec=1">收藏</a>] <font class = 'color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 1,219,747.6 <font class = 'color_invite'>邀请 </font>[<a href="invite.php?id=10086">发送</a>]: 4<br />
+<font class="color_ratio">分享率：</font> 3.907  <font class = 'color_uploaded'>上传量：</font> 3.913 TB<font class='color_downloaded'> 下载量：</font> 1.001 TB  <font class='color_active'>当前活动：</font> <img class="arrowup" alt="Torrents seeding" title="当前做种" src="pic/trans.gif" />285  <img class="arrowdown" alt="Torrents leeching" title="当前下载" src="pic/trans.gif" />0&nbsp;&nbsp;<font class = 'color_connectable'>可连接：</font><a href="https://et8.org/faq.php#id21"><b><font color="green">是</font></b></a></span></td>
+</tr></table></td>
+</tr></table>
+</body></html>`
+
+const et8UserdetailsFixture = `<html><body>
+<table>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">等级</td><td width="99%" class="rowfollow" valign="top" align="left"><img alt="养老族" title="养老族" src="pic/retiree.gif" /> &nbsp;86</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">邀请</td><td class="rowfollow" valign="top" align="left">26</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">加入日期</td><td width="99%" class="rowfollow" valign="top" align="left">2012-05-29 18:35:08 (<span title="2012-05-29 18:35:08">14年4月前</span>)</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">最近动向</td><td width="99%" class="rowfollow" valign="top" align="left">2026-07-18 15:48:13 (<span title="2026-07-18 15:48:13">8天23时前</span>)</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">最近动向(地点)</td><td width="99%" class="rowfollow" valign="top" align="left"></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">传输</td><td width="99%" class="rowfollow" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>分享率</strong>:  <font color="">82.107</font></td><td class="embedded">&nbsp;&nbsp;<img src="pic/smilies/super.gif" alt="" /></td></tr><tr><td class="embedded"><strong>上传量</strong>:  389.081 TB</td><td class="embedded">&nbsp;&nbsp;<strong>下载量</strong>:  4.739 TB</td></tr></table></td></tr>
+</table>
+</body></html>`
+
+// 详情页真实样本为 2X 免费（h1 中的 class 是 twoupfree，而非 free）
+const et8DetailFixture = `<html><body>
+<h1 align="center" id="top"><font color=red>[置顶++]</font> [TCCF首发]Example.Movie.1936.BluRay.1080p.DD1.0.x264-EXGRP <b>[<font class='twoupfree'  onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;twoupfree&quot;&gt;2X免费&lt;/font&gt;&lt;/b&gt;剩余时间：&lt;b&gt;&lt;span title=&quot;2026-07-29 14:25:51&quot;&gt;1天23时&lt;/span&gt;&lt;/b&gt;', 'trail', false, 'delay',500,'lifetime',3000,'fade','both','styleClass','niceTitle', 'fadeMax',87, 'maxWidth', 300);">2X免费</font>]</b>&nbsp;剩余时间：<b><span title="2026-07-29 14:25:51">1天23时</span></b></h1>
+<table>
+<tr><td class="rowhead" width="13%">下载</td><td class="rowfollow" width="87%" align="left"><a class="index" href="download.php?id=90001">[TCCF].Example.Movie.1936.BluRay.1080p.DD1.0.x264-EXGRP.torrent</a></td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">副标题</td><td class="rowfollow" valign="top" align="left">示例电影[全新修复完整版|原盘压制|简英字幕]</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">基本信息</td><td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>4.17 GB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;Movies.电影&nbsp;&nbsp;&nbsp;<b>媒介:&nbsp;</b>Encode&nbsp;&nbsp;&nbsp;<b>编码:&nbsp;</b>x264&nbsp;&nbsp;&nbsp;<b>分辨率:&nbsp;</b>1080p</td></tr>
+</table>
+<form><input type="hidden" name="torrent_name" value="[TCCF首发]Example.Movie.1936.BluRay.1080p.DD1.0.x264-EXGRP" />
+<input type="hidden" name="detail_torrent_id" value="90001" />
+<input type="hidden" name="in_detail" value="in_detail" /></form>
+</body></html>`
+
+// 无优惠种子：h1 中仅有无 class 的 <font color=red>，DiscountSelector 不应误命中
+const et8DetailNoPromoFixture = `<html><body>
+<h1 align="center" id="top">Example.Textbook.Grade2.Chinese</h1>
+<table>
+<tr><td class="rowhead nowrap" valign="top" align="right">基本信息</td><td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>88.5 MB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;Elearning&nbsp;&nbsp;&nbsp;<b>媒介:&nbsp;</b>Other</td></tr>
+</table>
+<form><input type="hidden" name="torrent_name" value="Example.Textbook.Grade2.Chinese" />
+<input type="hidden" name="detail_torrent_id" value="90003" /></form>
+</body></html>`
+
+// --- Helpers ---
+
+func getEt8Def(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("et8")
+	require.True(t, ok, "et8 definition not found")
+	return def
+}
+
+// --- Suite: Search ---
+
+func testEt8Search(t *testing.T) {
+	def := getEt8Def(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(et8SearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{
+		BaseURL:   server.URL,
+		Cookie:    "test_cookie=1",
+		Selectors: def.Selectors,
+	})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: "GET"})
+	require.NoError(t, err)
+
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 4, "should parse 4 torrent rows (colhead row excluded)")
+
+	twoUpFree := items[0]
+	assert.Equal(t, "90001", twoUpFree.ID)
+	assert.Equal(t, "[TCCF首发]Example.Movie.1936.BluRay.1080p.DD1.0.x264-EXGRP", twoUpFree.Title)
+	assert.Equal(t, "示例电影[全新修复完整版|原盘压制|简英字幕]", twoUpFree.Subtitle)
+	assert.Equal(t, v2.Discount2xFree, twoUpFree.DiscountLevel)
+	// 站点未把结束时间放进独立可选中的元素，只能从 onmouseover tooltip 的实体编码里兜底解析
+	require.False(t, twoUpFree.DiscountEndTime.IsZero(), "discount end time should come from onmouseover tooltip")
+	assert.Equal(t, "2026-07-29 14:25:51", twoUpFree.DiscountEndTime.Format("2006-01-02 15:04:05"))
+	assert.Equal(t, "Movies.电影", twoUpFree.Category)
+	assert.Equal(t, 22, twoUpFree.Seeders)
+	assert.Equal(t, 6, twoUpFree.Leechers)
+	assert.Equal(t, 23, twoUpFree.Snatched)
+	// 大小单元格为 "4.17<br />GB"
+	assert.Equal(t, int64(4477503406), twoUpFree.SizeBytes)
+	assert.NotZero(t, twoUpFree.UploadedAt, "upload time should be parsed from td4 span[title]")
+
+	free := items[1]
+	assert.Equal(t, "90002", free.ID)
+	assert.Equal(t, "Example.Cartoon.Idioms.Collection", free.Title)
+	assert.Equal(t, "示例成語動畫", free.Subtitle)
+	assert.Equal(t, v2.DiscountFree, free.DiscountLevel)
+	assert.True(t, free.DiscountEndTime.IsZero(), "长期免费无结束时间")
+	assert.Equal(t, 5, free.Seeders)
+	assert.Equal(t, 1, free.Leechers)
+	assert.Equal(t, 12, free.Snatched)
+	assert.Equal(t, int64(92798976), free.SizeBytes)
+
+	halfDown := items[2]
+	assert.Equal(t, "90003", halfDown.ID)
+	assert.Equal(t, "示例纪录片 | 2026年 第205期 | [国语/中字]", halfDown.Subtitle)
+	assert.Equal(t, v2.DiscountPercent50, halfDown.DiscountLevel)
+	assert.True(t, halfDown.DiscountEndTime.IsZero())
+	assert.Equal(t, "Documentaries.纪录片", halfDown.Category)
+	assert.Equal(t, 18, halfDown.Seeders)
+	assert.Equal(t, 0, halfDown.Leechers)
+	assert.Equal(t, 30, halfDown.Snatched)
+	assert.Equal(t, int64(2995739688), halfDown.SizeBytes)
+
+	plain := items[3]
+	assert.Equal(t, "90004", plain.ID)
+	assert.Equal(t, "示例國小國語2上電子教科書", plain.Subtitle)
+	assert.Equal(t, v2.DiscountNone, plain.DiscountLevel)
+	assert.True(t, plain.DiscountEndTime.IsZero())
+	assert.Equal(t, 4, plain.Seeders)
+	assert.Equal(t, 0, plain.Leechers)
+	assert.Equal(t, 9, plain.Snatched)
+	assert.Equal(t, int64(11940009082), plain.SizeBytes)
+}
+
+// --- Suite: Detail ---
+
+func testEt8Detail(t *testing.T) {
+	def := getEt8Def(t)
+
+	t.Run("TwoUpFree", func(t *testing.T) {
+		doc := FixtureDoc(t, "et8_detail", et8DetailFixture)
+		parser := v2.NewNexusPHPParserFromDefinition(def)
+		info := parser.ParseAll(doc.Selection)
+
+		assert.Equal(t, "90001", info.TorrentID)
+		assert.Equal(t, "[TCCF首发]Example.Movie.1936.BluRay.1080p.DD1.0.x264-EXGRP", info.Title)
+		assert.NotEmpty(t, info.Title)
+		assert.Equal(t, v2.Discount2xFree, info.DiscountLevel)
+		require.False(t, info.DiscountEnd.IsZero(), "discount end time should be parsed from h1 span[title]")
+		assert.Equal(t, "2026-07-29 14:25:51", info.DiscountEnd.Format("2006-01-02 15:04:05"))
+		// 4.17 GB -> MB（不是 0，也不是 4.17）
+		assert.InDelta(t, 4.17*1024, info.SizeMB, 0.1)
+		assert.False(t, info.HasHR, "et8 无 H&R")
+	})
+
+	t.Run("NoPromotion", func(t *testing.T) {
+		doc := FixtureDoc(t, "et8_detail_nopromo", et8DetailNoPromoFixture)
+		parser := v2.NewNexusPHPParserFromDefinition(def)
+		info := parser.ParseAll(doc.Selection)
+
+		assert.Equal(t, "90003", info.TorrentID)
+		assert.Equal(t, "Example.Textbook.Grade2.Chinese", info.Title)
+		assert.Equal(t, v2.DiscountNone, info.DiscountLevel)
+		assert.True(t, info.DiscountEnd.IsZero())
+		assert.InDelta(t, 88.5, info.SizeMB, 0.1)
+		assert.False(t, info.HasHR)
+	})
+}
+
+// --- Suite: UserInfo ---
+
+func testEt8UserInfo(t *testing.T) {
+	def := getEt8Def(t)
+	driver := newTestNexusPHPDriver(def)
+
+	t.Run("IndexPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "et8_index", et8IndexFixture)
+		fields := map[string]string{
+			"id":       "10086",
+			"name":     "fixture_user",
+			"seeding":  "285",
+			"leeching": "0",
+			// parseNumber 产出 float64，toString 用 %v 渲染，量级达到 1e6 后为科学计数法；
+			// setUserInfoField 再走 strconv.ParseFloat 还原，见下方 bonus_roundtrip
+			"bonus": "1.2197476e+06",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				got := driver.ExtractFieldValuePublic(doc, sel)
+				assert.Equal(t, expected, got)
+			})
+		}
+
+		t.Run("bonus_roundtrip", func(t *testing.T) {
+			got := driver.ExtractFieldValuePublic(doc, def.UserInfo.Selectors["bonus"])
+			f, err := strconv.ParseFloat(got, 64)
+			require.NoError(t, err)
+			assert.InDelta(t, 1219747.6, f, 0.01)
+		})
+	})
+
+	t.Run("UserdetailsPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "et8_userdetails", et8UserdetailsFixture)
+		exact := map[string]string{
+			"uploaded":     "427799083646713", // 389.081 TB
+			"downloaded":   "5210585604030",   // 4.739 TB
+			"ratio":        "82.107",
+			"levelName":    "养老族",
+			"joinTime":     "1338287708", // 2012-05-29 18:35:08 +0800
+			"lastAccessAt": "1784360893", // 2026-07-18 15:48:13 +0800
+		}
+		for field, expected := range exact {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				got := driver.ExtractFieldValuePublic(doc, sel)
+				assert.Equal(t, expected, got)
+			})
+		}
+
+		// 保号探测（lastAccessAt）必须产出正数时间戳
+		t.Run("lastAccessAt_positive", func(t *testing.T) {
+			sel := def.UserInfo.Selectors["lastAccessAt"]
+			got := driver.ExtractFieldValuePublic(doc, sel)
+			ts, err := strconv.ParseInt(got, 10, 64)
+			require.NoError(t, err, "lastAccessAt 应为 Unix 时间戳字符串，实际 %q", got)
+			assert.Greater(t, ts, int64(0), "lastAccessAt 必须 > 0，否则保号探测会失败")
+		})
+	})
+}
+
+// --- Standalone Tests ---
+
+func TestEt8_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":         et8SearchFixture,
+		"index":          et8IndexFixture,
+		"userdetails":    et8UserdetailsFixture,
+		"detail":         et8DetailFixture,
+		"detail_nopromo": et8DetailNoPromoFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			RequireNoSecrets(t, name, data)
+		})
+	}
+}

--- a/tools/browser-extension/src/core/constants.ts
+++ b/tools/browser-extension/src/core/constants.ts
@@ -508,6 +508,33 @@ export const KNOWN_SITES: KnownSite[] = [
     cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
     syncField: "cookie",
   },
+  {
+    id: "discfan",
+    name: "DiscFan",
+    domains: ["discfan.net"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
+  {
+    id: "et8",
+    name: "TCCF",
+    domains: ["et8.org"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
+  {
+    id: "eastgame",
+    name: "TLFBits",
+    domains: ["pt.eastgame.org"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
 ];
 
 export const PAGE_PATTERNS: Array<{ pattern: RegExp; pageType: PageType }> = [


### PR DESCRIPTION
## Summary

新增三个 NexusPHP 站点适配，关联 issue #494、#496、#502。

这是站点请求批量适配的第一批。全部使用现有共享解析能力，**未修改任何共享代码**。

| 站点 | ID | 域名 | Issue |
|---|---|---|---|
| DiscFan（碟粉） | `discfan` | discfan.net | #494 |
| TCCF（TorrentCCF） | `et8` | et8.org | #496 |
| TLFBits（TLF） | `eastgame` | pt.eastgame.org | #502 |

三站均为标准 NexusPHP 表格布局，Cookie 认证，无 H&R。

## 各站特殊点

**DiscFan — 繁体界面**

传输行标签既不是简体「传输」也不是繁体「傳輸」，而是**「傳送」**。这是勘查阶段两种常见写法都匹配不到的原因。体积标签行为 `基本資訊` 而非 `基本信息`，等级为 `等級`，最近动向为 `最近動向`。选择器按「繁体优先 + 简体兜底」排列，兼容站点改版。

副标题正则需额外跳过 `<br />` 后的语言标签 chip（`<span>粤语</span><span>国语</span>`），否则会把「粤语」当成副标题。

**TCCF — 种子列表含额外进度列**

列表有 10 列，第 9 列是本站特有的「进度」列，发布者列因此位于第 10 位。由于进度列排在 size/seeders/leechers/snatched 之后，前 8 列索引不受影响。

详情页样本的优惠 class 是 `twoupfree`（2X 免费）而非 `free`，全页无任何 `class='free'`。

优惠结束时间只有限时种子才有：真实页 35 个优惠种子中仅 3 个带结束时间，其余 `pro_free` / `pro_50pctdown` / `pro_30pctdown` / `pro_2up` 均为长期优惠。故不设 `DiscountEndTime`，交由驱动的 `parseDiscountEndTimeFromOnmouseover` 兜底——若改用可见 span，选择器极易误命中同行第 4 列的发布时间 span。

**TLFBits — 标准布局**

三站中最规整。种子行可能带多个 `img.sticky` 及 `(新)`、`[热门]` 装饰，选择器已确认不受干扰。

## Verification

**真实页面探针**（关键验证，非手写 fixture）

直接用用户采集的原始 HTML 解析：

| 站点 | 详情页 SizeMB | 换算校验 | 优惠 | 列表页解析 |
|---|---|---|---|---|
| DiscFan | `192819.20` | 188.30 × 1024 | FREE | 57/57 行，副标题全非空 |
| TCCF | `4270.08` | 4.17 × 1024 | 2XFREE | 100/100 行，无零大小 |
| TLFBits | `1996.80` | 1.95 × 1024 | FREE | 100/100 行 |

三站体积均正确换算，既非 0（正则不匹配）也非原始数值（单位未换算）。

**自动化检查**

- `node --experimental-strip-types scripts/check-sites.ts` → Go 与扩展**双侧 57**，`✅ Built-in sites are in sync.`
- `go test ./... -count=1` → exit 0，40 个包通过，0 FAIL
- `TestAllSites_FixtureCoverage/{discfan,et8,eastgame}` → 三站 Search / Detail / UserInfo 全部通过
- `make lint-go` → 0 issues
- `make fmt-check` → 全部文件格式正确
- 扩展 `pnpm typecheck` / `pnpm test` → 通过（7/7）
- 共享解析器 `nexusphp_parser.go` / `nexusphp_driver.go` → 未改动

fixture 全部脱敏：用户名、用户 ID、图片域名均替换为虚构值，各站含 `NoSecrets` 测试。

## 发现的扩展缺陷（另行处理）

适配 TLFBits 时发现，扩展的 passkey 脱敏器会**破坏导出的 HTML**：

```html
<a href='download.php?id=113372&passkey=REMOVED&passkey=REMOVED</a></td></tr>
```

收尾的 `'>` 被一并吃掉，属性未终止，解析器连带吞掉后续多个 table 行（副标题、基本信息、行为、字幕），隐藏域与体积行随之消失。首次探针因此得到 `ID="" Title="" SizeMB=0`，在内存中修复该字符串后全部正常——选择器无误，是导出数据损坏。

该缺陷会静默影响每一个含 passkey 链接的站点请求，将单独开 issue 跟踪，不在本 PR 范围内。

## 未能从采集数据验证的项

- 三站均未配置 `LevelRequirements`：采集数据只显示当前等级，无等级门槛表，不做臆造
- 三站均未开启 H&R：`hitandrun` 在全部 9 个页面中 0 次出现
- 部分优惠类名（如 `pro_50pctdown2up`）样本中未出现，仅按 NexusPHP 通用约定保留在选择器中
- `bonusPerHour` 未配置：三站均未采集 `mybonus.php`