### PR TITLE
feat(site): 新增四个站点适配并修复采集脱敏缺陷

### DIFF
--- a/docs/sites.md
+++ b/docs/sites.md
@@ -1,8 +1,8 @@
 ## 支持站点
 
-当前已适配 **57** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
+当前已适配 **61** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
 
-### NexusPHP 系列（53）
+### NexusPHP 系列（57）
 
 | 站点                  | 认证方式 | 支持功能                      | 适配情况 | 备注                                                             |
 | --------------------- | -------- | ----------------------------- | -------- | ---------------------------------------------------------------- |
@@ -59,6 +59,10 @@
 | **DiscFan**           | Cookie   | RSS、搜索、用户信息           | ✅       | 碟粉（discfan.net，繁体界面，issue #494）                        |
 | **TCCF**              | Cookie   | RSS、搜索、用户信息           | ✅       | TorrentCCF（et8.org，种子列表含进度列，issue #496）              |
 | **TLFBits**           | Cookie   | RSS、搜索、用户信息           | ✅       | TLF / The Last Fantasy（pt.eastgame.org，issue #502）            |
+| **LuckPT**            | Cookie   | RSS、搜索、用户信息           | ✅       | pt.luckpt.de（issue #498）                                       |
+| **青蛙**              | Cookie   | RSS、搜索、用户信息           | ✅       | QingWaPT（www.qingwapt.com，自定义 span 优惠标签，issue #501）   |
+| **RailgunPT**         | Cookie   | RSS、搜索、用户信息           | ✅       | 站名与域名不一致（bilibili.download，issue #500）                |
+| **HDArea**            | Cookie   | RSS、搜索、用户信息           | ✅       | 高清视界（hdarea.club，issue #495）                              |
 
 ### 其他架构（4）
 

--- a/site/v2/definitions/hdarea.go
+++ b/site/v2/definitions/hdarea.go
@@ -1,0 +1,207 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+// HdareaDefinition 描述 HDArea（hdarea.club）站点。
+//
+// 站点为 NexusPHP 1.5 魔改（页面自称 "Powered by HDAREA(基于NexusPHP1.5修改)"），详情页保留
+// input[name='torrent_name'] / input[name='detail_torrent_id'] 隐藏域，userdetails.php 的
+// 「传输」行是标准的 <strong>上传量</strong> 合并单元格，因此多数选择器与 btschool 一致。
+// 需要单独适配的三处：
+//
+//  1. torrents.php 上存在 **两个** table.torrents：
+//     第一个是「预告区（前 5 最新预告）」面板，表头为 td.colhead_notice（colspan=10），
+//     内容藏在 tbody#kokk 里；第二个才是真正的种子列表，表头为 10 个 td.colhead。
+//     若按常规写 `table.torrents > tbody > tr:has(table.torrentname)`，预告区一旦有内容
+//     就会被一起解析进来，因此这里用 :has(td.colhead) 把范围锁死在真实列表表格。
+//  2. 副标题是名称单元格内的第二个 <div>，带 title 属性（<div style="color: #666" title="...">），
+//     全页仅此一种 div[title]，可直接用普通字符串选择器命中。
+//  3. 促销结束时间以 (<font color='...'>剩余时间：<span title="..."></font>) 真实渲染，
+//     但同一子表里的豆瓣评分 <span title="豆瓣评分"> 也是 span[title]，必须用 font[color]
+//     限定范围；不同促销等级的 font color 取值不同（免费 #0000FF、2X 免费 #00CC66），
+//     故只判断属性存在而不判断取值。
+var HdareaDefinition = &v2.SiteDefinition{
+	ID:             "hdarea",
+	Name:           "HDArea",
+	Aka:            []string{"高清视界", "High Definition Area"},
+	Description:    "HDArea 高清设备交流分享平台",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://hdarea.club/"},
+	FaviconURL:     "https://hdarea.club/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "seeding", "leeching", "bonus"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields: []string{
+					"uploaded", "downloaded", "ratio",
+					"levelName", "joinTime", "lastAccessAt",
+				},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			"id": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php'][class*='Name']",
+					"a[href*='userdetails.php']",
+				},
+				Attr:    "href",
+				Filters: []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php'][class*='Name']",
+				},
+			},
+			// 「传输」行是合并单元格（内嵌 table），需以 html + regex 拆分：
+			// <strong>分享率</strong>: <font color="">5.603</font>
+			// <strong>上传量</strong>: 5.607 TB   <strong>下载量</strong>: 1.001 TB
+			"uploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>上传量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"downloaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>下载量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"ratio": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>分享率</strong>[：:\s]*(?:<font[^>]*>)?([\d.,]+|∞|Inf)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"levelName": {
+				Selector: []string{"td.rowhead:contains('等级') + td img", "td.rowhead:contains('等級') + td img"},
+				Attr:     "title",
+			},
+			// 魔力值只在 #info_block 渲染，且 class 属性带空格：
+			// <font class = 'color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 2,747,702.4
+			"bonus": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`魔力值\s*</font>\s*\[[^\]]*\]\s*[:：]\s*([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowup"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"joinTime": {
+				Selector: []string{
+					"td.rowhead:contains('加入日期') + td",
+					"td.rowhead:contains('Join') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+			// 保号探测只读取 UserInfo.LastAccess，缺失会导致线上探测解析失败。
+			// 本站 userdetails.php 只有一行「最近动向」，不存在同名的「(地点)」行。
+			"lastAccessAt": {
+				Selector: []string{
+					"td.rowhead:contains('最近动向') + td",
+					"td.rowhead:contains('最近動向') + td",
+					"td.rowhead:contains('上次访问') + td",
+					"td.rowhead:contains('Last access') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		// :has(td.colhead) 用于排除「预告区」表格（其表头是 td.colhead_notice）；
+		// tr:has(table.torrentname) 再排除真实列表自身的表头行。
+		TableRows: "table.torrents:has(td.colhead) > tbody > tr:has(table.torrentname), " +
+			"table.torrents:has(td.colhead) > tr:has(table.torrentname)",
+		Title:     "table.torrentname a[href*='details.php']",
+		TitleLink: "table.torrentname a[href*='details.php']",
+		// 副标题：名称单元格内带 title 的 div，全页唯一（100 行 100 个，无其它 div[title]）
+		Subtitle: "table.torrentname td.embedded > div[title]",
+		// 列序（colhead）：1 类型 2 海报 3 标题 4 评论数 5 存活时间 6 大小 7 种子数 8 下载数 9 完成数 10 发布者
+		Size:     "td.rowfollow:nth-child(6)",
+		Seeders:  "td.rowfollow:nth-child(7)",
+		Leechers: "td.rowfollow:nth-child(8)",
+		Snatched: "td.rowfollow:nth-child(9)",
+		// 实抓到 pro_free / pro_free2up，其余为 NexusPHP 通用促销图标类名。
+		// 不设置 DiscountMapping：驱动内置分支会先判 free2up 再判 free，
+		// 自定义 mapping 走的是无序 map 包含匹配，可能把 pro_free2up 误判为 free。
+		DiscountIcon: "img.pro_free, img.pro_free2up, img.pro_2up, img.pro_50pctdown, img.pro_50pctdown2up, img.pro_30pctdown",
+		// 限定在 font[color] 内，避免误取同一子表里的豆瓣评分 span[title="豆瓣评分"]；
+		// 若某些页面不渲染该 span，驱动会回退解析促销图标的 onmouseover 提示。
+		DiscountEndTime:    "table.torrentname font[color] span[title]",
+		Category:           "td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:         "td.rowfollow:nth-child(5) span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下载链接') + td a[href*='download.php'], td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords: []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		// 详情页保留隐藏域，标题/ID 直接取 value
+		TitleSelector: "input[name='torrent_name']",
+		IDSelector:    "input[name='detail_torrent_id']",
+		// h1#top 内促销标记为 <font class='free' >免费</font>（单引号 + 尾随空格），
+		// 解析器按 class token 匹配 DiscountMapping，能正确命中
+		DiscountSelector: "h1 font.free, h1 font[class]",
+		EndTimeSelector:  "h1 span[title]",
+		// ParseSizeMB 读取 SizeSelector 元素的 .Next() 兄弟节点，因此必须指向标签单元格；
+		// 单元格文本形如「大小：482.76 MB   类型: TV Series ...」，全角冒号，
+		// 单位放宽为 [KMGTP]i?B 以兼容站点混用二进制单位的情况
+		SizeSelector: "td.rowhead:contains('基本信息')",
+		SizeRegex:    `大小[：:][^\d]*([\d.]+)\s*([KMGTP]i?B)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(HdareaDefinition)
+}

--- a/site/v2/definitions/hdarea_fixture_test.go
+++ b/site/v2/definitions/hdarea_fixture_test.go
@@ -1,0 +1,353 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "hdarea",
+		Search:   testHdareaSearch,
+		Detail:   testHdareaDetail,
+		UserInfo: testHdareaUserInfo,
+	})
+}
+
+// --- Fixtures ---
+//
+// 结构照搬真实页面，但所有标题、副标题、种子 ID、用户名、用户 ID 和图片地址均已替换为虚构值。
+//
+// 搜索页需要覆盖的真实特征：
+//   - 页面上有 **两个** table.torrents：先是「预告区（前 5 最新预告）」面板
+//     （表头 td.colhead_notice + 内容藏在 tbody#kokk），再才是真正的种子列表（表头 td.colhead）。
+//     真实抓包时预告区为空，无法证明选择器是否越界，因此这里**故意**给预告区塞进一条
+//     带 table.torrentname 的行；若 TableRows 少了 :has(td.colhead)，解析结果会变成 3 条。
+//   - 名称单元格是两个 div：第一个 div 放标题 + 促销图标 + (剩余时间)，
+//     第二个 div 带 title 属性放副标题。
+//   - 促销结束时间同时出现在 img.pro_free 的 onmouseover 提示与
+//     (<font color='...'>剩余时间：<span title>) 中，且不同促销等级 font color 不同。
+//   - 名称子表第二个单元格（width=110）内有豆瓣评分 <span title="豆瓣评分">，
+//     它同样是 span[title]，必须不能被当成促销结束时间。
+//   - 列序为 10 列：类型 / 海报 / 标题 / 评论数 / 存活时间 / 大小 / 种子数 / 下载数 / 完成数 / 发布者。
+//   - 大小列是 "482.76<br />MB"（数字与单位被 <br /> 分开）。
+
+const hdareaSearchFixture = `<html><body>
+<table width="100%" class="main" border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded">
+<table class="torrents" cellspacing="0" cellpadding="5" width="100%">
+<tbody><tr><td class="colhead_notice" align="center" colspan="10"><a href="javascript: klappe_news('okk')"><img class="plus" src="pic/trans.gif" id="picokk" alt="Show/Hide" />预告区（前5最新预告）</a> - [<a href="advance_notice.php">更多</a>]</td></tr></tbody>
+<tbody id="kokk" style="display: none;">
+	<tr class='nonstick_outer_bg'>
+	<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=401"><img class="c_movie" src="pic/cattrans.gif" alt="Movies" title="Movies" /></a></td>
+	<td class="rowfollow" align="center" valign="middle" style="padding: 3px;"><img class="torrent-poster-thumb" src="pic/trans.gif" /></td>
+	<td class="rowfollow" width="100%" align="left"><table class="torrentname" width="100%"><tr><td class="embedded"><div style="display: flex; align-items: center; max-width: 775px;"><a title="Fixture.Advance.Notice.2026.1080p-FIXTURE" href="details.php?id=88109"><b>Fixture.Advance.Notice.2026.1080p-FIXTURE</b></a></div><div style="color: #666;" title="虚构预告区条目">虚构预告区条目</div></td></tr></table></td>
+	<td class="rowfollow">0</td>
+	<td class="rowfollow nowrap"><span title="2026-07-27 10:00:00">&lt; 1分</span></td>
+	<td class="rowfollow">1.00<br />GB</td>
+	<td class="rowfollow" align="center"><b>0</b></td>
+	<td class="rowfollow"><b>0</b></td>
+	<td class="rowfollow">0</td>
+	<td class="rowfollow"><i>匿名</i></td>
+	</tr>
+</tbody></table>
+</td></tr></table>
+<br />
+<table class="torrents" cellspacing="0" cellpadding="5" width="100%">
+<tr>
+<td class="colhead" style="padding: 0px">类型</td>
+<td class="colhead">海报</td>
+<td class="colhead"><a href="?sort=1&amp;type=asc">标题</a></td>
+<td class="colhead"><a href="?sort=3&amp;type=desc"><img class="comments" src="pic/trans.gif" alt="comments" title="评论数" /></a></td>
+<td class="colhead"><a href="?sort=4&amp;type=desc"><img class="time" src="pic/trans.gif" alt="time" title="存活时间" /></a></td>
+<td class="colhead"><a href="?sort=5&amp;type=desc"><img class="size" src="pic/trans.gif" alt="size" title="大小" /></a></td>
+<td class="colhead"><a href="?sort=7&amp;type=desc"><img class="seeders" src="pic/trans.gif" alt="seeders" title="种子数" /></a></td>
+<td class="colhead"><a href="?sort=8&amp;type=desc"><img class="leechers" src="pic/trans.gif" alt="leechers" title="下载数" /></a></td>
+<td class="colhead"><a href="?sort=6&amp;type=desc"><img class="snatched" src="pic/trans.gif" alt="snatched" title="完成数" /></a></td>
+<td class="colhead"><a href="?sort=9&amp;type=desc">发布者</a></td>
+</tr>
+<tr class='nonstick_outer_bg'>
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=402"><img class="c_tvseries" src="pic/cattrans.gif" alt="TV Series" title="TV Series" style="background-image: url(pic/catsprites.png);" /></a></td>
+<td class="rowfollow" align="center" valign="middle" style="padding: 3px;"><img class="torrent-poster-thumb lazy-loading" src="pic/trans.gif" data-src="pic/poster/fixture-a.jpg" /></td>
+<td class="rowfollow" width="100%" align="left"><table class="torrentname" width="100%"><tr class='nonstick_inner_bg'><td class="embedded"><div style="display: flex; align-items: center; max-width: 775px;"><a title="Fixture.Show.S01E03.2026.2160p.WEB-DL.H265-FIXTURE"  href="details.php?id=88101" style="min-width: 0; white-space: nowrap;"><b>Fixture.Show.S01E03.2026.2160p.WEB-DL.H265-FIXTURE</b></a><span style="flex-shrink: 0; white-space: nowrap;"><b> (<font class='new'>新</font>)</b> <img class="pro_free" src="pic/trans.gif" alt="Free"  onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;free&quot;&gt;免费&lt;/font&gt;&lt;/b&gt;剩余时间：&lt;b&gt;&lt;span title=&quot;2026-07-28 15:09:57&quot;&gt;23时59分&lt;/span&gt;&lt;/b&gt;', 'trail', false, 'delay',500,'lifetime',3000);" /> (<font color='#0000FF'>剩余时间：<span title="2026-07-28 15:09:57">23时59分</span></font>)</span></div><div style="color: #666; max-width: 775px; white-space: nowrap; padding-top: 2px;" title="虚构副标题一 第03集 | 国语 | 中字 | 官方">虚构副标题一 第03集 | 国语 | 中字 | 官方</div></td>
+<td width="110" class="embedded" style="text-align: right;" valign="middle">
+  <div style="display: flex; justify-content: flex-end; align-items: center; gap: 6px;">
+    <div><div style="display: flex; align-items: center;"><a href="https://example.invalid/subject/00000001/" target="_blank"><span style="display: inline-flex;" title="豆瓣评分"><span>豆瓣</span><span>0.0</span></span></a></div></div>
+    <div style="text-align: left; line-height: 1; flex-shrink: 0;"><a href="download.php?id=88101"><img class="download" src="pic/trans.gif" alt="download" title="下载本种" /></a>&nbsp<a href="download_zip.php?id=88101"><img class="download_zip" src="pic/trans.gif" alt="download_zip" title="打包下载" /></a></div>
+  </div>
+</td>
+</tr></table></td><td class="rowfollow"><a href="comment.php?action=add&amp;pid=88101&amp;type=torrent" title="添加评论">0</a></td><td class="rowfollow nowrap"><span title="2026-07-27 15:09:57">&lt; 1分</span></td><td class="rowfollow">482.76<br />MB</td><td class="rowfollow" align="center"><b><a href="details.php?id=88101&amp;dllist=1#seeders">1</a></b></td>
+<td class="rowfollow"><b><a href="details.php?id=88101&amp;dllist=1#leechers">2</a></b></td>
+<td class="rowfollow">3</td>
+<td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr class='nonstick_outer_bg'>
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=403"><img class="c_tvshows" src="pic/cattrans.gif" alt="TV Shows" title="TV Shows" style="background-image: url(pic/catsprites.png);" /></a></td>
+<td class="rowfollow" align="center" valign="middle" style="padding: 3px;"><img class="torrent-poster-thumb lazy-loading" src="pic/trans.gif" data-src="pic/poster/fixture-b.jpg" /></td>
+<td class="rowfollow" width="100%" align="left"><table class="torrentname" width="100%"><tr class='nonstick_inner_bg'><td class="embedded"><div style="display: flex; align-items: center; max-width: 775px;"><a title="Fixture.Variety.S01E06.2026.1080p.WEB-DL.H264-FIXTURE"  href="details.php?id=88102" style="min-width: 0; white-space: nowrap;"><b>Fixture.Variety.S01E06.2026.1080p.WEB-DL.H264-FIXTURE</b></a><span style="flex-shrink: 0; white-space: nowrap;"><b> (<font class='new'>新</font>)</b> <img class="pro_free2up" src="pic/trans.gif" alt="2X Free"  onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;twoupfree&quot;&gt;2X免费&lt;/font&gt;&lt;/b&gt;剩余时间：&lt;b&gt;&lt;span title=&quot;2026-07-28 14:08:49&quot;&gt;22时58分&lt;/span&gt;&lt;/b&gt;', 'trail', false, 'delay',500,'lifetime',3000);" /> (<font color='#00CC66'>剩余时间：<span title="2026-07-28 14:08:49">22时58分</span></font>)</span></div><div style="color: #666; max-width: 775px; white-space: nowrap; padding-top: 2px;" title="虚构副标题二 第06集 | 中字 | 官方">虚构副标题二 第06集 | 中字 | 官方</div></td>
+<td width="110" class="embedded" style="text-align: right;" valign="middle"><a href="download.php?id=88102"><img class="download" src="pic/trans.gif" alt="download" title="下载本种" /></a></td>
+</tr></table></td><td class="rowfollow"><a href="comment.php?action=add&amp;pid=88102&amp;type=torrent" title="添加评论">5</a></td><td class="rowfollow nowrap"><span title="2026-07-27 14:08:49">&lt; 1分</span></td><td class="rowfollow">2.05<br />GB</td><td class="rowfollow" align="center"><b><a href="details.php?id=88102&amp;dllist=1#seeders">12</a></b></td>
+<td class="rowfollow"><b><a href="details.php?id=88102&amp;dllist=1#leechers">4</a></b></td>
+<td class="rowfollow">6</td>
+<td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr class='nonstick_outer_bg'>
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=401"><img class="c_movie" src="pic/cattrans.gif" alt="Movies" title="Movies" style="background-image: url(pic/catsprites.png);" /></a></td>
+<td class="rowfollow" align="center" valign="middle" style="padding: 3px;"><img class="torrent-poster-thumb lazy-loading" src="pic/trans.gif" data-src="pic/poster/fixture-c.jpg" /></td>
+<td class="rowfollow" width="100%" align="left"><table class="torrentname" width="100%"><tr class='nonstick_inner_bg'><td class="embedded"><div style="display: flex; align-items: center; max-width: 775px;"><a title="Fixture.Movie.2026.BluRay.1080p.x264-FIXTURE"  href="details.php?id=88103" style="min-width: 0; white-space: nowrap;"><b>Fixture.Movie.2026.BluRay.1080p.x264-FIXTURE</b></a></div><div style="color: #666; max-width: 775px; white-space: nowrap; padding-top: 2px;" title="虚构副标题三 | 国语 | 中字">虚构副标题三 | 国语 | 中字</div></td>
+<td width="110" class="embedded" style="text-align: right;" valign="middle">
+  <div><a href="https://example.invalid/subject/00000003/" target="_blank"><span style="display: inline-flex;" title="豆瓣评分"><span>豆瓣</span><span>8.1</span></span></a></div>
+  <div><a href="download.php?id=88103"><img class="download" src="pic/trans.gif" alt="download" title="下载本种" /></a></div>
+</td>
+</tr></table></td><td class="rowfollow"><a href="comment.php?action=add&amp;pid=88103&amp;type=torrent" title="添加评论">1</a></td><td class="rowfollow nowrap"><span title="2026-07-20 08:30:00">7天</span></td><td class="rowfollow">16.87<br />GB</td><td class="rowfollow" align="center"><b><a href="details.php?id=88103&amp;dllist=1#seeders">88</a></b></td>
+<td class="rowfollow"><b><a href="details.php?id=88103&amp;dllist=1#leechers">0</a></b></td>
+<td class="rowfollow">120</td>
+<td class="rowfollow"><i>匿名</i></td>
+</tr>
+</table>
+</body></html>`
+
+// 详情页：标题/ID 来自「字幕」行 <form> 内的隐藏域（本站保留），h1#top 的促销标记为
+// <font class='free' >（单引号 + 尾随空格）；「基本信息」行使用全角冒号，且真实体积单位是 MB。
+const hdareaDetailFixture = `<html><body>
+<h1 align="center" id="top">Fixture.Show.S01E03.2026.2160p.WEB-DL.H265-FIXTURE&nbsp;&nbsp;&nbsp; <b>[<font class='free' >免费</font>]</b>&nbsp; (<font color='#0000FF'>剩余时间：<span title="2026-07-28 15:09:57">23时59分</span></font>)</h1>
+<table width="1280" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead" width="13%">下载</td><td class="rowfollow" width="87%" align="left"><a class="index" href="download.php?id=88101">[HDArea].Fixture.Show.S01E03.2026.2160p.WEB-DL.H265-FIXTURE.torrent</a>&nbsp;&nbsp;&nbsp;由&nbsp;<i>匿名</i>发布于<span title="2026-07-27 15:09:57">&lt; 1分前</span></td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">副标题</td><td class="rowfollow" valign="top" align="left">虚构副标题一 第03集 | 国语 | 中字 | 官方</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">基本信息</td><td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>482.76 MB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;TV Series&nbsp;&nbsp;&nbsp;<b>媒介:&nbsp;</b>WEB-DL&nbsp;&nbsp;&nbsp;<b>编码:&nbsp;</b>H.265(x265/HEVC)&nbsp;&nbsp;&nbsp;<b>分辨率:&nbsp;</b>4K</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">行为</td><td class="rowfollow" valign="top" align="left"><a title="下载种子" href="download.php?id=88101"><img class="dt_download" src="pic/trans.gif" alt="download" /></a></td></tr>
+<tr><td class="rowhead nowrap">下载链接</td><td valign="top" align="left" class="rowfollow">https://hdarea.club/download.php?id=88101&amp;passkey=FIXTUREPASSKEY<br /><strong style=color:#F00 >链接包含个人passkey, 请勿泄露</strong></td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><table border="0" cellspacing="0"><tr><td class="embedded"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Fixture.Show.S01E03.2026.2160p.WEB-DL.H265-FIXTURE" /><input type="hidden" name="detail_torrent_id" value="88101" /></form></td></tr></table></td></tr>
+</table>
+</body></html>`
+
+// 无促销 + 带 H&R 的详情页，用于确认促销为 DiscountNone、结束时间为零值，
+// 且体积单位为 GB 时能正确换算。
+const hdareaDetailWithHRFixture = `<html><body>
+<h1 align="center" id="top">Fixture.Movie.2026.BluRay.1080p.x264-FIXTURE</h1>
+<table width="1280" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead nowrap" valign="top" align="right">基本信息</td><td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>16.87 GB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;Movies</td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Fixture.Movie.2026.BluRay.1080p.x264-FIXTURE" /><input type="hidden" name="detail_torrent_id" value="88103" /></form></td></tr>
+</table>
+<img src="pic/hit_run.gif" alt="Hit and Run" />
+</body></html>`
+
+// index.php 顶部 #info_block：id / name / 魔力值 / 做种下载数均取自这里。
+// 注意 class 属性带空格（class = 'color_bonus'），与真实页面一致。
+const hdareaIndexFixture = `<html><body>
+<table id="info_block" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+	<td><table width="100%" cellspacing="0" cellpadding="4" border="0"><tr>
+		<td class="bottom12" align="left"><span class="medium">欢迎回来, <span class="nowrap"><a  href="userdetails.php?id=77001" class='VeteranUser_Name'><b>fixture_user</b></a></span>  [<a href="logout.php">退出</a>] <font class = 'color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 2,747,702.4 <font class = 'color_invite'>邀请 </font>[<a href="invite.php?id=77001">发送</a>]: 0<br />
+	<font class="color_ratio">分享率：</font> 5.603  <font class='color_uploaded'>上传量：</font> 5.607 TB<font class='color_downloaded'> 下载量：</font> 1.001 TB  <font class='color_active'>当前活动：</font> <img class="arrowup" alt="Torrents seeding" title="当前做种" src="pic/trans.gif" />487  <img class="arrowdown" alt="Torrents leeching" title="当前下载" src="pic/trans.gif" />0&nbsp;&nbsp;<font class='color_connectable'>可连接：</font><b><font color="green">是</font></b></span></td>
+	</tr></table></td>
+</tr></table>
+</body></html>`
+
+// userdetails.php 正文表格：「传输」行是标准的
+// <strong>分享率</strong> / <strong>上传量</strong> / <strong>下载量</strong> 合并单元格；
+// 「最近动向」只出现一次，不存在同名的「(地点)」行。
+const hdareaUserdetailsFixture = `<html><body>
+<h1 style='margin:0px'><span class="nowrap"><b>fixture_target</b></span></h1>
+<table width="100%" border="1" cellspacing="0" cellpadding="5">
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">邀请</td><td width="99%" class="rowfollow" valign="top" align="left">0</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">加入日期</td><td width="99%" class="rowfollow" valign="top" align="left">2025-12-13 21:58:57 (<span title="2025-12-13 21:58:57">7月15天前</span>)</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">最近动向</td><td width="99%" class="rowfollow" valign="top" align="left">2026-07-27 15:10:35 (<span title="2026-07-27 15:10:35">&lt; 1分前</span>)</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">BT客户端</td><td width="99%" class="rowfollow" valign="top" align="left">qBittorrent/5.1.2</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">传输</td><td width="99%" class="rowfollow" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>分享率</strong>:  <font color="">5.603</font></td><td class="embedded">&nbsp;&nbsp;<img src="pic/smilies/5.gif" alt="" /></td></tr><tr><td class="embedded"><strong>上传量</strong>:  5.607 TB</td><td class="embedded">&nbsp;&nbsp;<strong>下载量</strong>:  1.001 TB</td></tr></table></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">BT时间</td><td width="99%" class="rowfollow" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>做种时间</strong>:  1015天05:12:11</td><td class="embedded">&nbsp;&nbsp;<strong>下载时间</strong>:  61天03:44:02</td></tr></table></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">等级</td><td width="99%" class="rowfollow" valign="top" align="left"><img alt="Veteran User" title="Veteran User" src="pic/veteran.gif" /> </td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">魔力值</td><td width="99%" class="rowfollow" valign="top" align="left">2,747,702.4</td></tr>
+</table>
+</body></html>`
+
+// --- Helpers ---
+
+func getHdareaDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("hdarea")
+	require.True(t, ok, "hdarea definition not found")
+	return def
+}
+
+// --- Suite: Search ---
+
+func testHdareaSearch(t *testing.T) {
+	def := getHdareaDef(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(hdareaSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{
+		BaseURL:   server.URL,
+		Cookie:    "test_cookie=1",
+		Selectors: def.Selectors,
+	})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: "GET"})
+	require.NoError(t, err)
+
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	// 关键断言：fixture 里有 4 条 table.torrentname（预告区 1 条 + 真实列表 3 条），
+	// TableRows 必须只命中真实列表的 3 条。
+	require.Len(t, items, 3, "TableRows must skip the 预告区 table (expect 3, not 4)")
+	for _, it := range items {
+		require.NotEqual(t, "88109", it.ID, "预告区条目不应出现在搜索结果中")
+	}
+
+	free := items[0]
+	assert.Equal(t, "88101", free.ID)
+	assert.Equal(t, "Fixture.Show.S01E03.2026.2160p.WEB-DL.H265-FIXTURE", free.Title)
+	// 副标题是名称单元格内带 title 的第二个 div
+	assert.Equal(t, "虚构副标题一 第03集 | 国语 | 中字 | 官方", free.Subtitle)
+	assert.Equal(t, v2.DiscountFree, free.DiscountLevel)
+	// 大小列为 "482.76<br />MB"，parseSize 去空白后按 1024 进制换算
+	assert.Equal(t, int64(506210549), free.SizeBytes)
+	assert.Equal(t, 1, free.Seeders)
+	assert.Equal(t, 2, free.Leechers)
+	assert.Equal(t, 3, free.Snatched)
+	assert.Equal(t, "TV Series", free.Category)
+	// 促销结束时间取 (<font color>剩余时间：<span title>)，
+	// 不能误取第 5 列的存活时间 span，也不能误取豆瓣评分 span[title="豆瓣评分"]
+	require.False(t, free.DiscountEndTime.IsZero(), "discount end time should be parsed")
+	assert.Equal(t, "2026-07-28 15:09:57", free.DiscountEndTime.Format("2006-01-02 15:04:05"))
+	assert.Equal(t, int64(1785164997), free.UploadedAt)
+
+	// 2X 免费：内置分支先判 free2up，不会退化成 DiscountFree；font color 与免费不同
+	twoXFree := items[1]
+	assert.Equal(t, "88102", twoXFree.ID)
+	assert.Equal(t, v2.Discount2xFree, twoXFree.DiscountLevel)
+	assert.Equal(t, "虚构副标题二 第06集 | 中字 | 官方", twoXFree.Subtitle)
+	assert.Equal(t, int64(2201170739), twoXFree.SizeBytes)
+	assert.Equal(t, 12, twoXFree.Seeders)
+	assert.Equal(t, 4, twoXFree.Leechers)
+	assert.Equal(t, 6, twoXFree.Snatched)
+	require.False(t, twoXFree.DiscountEndTime.IsZero())
+	assert.Equal(t, "2026-07-28 14:08:49", twoXFree.DiscountEndTime.Format("2006-01-02 15:04:05"))
+
+	// 无促销行：即便名称子表里有豆瓣评分 span[title="豆瓣评分"]，结束时间也必须是零值
+	normal := items[2]
+	assert.Equal(t, "88103", normal.ID)
+	assert.Equal(t, "Fixture.Movie.2026.BluRay.1080p.x264-FIXTURE", normal.Title)
+	assert.Equal(t, "虚构副标题三 | 国语 | 中字", normal.Subtitle)
+	assert.Equal(t, v2.DiscountNone, normal.DiscountLevel)
+	assert.True(t, normal.DiscountEndTime.IsZero(), "no discount -> no end time (豆瓣评分 span must not leak)")
+	assert.Equal(t, int64(18114024570), normal.SizeBytes)
+	assert.Equal(t, 88, normal.Seeders)
+	assert.Equal(t, 0, normal.Leechers)
+	assert.Equal(t, 120, normal.Snatched)
+	assert.Equal(t, "Movies", normal.Category)
+}
+
+// --- Suite: Detail ---
+
+func testHdareaDetail(t *testing.T) {
+	def := getHdareaDef(t)
+
+	t.Run("Free", func(t *testing.T) {
+		doc := FixtureDoc(t, "hdarea_detail", hdareaDetailFixture)
+		info := v2.NewNexusPHPParserFromDefinition(def).ParseAll(doc.Selection)
+
+		assert.Equal(t, "88101", info.TorrentID)
+		assert.Equal(t, "Fixture.Show.S01E03.2026.2160p.WEB-DL.H265-FIXTURE", info.Title)
+		assert.Equal(t, v2.DiscountFree, info.DiscountLevel)
+		require.False(t, info.DiscountEnd.IsZero(), "discount end time should be parsed")
+		assert.Equal(t, "2026-07-28 15:09:57", info.DiscountEnd.Format("2006-01-02 15:04:05"))
+		// 「基本信息」标签单元格 + .Next() 兄弟节点；真实抓包体积单位是 MB，不做换算
+		assert.InDelta(t, 482.76, info.SizeMB, 0.01)
+		assert.False(t, info.HasHR)
+	})
+
+	t.Run("NoDiscountWithHR", func(t *testing.T) {
+		doc := FixtureDoc(t, "hdarea_detail_hr", hdareaDetailWithHRFixture)
+		info := v2.NewNexusPHPParserFromDefinition(def).ParseAll(doc.Selection)
+
+		assert.Equal(t, "88103", info.TorrentID)
+		assert.Equal(t, "Fixture.Movie.2026.BluRay.1080p.x264-FIXTURE", info.Title)
+		assert.Equal(t, v2.DiscountNone, info.DiscountLevel)
+		assert.True(t, info.DiscountEnd.IsZero())
+		assert.InDelta(t, 16.87*1024, info.SizeMB, 0.1)
+		assert.True(t, info.HasHR, "should detect HR from hit_run.gif")
+	})
+}
+
+// --- Suite: UserInfo ---
+
+func testHdareaUserInfo(t *testing.T) {
+	def := getHdareaDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	t.Run("IndexPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "hdarea_index", hdareaIndexFixture)
+		fields := map[string]string{
+			"id":       "77001",
+			"name":     "fixture_user",
+			"seeding":  "487",
+			"leeching": "0",
+			// parseNumber 对大数值返回科学计数法字符串
+			"bonus": "2.7477024e+06",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+	})
+
+	t.Run("UserdetailsPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "hdarea_userdetails", hdareaUserdetailsFixture)
+		fields := map[string]string{
+			// 5.607 TB / 1.001 TB 按 1024 进制换算为字节
+			"uploaded":   "6164961696940",
+			"downloaded": "1100611139403",
+			"ratio":      "5.603",
+			"levelName":  "Veteran User",
+			// parseTime 按站点 TimezoneOffset(+0800) 解析
+			"joinTime":     "1765634337",
+			"lastAccessAt": "1785136235",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+
+		// 保号探测只读取 UserInfo.LastAccess，必须为正的 Unix 秒
+		sel := def.UserInfo.Selectors["lastAccessAt"]
+		got := driver.ExtractFieldValuePublic(doc, sel)
+		require.NotEmpty(t, got, "lastAccessAt must be parsed for the login probe")
+		assert.Regexp(t, `^\d+$`, got)
+		assert.Greater(t, got, "0")
+	})
+}
+
+// --- Standalone Tests ---
+
+func TestHdarea_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":      hdareaSearchFixture,
+		"detail":      hdareaDetailFixture,
+		"detail_hr":   hdareaDetailWithHRFixture,
+		"index":       hdareaIndexFixture,
+		"userdetails": hdareaUserdetailsFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			RequireNoSecrets(t, name, data)
+		})
+	}
+}

--- a/site/v2/definitions/luckpt.go
+++ b/site/v2/definitions/luckpt.go
@@ -1,0 +1,234 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+// LuckptDefinition 描述 LuckPT（pt.luckpt.de）站点。
+//
+// 站点为标准 NexusPHP 架构（页面标题 "LuckPT :: ... - Powered by NexusPHP"），
+// 详情页保留了 input[name='torrent_name'] / input[name='detail_torrent_id'] 隐藏域，
+// 因此标题/ID 直接走隐藏域取值。需要单独适配的点：
+//  1. 搜索页名称单元格前有封面缩略图单元格（data-has-cover=1，20/20 行都有），
+//     td.embedded 的第一个是封面而不是名称，必须用 :has(a[href*='details.php']) 定位名称单元格。
+//  2. 副标题是 <br /> 之后的裸文本节点，且前面还有 1~3 个彩色标签 <span>（官方/中字/完结…），
+//     eastgame 只跳过一个 span 的正则无法命中，需要跳过任意个完整 span。
+//  3. 名称单元格内除促销的「剩余时间」<span title> 外，还有一个审核状态 <span title="通过">，
+//     促销结束时间选择器必须限定在 font:contains('剩余时间') 内，否则非促销行会误取 title="通过"。
+//  4. 「基本信息」行体积同时出现十进制（46.11 GB）与二进制（GiB）单位，SizeRegex 的单位组放宽为
+//     [KMGT]i?B；共享的 ParseSizeMB 已能换算 KiB/MiB/GiB/TiB。
+//  5. userdetails.php 的「传输」行为合并单元格，且魔力值在本站叫「幸运星」，
+//     标签后面跟了两个 [链接]（详情/商城）才是冒号，需要专用正则。
+var LuckptDefinition = &v2.SiteDefinition{
+	ID:             "luckpt",
+	Name:           "LuckPT",
+	Description:    "综合性 PT 站点（NexusPHP）",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://pt.luckpt.de/"},
+	FaviconURL:     "https://pt.luckpt.de/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "seeding", "leeching", "bonus"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields: []string{
+					"uploaded", "downloaded", "ratio", "trueUploaded",
+					"levelName", "joinTime", "lastAccessAt",
+				},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			// #info_block 里的用户链接是绝对地址（https://pt.luckpt.de/userdetails.php?id=…），
+			// querystring 过滤器基于 url.Parse，绝对/相对地址都能取到 id。
+			"id": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php'][class*='Name']",
+					"a[href*='userdetails.php']",
+				},
+				Attr:    "href",
+				Filters: []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php'][class*='Name']",
+				},
+			},
+			// 「传输」行是合并单元格（内嵌 table），需以 html + regex 拆分。
+			// 行内同时存在 实际上传量 / 保种上传量，字面量 <strong>上传量</strong> 只会命中纯上传量那一项。
+			"uploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>上传量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			// 实际上传量（不参与分享率计算），仅作记录展示
+			"trueUploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>实际上传量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"downloaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>下载量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			// 分享率后面括号里还有「实际分享率」，字面量 <strong>分享率</strong> 只命中前者
+			"ratio": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>分享率</strong>[：:\s]*(?:<font[^>]*>)?([\d.,]+|∞|Inf)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"levelName": {
+				Selector: []string{"td.rowhead:contains('等级') + td img", "td.rowhead:contains('等級') + td img"},
+				Attr:     "title",
+			},
+			// 本站魔力值叫「幸运星」，格式：
+			// <font class = 'color_bonus'>幸运星 </font>[<a>详情</a>][<a>商城</a>]: 86,666.1
+			// 标签后可能跟多个 [链接]，需用 (?:\[...\]\s*)+ 吞掉后再取冒号后的数值。
+			"bonus": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:幸运星|魔力值)\s*</font>\s*(?:\[[^\]]*\]\s*)+[:：]\s*([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowup"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"joinTime": {
+				Selector: []string{
+					"td.rowhead:contains('加入日期') + td",
+					"td.rowhead:contains('Join') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+			// 保号探测只读取 UserInfo.LastAccess，缺失会导致线上探测解析失败。
+			// 「最近动向(地点)」行同样命中 :contains('最近动向')，但取值走 First()，
+			// 文档顺序上「最近动向」在前，因此不会误取地点行。
+			"lastAccessAt": {
+				Selector: []string{
+					"td.rowhead:contains('最近动向') + td",
+					"td.rowhead:contains('最近動向') + td",
+					"td.rowhead:contains('上次访问') + td",
+					"td.rowhead:contains('Last access') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		TableRows: "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:     "table.torrentname a[href*='details.php']",
+		TitleLink: "table.torrentname a[href*='details.php']",
+		// 名称单元格是 table.torrentname 内「包含 details.php 链接」的那个 td.embedded：
+		// 第一个 td.embedded 是封面缩略图（20/20 行都有），不能用 First() 直接取。
+		// 副标题是 <br /> 之后的裸文本，前面还有若干彩色标签 <span>（官方/中字/完结…），
+		// 需先吞掉任意个完整 <span>…</span> 再截取裸文本。
+		SubtitleSelector: &v2.FieldSelector{
+			Selector: []string{"table.torrentname td.embedded:has(a[href*='details.php'])"},
+			Attr:     "html",
+			Filters: []v2.Filter{
+				{Name: "regex", Args: []any{`(?s)<br\s*/?>(?:\s*<span[^>]*>[^<]*</span>)*\s*([^<]+)`}},
+				// 走 html 取值会保留实体编码，需手动还原；&amp; 必须最后替换以避免二次解码
+				{Name: "replace", Args: []any{"&#39;", "'"}},
+				{Name: "replace", Args: []any{"&quot;", `"`}},
+				{Name: "replace", Args: []any{"&lt;", "<"}},
+				{Name: "replace", Args: []any{"&gt;", ">"}},
+				{Name: "replace", Args: []any{"&nbsp;", " "}},
+				{Name: "replace", Args: []any{"&amp;", "&"}},
+				{Name: "trim"},
+			},
+		},
+		// 列序（colhead）：1 类型 2 标题 3 评论数 4 存活时间 5 大小 6 种子数 7 下载数 8 完成数 9 发布者
+		Size:     "td.rowfollow:nth-child(5)",
+		Seeders:  "td.rowfollow:nth-child(6)",
+		Leechers: "td.rowfollow:nth-child(7)",
+		Snatched: "td.rowfollow:nth-child(8)",
+		// 采集样本中实际出现的是 pro_free 与 pro_free2up，其余为 NexusPHP 通用促销图标类名。
+		// 这里不设置 DiscountMapping：驱动内建的判定顺序会先识别 free2up 再识别 free，
+		// 而自定义 mapping 是无序遍历 + 子串匹配，会让 pro_free2up 有概率被误判为 free。
+		DiscountIcon: "img.pro_free, img.pro_free2up, img.pro_2up, img.pro_50pctdown, img.pro_50pctdown2up, img.pro_30pctdown",
+		// 促销结束时间真实渲染为 <font color='#0000FF'>剩余时间：<span title="…">6天19时</span></font>，
+		// 必须限定在 font:contains('剩余时间') 内：名称单元格里还有审核状态 <span title="通过">，
+		// 而第 4 列的存活时间也是 span[title]。若某些页面不渲染该 span，
+		// 驱动会回退解析促销图标的 onmouseover 提示。
+		DiscountEndTime:    "table.torrentname font:contains('剩余时间') span[title]",
+		Category:           "td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:         "td.rowfollow:nth-child(4) span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords: []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		// 详情页保留隐藏域，标题/ID 直接取 value
+		TitleSelector: "input[name='torrent_name']",
+		IDSelector:    "input[name='detail_torrent_id']",
+		// h1 里促销标记为 <font class='free' >免费</font>（单引号 + 尾随空格），
+		// 同时可能出现 <font class='classic'>经典</font> 之类的非促销标记，
+		// ParseDiscount 会逐个比对 class 直到命中 DiscountMapping，因此取全部带 class 的 font 即可。
+		DiscountSelector: "h1 font[class]",
+		// h1 内除「剩余时间」span 外还有审核状态 <span title="通过">，
+		// 限定 font:contains('剩余时间') 保证取到促销结束时间；保留通用兜底。
+		EndTimeSelector: "h1 font:contains('剩余时间') span[title], h1 span[title]",
+		// ParseSizeMB 读取 SizeSelector 元素的 .Next() 兄弟节点，因此必须指向标签单元格；
+		// 体积使用全角冒号（大小：46.11 GB），且本站十进制/二进制单位混用，单位组放宽为 [KMGT]i?B
+		SizeSelector: "td.rowhead:contains('基本信息')",
+		SizeRegex:    `大小[：:][^\d]*([\d.]+)[\s\x{00a0}]*([KMGT]i?B)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(LuckptDefinition)
+}

--- a/site/v2/definitions/luckpt_fixture_test.go
+++ b/site/v2/definitions/luckpt_fixture_test.go
@@ -1,0 +1,334 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "luckpt",
+		Search:   testLuckptSearch,
+		Detail:   testLuckptDetail,
+		UserInfo: testLuckptUserInfo,
+	})
+}
+
+// --- Fixtures ---
+//
+// 结构照搬真实采集页面，但所有标题、副标题、种子 ID、用户名、用户 ID 与图床地址均替换为虚构值。
+//
+// 搜索页需要覆盖的真实特征：
+//   - 名称列第一个 td.embedded 是封面缩略图（真实页面 20/20 行都有 data-has-cover=1）
+//   - 名称单元格前缀可能有多个 img.sticky、<b>(新)</b>、<b>[经典]</b>
+//   - 促销结束时间同时出现在促销图标的 onmouseover 提示与
+//     <font color='#0000FF'>剩余时间：<span title>…</span></font> 中
+//   - 名称单元格里还有一个审核状态 <span title="通过">（含内嵌 svg），非促销行也存在，
+//     因此促销结束时间选择器必须限定在 font:contains('剩余时间') 内
+//   - 副标题是 <br /> 之后的裸文本，前面还有 1~3 个彩色标签 <span>（官方/中字/完结…）
+//   - 大小列是 "46.11<br />GB"（数字与单位被 <br /> 分开）
+
+const luckptApprovedIcon = `<span style="margin-left: 6px" title="通过"><svg t="1655145688503" class="icon" viewBox="0 0 1413 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M1381.8 107.5L1274.7 0.4 465.3 809.9 142.6 487.2 35.4 594.2l430.1 430z" fill="#1afa29"></path></svg></span>`
+
+const luckptTagSpans = `<span style="background-color:#0000ff;color:#ffffff;border-radius:0;font-size:12px;margin:0 4px 0 0;padding:1px 2px" title="">官方</span><span style="background-color:#006400;color:#ffffff;border-radius:0;font-size:12px;margin:0 4px 0 0;padding:1px 2px" title="">中字</span><span style="background-color:#f02498;color:#ffffff;border-radius:0;font-size:12px;margin:0 4px 0 0;padding:1px 2px" title="">完结</span>`
+
+const luckptSearchFixture = `<html><body>
+<table class="torrents" cellspacing="0" cellpadding="5" width="100%">
+<tr>
+<td class="colhead" style="padding: 0px">类型</td>
+<td class="colhead"><a href="?sort=1&amp;type=asc">标题</a></td>
+<td class="colhead"><a href="?sort=3&amp;type=desc"><img class="comments" src="pic/trans.gif" alt="comments" title="评论数" /></a></td>
+<td class="colhead"><a href="?sort=4&amp;type=desc"><img class="time" src="pic/trans.gif" alt="time" title="存活时间" /></a></td>
+<td class="colhead"><a href="?sort=5&amp;type=desc"><img class="size" src="pic/trans.gif" alt="size" title="大小" /></a></td>
+<td class="colhead"><a href="?sort=7&amp;type=desc"><img class="seeders" src="pic/trans.gif" alt="seeders" title="种子数" /></a></td>
+<td class="colhead"><a href="?sort=8&amp;type=desc"><img class="leechers" src="pic/trans.gif" alt="leechers" title="下载数" /></a></td>
+<td class="colhead"><a href="?sort=6&amp;type=desc"><img class="snatched" src="pic/trans.gif" alt="snatched" title="完成数" /></a></td>
+<td class="colhead"><a href="?sort=9&amp;type=desc">发布者</a></td>
+</tr>
+<tr class='nexus-sticky nexus-sticky--1' style="--nexus-torrent-tint: rgba(254, 215, 170, 0.56)">
+<td class="rowfollow nowrap" data-col="type" data-label="类型" data-cat="c_anime" valign="middle" style='padding: 0px'><a href="?cat=405"><img class="c_anime" src="pic/cattrans.gif" alt="动画" title="动画" /></a></td>
+<td class="rowfollow" data-col="name" data-label="标题" data-has-cover="1" data-cover-src="https://img.example.invalid/cover-a.webp" width="100%" align="left" style='padding: 0px'><table class="torrentname" width="100%"><tr><td class="embedded" style="text-align: center;width: 60px;height: 60px"><img src="pic/misc/spinner.svg" data-src="https://img.example.invalid/cover-a.webp" class="nexus-lazy-load" loading="lazy" width="60" height="60" alt="" /></td><td class="embedded" style='padding-left: 5px'><img class="sticky" src="pic/trans.gif" alt="Sticky" title="一级置顶" />&nbsp;<img class="sticky" src="pic/trans.gif" alt="Sticky" title="一级置顶" />&nbsp;<a title="Fixture.Anime.S02.2026.1080p.BluRay.Remux.AVC.TrueHD.5.1-FIXTURE"  href="details.php?id=88001&amp;hit=1"><b>Fixture.Anime.S02.2026.1080p.BluRay.Remux.AVC.TrueHD.5.1-FIXTURE</b></a><b> (<font class='new'>新</font>)</b> <b>[<font class='classic'>经典</font>]</b> <img class="pro_free" src="pic/trans.gif" alt="Free"  onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;free&quot;&gt;免费&lt;/font&gt;&lt;/b&gt;剩余时间：&lt;b&gt;&lt;span title=&quot;2026-08-03 10:42:47&quot;&gt;6天19时&lt;/span&gt;&lt;/b&gt;', 'trail', false, 'delay',500,'lifetime',3000);" /> <font color='#0000FF'>剩余时间：<span title="2026-08-03 10:42:47">6天19时</span></font>` + luckptApprovedIcon + `<br />` + luckptTagSpans + `虚构副标题一 [内封中字]</td><td class="embedded" style="text-align: right; width: 40px;padding: 4px"><img src="pic/imdb2.png" alt="imdb" title="imdb" /><span data-imdbid="tt0000001">N/A</span></td><td width="20" class="embedded" data-col="quick" style="text-align: right;padding-right: 5px" valign="middle"><a href="download.php?id=88001"><img class="download" src="pic/trans.gif" alt="download" title="下载本种" /></a><br /><a id="bookmark0"  href="javascript: bookmark(88001,0);" ><img class="delbookmark" src="pic/trans.gif" alt="Unbookmarked" title="收藏" /></a></td>
+</tr></table></td><td class="rowfollow" data-col="comments" data-label="评论数"><a href="comment.php?action=add&amp;pid=88001&amp;type=torrent" title="添加评论">0</a></td><td class="rowfollow nowrap" data-col="time" data-label="存活时间"><span title="2026-07-27 10:42:47">4时<br />30分钟</span></td><td class="rowfollow" data-col="size" data-label="大小">46.11<br />GB</td><td class="rowfollow" data-col="seeders" data-label="种子数" align="center"><b><a href="details.php?id=88001&amp;hit=1&amp;dllist=1#seeders">9</a></b></td>
+<td class="rowfollow" data-col="leechers" data-label="下载数">0</td>
+<td class="rowfollow" data-col="snatched" data-label="完成数"><a href="viewsnatches.php?id=88001"><b>10</b></a></td>
+<td class="rowfollow" data-col="uploader" data-label="发布者"><span class="nowrap"><a  href="https://pt.luckpt.de/userdetails.php?id=70002" class='SysOp_Name'><b>fixture_target</b></a></span></td>
+</tr>
+<tr>
+<td class="rowfollow nowrap" data-col="type" data-label="类型" data-cat="c_anime" valign="middle" style='padding: 0px'><a href="?cat=405"><img class="c_anime" src="pic/cattrans.gif" alt="动画" title="动画" /></a></td>
+<td class="rowfollow" data-col="name" data-label="标题" data-has-cover="1" data-cover-src="https://img.example.invalid/cover-b.webp" width="100%" align="left" style='padding: 0px'><table class="torrentname" width="100%"><tr><td class="embedded" style="text-align: center;width: 60px;height: 60px"><img src="pic/misc/spinner.svg" data-src="https://img.example.invalid/cover-b.webp" class="nexus-lazy-load" loading="lazy" width="60" height="60" alt="" /></td><td class="embedded" style='padding-left: 5px'><a title="Fixture.Anime.S00.2026.1080p.BluRay.Remux.AVC.LPCM.2.0-FIXTURE"  href="details.php?id=88002&amp;hit=1"><b>Fixture.Anime.S00.2026.1080p.BluRay.Remux.AVC.LPCM.2.0-FIXTURE</b></a> <img class="pro_free2up" src="pic/trans.gif" alt="Free 2X"  onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;twoupfree&quot;&gt;2X免费&lt;/font&gt;&lt;/b&gt;剩余时间：&lt;b&gt;&lt;span title=&quot;2026-08-01 16:17:11&quot;&gt;5天1时&lt;/span&gt;&lt;/b&gt;', 'trail', false, 'delay',500,'lifetime',3000);" /> <font color='#00CC66'>剩余时间：<span title="2026-08-01 16:17:11">5天1时</span></font>` + luckptApprovedIcon + `<br />` + luckptTagSpans + `虚构副标题二 [内封中字]</td><td width="20" class="embedded" data-col="quick" style="text-align: right;padding-right: 5px" valign="middle"><a href="download.php?id=88002"><img class="download" src="pic/trans.gif" alt="download" title="下载本种" /></a></td>
+</tr></table></td><td class="rowfollow" data-col="comments" data-label="评论数"><a href="comment.php?action=add&amp;pid=88002&amp;type=torrent" title="添加评论">2</a></td><td class="rowfollow nowrap" data-col="time" data-label="存活时间"><span title="2026-07-23 16:17:11">3天<br />22时</span></td><td class="rowfollow" data-col="size" data-label="大小">17.49<br />GB</td><td class="rowfollow" data-col="seeders" data-label="种子数" align="center"><b><a href="details.php?id=88002&amp;hit=1&amp;dllist=1#seeders">17</a></b></td>
+<td class="rowfollow" data-col="leechers" data-label="下载数">0</td>
+<td class="rowfollow" data-col="snatched" data-label="完成数"><a href="viewsnatches.php?id=88002"><b>37</b></a></td>
+<td class="rowfollow" data-col="uploader" data-label="发布者"><i>匿名</i></td>
+</tr>
+<tr>
+<td class="rowfollow nowrap" data-col="type" data-label="类型" data-cat="c_tvseries" valign="middle" style='padding: 0px'><a href="?cat=402"><img class="c_tvseries" src="pic/cattrans.gif" alt="电视剧" title="电视剧" /></a></td>
+<td class="rowfollow" data-col="name" data-label="标题" data-has-cover="1" data-cover-src="https://img.example.invalid/cover-c.webp" width="100%" align="left" style='padding: 0px'><table class="torrentname" width="100%"><tr><td class="embedded" style="text-align: center;width: 60px;height: 60px"><img src="pic/misc/spinner.svg" data-src="https://img.example.invalid/cover-c.webp" class="nexus-lazy-load" loading="lazy" width="60" height="60" alt="" /></td><td class="embedded" style='padding-left: 5px'><a title="Fixture.Show.S01.2026.2160p.WEB-DL.HEVC.HDR10-FIXTURE"  href="details.php?id=88003&amp;hit=1"><b>Fixture.Show.S01.2026.2160p.WEB-DL.HEVC.HDR10-FIXTURE</b></a> <b>[<font class='classic'>经典</font>]</b>` + luckptApprovedIcon + `<br />` + luckptTagSpans + `虚构副标题三 | 全集 | 类型: 剧情</td><td width="20" class="embedded" data-col="quick" style="text-align: right;padding-right: 5px" valign="middle"><a href="download.php?id=88003"><img class="download" src="pic/trans.gif" alt="download" title="下载本种" /></a></td>
+</tr></table></td><td class="rowfollow" data-col="comments" data-label="评论数"><a href="comment.php?action=add&amp;pid=88003&amp;type=torrent" title="添加评论">5</a></td><td class="rowfollow nowrap" data-col="time" data-label="存活时间"><span title="2026-07-05 08:00:00">22天<br />6时</span></td><td class="rowfollow" data-col="size" data-label="大小">74.41<br />GB</td><td class="rowfollow" data-col="seeders" data-label="种子数" align="center"><b><a href="details.php?id=88003&amp;hit=1&amp;dllist=1#seeders">13</a></b></td>
+<td class="rowfollow" data-col="leechers" data-label="下载数">0</td>
+<td class="rowfollow" data-col="snatched" data-label="完成数"><a href="viewsnatches.php?id=88003"><b>24</b></a></td>
+<td class="rowfollow" data-col="uploader" data-label="发布者"><i>匿名</i></td>
+</tr>
+</table>
+</body></html>`
+
+// 详情页：标题/ID 来自 <form> 内的隐藏域（本站保留），h1 中的促销标记为
+// <font class='free' >（单引号 + 尾随空格），后面紧跟真实渲染的 剩余时间 span 与审核状态 span；
+// 「基本信息」行使用全角冒号 + 十进制单位。
+// 真实页面的「种子链接」行会渲染带 downhash 的一次性链接，属于凭据，fixture 中整行省略。
+const luckptDetailFixture = `<html><body>
+<h1 align="center" id="top">Fixture.Anime.S02.2026.1080p.BluRay.Remux.AVC.TrueHD.5.1-FIXTURE&nbsp;&nbsp;&nbsp; <b>[<font class='free' >免费</font>]</b> <font color='#0000FF'>剩余时间：<span title="2026-08-03 10:42:47">6天19时</span></font>` + luckptApprovedIcon + `</h1>
+<table width="100%" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead" width="13%">下载</td><td class="rowfollow" width="87%" align="left"><a class="index" href="download.php?id=88001">[LuckPT].Fixture.Anime.S02.torrent</a>&nbsp;&nbsp;&nbsp;由&nbsp;<span class="nowrap"><a  href="https://pt.luckpt.de/userdetails.php?id=70002" class='SysOp_Name'><b>fixture_target</b></a></span>发布于<span title="2026-07-27 10:42:47">4时30分钟前</span></td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">副标题</td><td class="rowfollow" valign="top" align="left">虚构副标题一 [内封中字]</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">标签</td><td class="rowfollow" valign="top" align="left">` + luckptTagSpans + `</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">基本信息</td><td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>46.11 GB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;动画&nbsp;&nbsp;&nbsp;<b>媒介: </b>Remux&nbsp;&nbsp;&nbsp;<b>编码: </b>H.264/AVC&nbsp;&nbsp;&nbsp;<b>分辨率: </b>1080p/1080i&nbsp;&nbsp;&nbsp;<b>音频: </b>TrueHD</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">行为</td><td class="rowfollow" valign="top" align="left"><a title="下载种子" href="download.php?id=88001"><img class="dt_download" src="pic/trans.gif" alt="download" />&nbsp;<b><font class="small">下载种子</font></b></a></td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><table border="0" cellspacing="0"><tr><td class="embedded">该种子暂无字幕</td></tr></table><table border="0" cellspacing="0"><tr><td class="embedded"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Fixture.Anime.S02.2026.1080p.BluRay.Remux.AVC.TrueHD.5.1-FIXTURE" /><input type="hidden" name="detail_torrent_id" value="88001" /><input type="hidden" name="in_detail" value="in_detail" /><input type="submit" value="上传字幕" /></form></td></tr></table></td></tr>
+</table>
+</body></html>`
+
+// 同一站点也会把体积渲染成二进制单位（GiB），SizeRegex 的单位组必须同时接受十进制与 IEC 单位。
+const luckptDetailGiBFixture = `<html><body>
+<h1 align="center" id="top">Fixture.Show.S01.2026.2160p.WEB-DL.HEVC.HDR10-FIXTURE</h1>
+<table width="100%" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead nowrap" valign="top" align="right">基本信息</td><td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>43.05 GiB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;电视剧</td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Fixture.Show.S01.2026.2160p.WEB-DL.HEVC.HDR10-FIXTURE" /><input type="hidden" name="detail_torrent_id" value="88003" /></form></td></tr>
+</table>
+</body></html>`
+
+// index.php 顶部 #info_block：id / name / 幸运星（本站的魔力值）/ 做种下载数均取自这里。
+// 注意 class 属性带空格（class = 'color_bonus'），且幸运星标签后跟了两个 [链接] 才是冒号；
+// 用户链接是绝对地址。
+const luckptIndexFixture = `<html><body>
+<table id="info_block" cellpadding="4" cellspacing="0" border="0" width="100%"><tr>
+	<td><table width="100%" cellspacing="0" cellpadding="0" border="0"><tr>
+		<td class="bottom" align="left">
+            <span class="medium">
+                欢迎回来, <span class="nowrap"><a  href="https://pt.luckpt.de/userdetails.php?id=70001" class='User_Name'><b>fixture_user</b></a><img src="https://img.example.invalid/medal-1.webp" title="虚构勋章一" class="nexus-username-medal preview" /></span>                                [<a href="logout.php">退出</a>]
+                [<a href="usercp.php">控制面板</a>]
+                <font class = 'color_bonus'>幸运星 </font>[<a href="mybonus.php">详情</a>][<a href="bonusshop.php">商城</a>]: 86,666.1
+                 <a href="attendance.php" class="">[签到已得1000, 补签卡: 3]</a>
+                <font class = 'color_invite'>邀请 </font>[<a href="invite.php?id=70001">发送</a>]: 10(0)                                <br />
+	            <font class="color_ratio">分享率:</font> 31.432                <font class='color_uploaded'>上传量:</font> 2.828 TB                <font class='color_downloaded'> 下载量:</font> 91.82 GB                <font class='color_active'>当前活动:</font> <img class="arrowup" alt="Torrents seeding" title="当前做种" src="pic/trans.gif" />81  <img class="arrowdown" alt="Torrents leeching" title="当前下载" src="pic/trans.gif" />0&nbsp;&nbsp;
+                <font class='color_connectable'>可连接:</font><b><font color="green">是</font></b> <font class='color_bonus'>认领: </font> [<a href="claim.php?uid=70001">108/1000</a>]            </span>
+        </td>
+	</tr></table></td>
+</tr></table>
+</body></html>`
+
+// userdetails.php 正文表格：「传输」行是合并单元格，同一行里同时有
+// 分享率/实际分享率、上传量/实际上传量/保种上传量、下载量/实际下载量，
+// 字面量正则只能命中不带前缀的那一项；「最近动向」之后紧跟同样命中
+// :contains('最近动向') 的「最近动向(地点)」行。
+const luckptUserdetailsFixture = `<html><body>
+<h1 style='margin:0px'><span class="nowrap"><b>fixture_target</b></span></h1>
+<table width="100%" border="1" cellspacing="0" cellpadding="5">
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">等级</td><td width="99%" class="rowfollow" valign="top" align="left"><img alt="Elite User" title="Elite User" src="pic/elite.gif" /> </td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">加入日期</td><td width="99%" class="rowfollow" valign="top" align="left">2025-07-13 14:24:16 (<span title="2025-07-13 14:24:16">1年0月前</span>, 54.1周)</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">最近动向</td><td width="99%" class="rowfollow" valign="top" align="left">2026-07-27 15:06:52 (<span title="2026-07-27 15:06:52">6分钟前</span>)</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">最近动向(地点)</td><td width="99%" class="rowfollow" valign="top" align="left">home</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">BT客户端</td><td width="99%" class="rowfollow" valign="top" align="left">qBittorrent/5.2.3</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">传输</td><td width="99%" class="rowfollow" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>分享率</strong>:  <font color="">1,234.567</font>（<strong>实际分享率</strong>：3.138）</td><td class="embedded">&nbsp;&nbsp;<img src="pic/smilies/163.gif" alt="" /></td></tr><tr><td class="embedded"><strong>上传量</strong>:  12.345 TB</td><td class="embedded">&nbsp;&nbsp;<strong>下载量</strong>:  45.67 GB</td></tr><tr><td class="embedded"><strong>实际上传量</strong>:  6.789 TB</td><td class="embedded">&nbsp;&nbsp;<strong>实际下载量</strong>:  2.164 TB</td><td class="embedded text-muted">&nbsp;&nbsp;实际上传/下载量 (仅用于记录, 不参与分享率计算)</td></tr><tr><td class="embedded"><strong>保种上传量</strong>:  8.936 TB</td><td class="embedded">&nbsp;&nbsp;<strong>保种下载量</strong>:  493.50 GB</td></tr></table></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">BT时间</td><td width="99%" class="rowfollow" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>做种时间</strong>:  1024天09:29:36</td><td class="embedded">&nbsp;&nbsp;<strong>下载时间</strong>:  31天01:09:40</td></tr></table></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">种子评论</td><td width="99%" class="rowfollow" valign="top" align="left">34</td></tr>
+</table>
+</body></html>`
+
+// --- Helpers ---
+
+func getLuckptDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("luckpt")
+	require.True(t, ok, "luckpt definition not found")
+	return def
+}
+
+// --- Suite: Search ---
+
+func testLuckptSearch(t *testing.T) {
+	def := getLuckptDef(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(luckptSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{
+		BaseURL:   server.URL,
+		Cookie:    "test_cookie=1",
+		Selectors: def.Selectors,
+	})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: "GET"})
+	require.NoError(t, err)
+
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 3, "should parse 3 torrent rows")
+
+	free := items[0]
+	assert.Equal(t, "88001", free.ID)
+	assert.Equal(t, "Fixture.Anime.S02.2026.1080p.BluRay.Remux.AVC.TrueHD.5.1-FIXTURE", free.Title)
+	// 副标题是 <br /> 之后的裸文本，前面还有 3 个彩色标签 span，需要 SubtitleSelector 才能取到
+	assert.Equal(t, "虚构副标题一 [内封中字]", free.Subtitle)
+	assert.Equal(t, v2.DiscountFree, free.DiscountLevel)
+	// 大小列为 "46.11<br />GB"，parseSize 去空白后按 1024 进制换算
+	assert.Equal(t, int64(49510235504), free.SizeBytes)
+	assert.Equal(t, 9, free.Seeders)
+	assert.Equal(t, 0, free.Leechers)
+	assert.Equal(t, 10, free.Snatched)
+	assert.Equal(t, "动画", free.Category)
+	// 促销结束时间取名称单元格内 font:contains('剩余时间') 下的 span[title]，
+	// 不能误取审核状态 span[title="通过"]，也不能误取第 4 列的存活时间
+	require.False(t, free.DiscountEndTime.IsZero(), "discount end time should be parsed")
+	assert.Equal(t, 2026, free.DiscountEndTime.Year())
+	assert.Equal(t, 8, int(free.DiscountEndTime.Month()))
+	assert.Equal(t, 3, free.DiscountEndTime.Day())
+	assert.Positive(t, free.UploadedAt)
+
+	// pro_free2up 必须判为 2X 免费：定义里不设置自定义 DiscountMapping，
+	// 依赖驱动内建的有序判定（先 free2up 再 free）
+	free2up := items[1]
+	assert.Equal(t, "88002", free2up.ID)
+	assert.Equal(t, "虚构副标题二 [内封中字]", free2up.Subtitle)
+	assert.Equal(t, v2.Discount2xFree, free2up.DiscountLevel)
+	assert.Equal(t, int64(18779744501), free2up.SizeBytes)
+	assert.Equal(t, 17, free2up.Seeders)
+	assert.Equal(t, 37, free2up.Snatched)
+	require.False(t, free2up.DiscountEndTime.IsZero())
+	assert.Equal(t, 1, free2up.DiscountEndTime.Day())
+
+	// 无促销行同样带 span[title="通过"]，结束时间必须为零值
+	normal := items[2]
+	assert.Equal(t, "88003", normal.ID)
+	assert.Equal(t, "Fixture.Show.S01.2026.2160p.WEB-DL.HEVC.HDR10-FIXTURE", normal.Title)
+	assert.Equal(t, "虚构副标题三 | 全集 | 类型: 剧情", normal.Subtitle)
+	assert.Equal(t, v2.DiscountNone, normal.DiscountLevel)
+	assert.True(t, normal.DiscountEndTime.IsZero(), "no discount -> no end time")
+	assert.Equal(t, int64(79897129123), normal.SizeBytes)
+	assert.Equal(t, 13, normal.Seeders)
+	assert.Equal(t, 0, normal.Leechers)
+	assert.Equal(t, 24, normal.Snatched)
+	assert.Equal(t, "电视剧", normal.Category)
+}
+
+// --- Suite: Detail ---
+
+func testLuckptDetail(t *testing.T) {
+	def := getLuckptDef(t)
+
+	t.Run("Free", func(t *testing.T) {
+		doc := FixtureDoc(t, "luckpt_detail", luckptDetailFixture)
+		info := v2.NewNexusPHPParserFromDefinition(def).ParseAll(doc.Selection)
+
+		assert.Equal(t, "88001", info.TorrentID)
+		assert.Equal(t, "Fixture.Anime.S02.2026.1080p.BluRay.Remux.AVC.TrueHD.5.1-FIXTURE", info.Title)
+		assert.Equal(t, v2.DiscountFree, info.DiscountLevel)
+		require.False(t, info.DiscountEnd.IsZero(), "discount end time should be parsed")
+		assert.Equal(t, 2026, info.DiscountEnd.Year())
+		assert.Equal(t, 8, int(info.DiscountEnd.Month()))
+		assert.Equal(t, 3, info.DiscountEnd.Day())
+		// 「基本信息」标签单元格 + .Next() 兄弟节点，全角冒号 + 十进制 GB
+		assert.InDelta(t, 46.11*1024, info.SizeMB, 0.1)
+		assert.False(t, info.HasHR)
+	})
+
+	t.Run("BinaryUnit", func(t *testing.T) {
+		doc := FixtureDoc(t, "luckpt_detail_gib", luckptDetailGiBFixture)
+		info := v2.NewNexusPHPParserFromDefinition(def).ParseAll(doc.Selection)
+
+		assert.Equal(t, "88003", info.TorrentID)
+		assert.Equal(t, "Fixture.Show.S01.2026.2160p.WEB-DL.HEVC.HDR10-FIXTURE", info.Title)
+		assert.Equal(t, v2.DiscountNone, info.DiscountLevel)
+		assert.True(t, info.DiscountEnd.IsZero())
+		// GiB 与 GB 同样按 1024 换算，SizeRegex 的单位组必须放行 IEC 单位
+		assert.InDelta(t, 43.05*1024, info.SizeMB, 0.1)
+		// 采集样本三页均无 hitandrun / hit_run.gif，本站未启用 H&R
+		assert.False(t, info.HasHR)
+	})
+}
+
+// --- Suite: UserInfo ---
+
+func testLuckptUserInfo(t *testing.T) {
+	def := getLuckptDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	t.Run("IndexPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "luckpt_index", luckptIndexFixture)
+		fields := map[string]string{
+			"id":   "70001",
+			"name": "fixture_user",
+			// 幸运星 86,666.1：标签后跟 [详情][商城] 两个链接才是冒号
+			"bonus":    "86666.1",
+			"seeding":  "81",
+			"leeching": "0",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+	})
+
+	t.Run("UserdetailsPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "luckpt_userdetails", luckptUserdetailsFixture)
+		fields := map[string]string{
+			// 12.345 TB / 6.789 TB / 45.67 GB 按 1024 进制换算为字节
+			"uploaded":     "13573471044894",
+			"trueUploaded": "7464584440971",
+			"downloaded":   "49037789102",
+			// 1,234.567 需要 parseNumber 去掉千分位
+			"ratio":     "1234.567",
+			"levelName": "Elite User",
+			// parseTime 按站点 TimezoneOffset(+0800) 解析
+			"joinTime":     "1752387856",
+			"lastAccessAt": "1785136012",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+
+		// 保号探测只读取 UserInfo.LastAccess，必须为正的 Unix 秒
+		sel := def.UserInfo.Selectors["lastAccessAt"]
+		got := driver.ExtractFieldValuePublic(doc, sel)
+		require.NotEmpty(t, got, "lastAccessAt must be parsed for the login probe")
+		assert.Regexp(t, `^\d+$`, got)
+		assert.Greater(t, got, "0")
+	})
+}
+
+// --- Standalone Tests ---
+
+func TestLuckpt_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"approved_icon": luckptApprovedIcon,
+		"tag_spans":     luckptTagSpans,
+		"search":        luckptSearchFixture,
+		"detail":        luckptDetailFixture,
+		"detail_gib":    luckptDetailGiBFixture,
+		"index":         luckptIndexFixture,
+		"userdetails":   luckptUserdetailsFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			RequireNoSecrets(t, name, data)
+		})
+	}
+}

--- a/site/v2/definitions/qingwapt.go
+++ b/site/v2/definitions/qingwapt.go
@@ -1,0 +1,240 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+// QingwaptDefinition 描述青蛙（www.qingwapt.com）站点。
+//
+// 站点为标准 NexusPHP 架构（qw 皮肤），详情页保留了 input[name='torrent_name'] /
+// input[name='detail_torrent_id'] 隐藏域，userdetails.php 的「传输」行是经典的
+// <strong>上传量</strong> 合并单元格，因此绝大多数选择器与 btschool 一致。
+// 需要单独适配的三处：
+//  1. 搜索页促销标记不是 img.pro_free，而是自绘的文字徽章
+//     <span style="..." alt="Free" onmouseover="...">Free</span>，
+//     必须用 span[alt] 命中（parseDiscountFromElement 会读 class+src+alt）。
+//  2. 促销剩余时间渲染为 <font color='#0000FF'>剩余时间：<span title="...">…</span></font>，
+//     名称单元格里还存在 title="置顶促销" / title="自动审核通过" 等非时间 span，
+//     因此必须限定到 font[color] 之内，否则会取到非时间值。
+//  3. 搜索页副标题是名称单元格末尾的裸文本节点，且前面穿插若干自绘标签 span
+//     （官方 / 中字 / 分集），只能取单元格 html 后用正则截取尾部文本。
+//
+// 魔力值在本站叫「蝌蚪」，#info_block 中的标签文本据此适配。
+var QingwaptDefinition = &v2.SiteDefinition{
+	ID:             "qingwapt",
+	Name:           "青蛙",
+	Description:    "综合性 PT 站点（NexusPHP）",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://www.qingwapt.com/"},
+	FaviconURL:     "https://www.qingwapt.com/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "seeding", "leeching", "bonus"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields: []string{
+					"uploaded", "downloaded", "ratio", "trueUploaded", "trueDownloaded",
+					"levelName", "joinTime", "lastAccessAt",
+				},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			"id": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php'][class*='Name']",
+					"a[href*='userdetails.php']",
+				},
+				Attr:    "href",
+				Filters: []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php'][class*='Name']",
+				},
+			},
+			// 「传输」行是合并单元格（内嵌 table），需以 html + regex 拆分：
+			//   <strong>上传量</strong>: 3.131 TB   <strong>下载量</strong>: 1.538 TB
+			//   <strong>实际上传量</strong>: 2.070 TB  <strong>实际下载量</strong>: 3.758 TB
+			// 正则要求 <strong> 紧跟标签，因此「实际上传量」不会误命中「上传量」。
+			"uploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>上传量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"downloaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>下载量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"trueUploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>实际上传量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"trueDownloaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>实际下载量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			// 分享率行形如 <strong>分享率</strong>: <font color="">2.035</font>（<strong>实际分享率</strong>：0.550），
+			// 取 <font> 内的第一个数值即名义分享率。
+			"ratio": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>分享率</strong>[：:\s]*(?:<font[^>]*>)?([\d.,]+|∞|Inf)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"levelName": {
+				Selector: []string{"td.rowhead:contains('等级') + td img", "td.rowhead:contains('等級') + td img"},
+				Attr:     "title",
+			},
+			// 本站把魔力值叫「蝌蚪」：
+			// <font class="color_bonus">蝌蚪 </font>[详情][使用]: 260,200.3
+			// #info_block 内还有第二个 color_bonus（认领），正则取首个匹配即蝌蚪。
+			"bonus": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?:蝌蚪|魔力值)\s*</font>(?:\s*\[[^\]]*\])*\s*[:：]\s*([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowup"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"joinTime": {
+				Selector: []string{
+					"td.rowhead:contains('加入日期') + td",
+					"td.rowhead:contains('Join') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+			// 保号探测只读取 UserInfo.LastAccess，缺失会导致线上探测解析失败。
+			// 「最近动向(地点)」行同样命中 :contains('最近动向')，但取值走 First()，
+			// 文档顺序上「最近动向」在前，因此不会误取地点行。
+			"lastAccessAt": {
+				Selector: []string{
+					"td.rowhead:contains('最近动向') + td",
+					"td.rowhead:contains('最近動向') + td",
+					"td.rowhead:contains('上次访问') + td",
+					"td.rowhead:contains('Last access') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		TableRows: "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:     "table.torrentname a[href*='details.php']",
+		TitleLink: "table.torrentname a[href*='details.php']",
+		// 副标题是名称单元格末尾的裸文本节点，前面可能穿插 img.sticky、<b>(新)</b>、
+		// <b>[热门]</b>、促销徽章、剩余时间以及若干自绘标签 span（官方/中字/分集），
+		// 无法用普通 CSS 选择器命中，因此取名称单元格 html 后正则截取末尾文本。
+		// 名称子表内还有海报单元格与评分单元格（同为 td.embedded），
+		// 用 :has(a[href*='details.php']) 精确锁定名称单元格。
+		SubtitleSelector: &v2.FieldSelector{
+			Selector: []string{"table.torrentname td.embedded:has(a[href*='details.php'])"},
+			Attr:     "html",
+			Filters: []v2.Filter{
+				{Name: "regex", Args: []any{`(?s)>\s*([^<>]+?)\s*$`}},
+				// 走 html 取值会保留实体编码，需手动还原；&amp; 必须最后替换以避免二次解码
+				{Name: "replace", Args: []any{"&#39;", "'"}},
+				{Name: "replace", Args: []any{"&quot;", `"`}},
+				{Name: "replace", Args: []any{"&lt;", "<"}},
+				{Name: "replace", Args: []any{"&gt;", ">"}},
+				{Name: "replace", Args: []any{"&nbsp;", " "}},
+				{Name: "replace", Args: []any{"&amp;", "&"}},
+				{Name: "trim"},
+			},
+		},
+		// 列序（colhead）：1 类型 2 标题 3 评论数 4 存活时间 5 大小 6 种子数 7 下载数 8 完成数 9 发布者
+		Size:     "td.rowfollow:nth-child(5)",
+		Seeders:  "td.rowfollow:nth-child(6)",
+		Leechers: "td.rowfollow:nth-child(7)",
+		Snatched: "td.rowfollow:nth-child(8)",
+		// 本站促销标记为自绘文字徽章 <span ... alt="Free" onmouseover="...">Free</span>，
+		// 名称单元格内只有该徽章带 alt 属性；img.pro_* 为 NexusPHP 通用类名，留作兜底。
+		DiscountIcon: "table.torrentname span[alt], img.pro_free, img.pro_free2up, img.pro_2up, img.pro_50pctdown, img.pro_50pctdown2up, img.pro_30pctdown",
+		// 剩余时间固定包在 <font color='#0000FF'> 内，限定 font[color] 可避开
+		// title="置顶促销" / title="自动审核通过" 等非时间 span；若某些页面不渲染该
+		// 元素，驱动会回退解析促销徽章的 onmouseover 提示。
+		DiscountEndTime:    "table.torrentname font[color] span[title]",
+		Category:           "td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:         "td.rowfollow:nth-child(4) span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords: []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		// 详情页保留隐藏域，标题/ID 直接取 value
+		TitleSelector: "input[name='torrent_name']",
+		IDSelector:    "input[name='detail_torrent_id']",
+		// h1 内为 <b>[<font class='free' >免费</font>]</b>（单引号 + 尾部空格），
+		// ParseDiscount 按 strings.Fields 拆 class，能正确命中 free
+		DiscountSelector: "h1 font.free, h1 font[class]",
+		// h1 内第一个 span[title] 就是剩余时间，晚于它的 title="自动审核通过" 不会被取到
+		EndTimeSelector: "h1 span[title]",
+		// ParseSizeMB 读取 SizeSelector 元素的 .Next() 兄弟节点，因此必须指向标签单元格；
+		// 采集样本为「大小：1.44 GB」（全角冒号 + 十进制单位），单位组一并覆盖二进制写法
+		SizeSelector: "td.rowhead:contains('基本信息')",
+		SizeRegex:    `大小[：:]\s*([\d.]+)\s*(TiB|GiB|MiB|KiB|TB|GB|MB|KB)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(QingwaptDefinition)
+}

--- a/site/v2/definitions/qingwapt_fixture_test.go
+++ b/site/v2/definitions/qingwapt_fixture_test.go
@@ -1,0 +1,316 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "qingwapt",
+		Search:   testQingwaptSearch,
+		Detail:   testQingwaptDetail,
+		UserInfo: testQingwaptUserInfo,
+	})
+}
+
+// --- Fixtures ---
+//
+// 结构照搬真实采集页面（qw 皮肤），但所有标题、副标题、种子 ID、用户名、用户 ID
+// 与图片地址均已替换为虚构值。
+//
+// 搜索页需要覆盖的真实特征：
+//   - 促销标记不是 img.pro_free，而是自绘文字徽章
+//     <span style="..." alt="Free" onmouseover="...">Free</span>
+//   - 剩余时间渲染为 <font color='#0000FF'>剩余时间：<span title="...">…</span></font>
+//   - 名称单元格内还有 title="置顶促销" / title="自动审核通过" 等非时间 span
+//   - 名称单元格前缀可能带多个 img.sticky、<b>(新)</b>、<b>[热门]</b>
+//   - 副标题是若干自绘标签 span（官方/中字/分集）之后的裸文本节点
+//   - 大小列是 "496.43<br />MB"（数字与单位被 <br /> 分开）
+//   - 名称子表内还有海报单元格、评分单元格与下载单元格（均为 td.embedded）
+//
+// 注意：采集样本 52 行全部处于免费状态（站点当时开放全站促销），
+// 因此下面第二行「无促销」是人工构造的合成行，用于验证 DiscountNone 以及
+// font[color] 限定确实能避开 title="置顶促销" 这类非时间 span，
+// 真实抓取数据未观测到非免费行。
+const qingwaptSearchFixture = `<html><body>
+<table class="torrents" cellspacing="0" cellpadding="5" width="100%">
+<tr>
+<td class="colhead" style="padding: 0px">类型</td>
+<td class="colhead"><a href="?sort=1&amp;type=asc">标题</a></td>
+<td class="colhead"><a href="?sort=3&amp;type=desc"><img class="comments" src="pic/trans.gif" alt="comments" title="评论数" /></a></td>
+<td class="colhead"><a href="?sort=4&amp;type=desc"><img class="time" src="pic/trans.gif" alt="time" title="存活时间" /></a></td>
+<td class="colhead"><a href="?sort=5&amp;type=desc"><img class="size" src="pic/trans.gif" alt="size" title="大小" /></a></td>
+<td class="colhead"><a href="?sort=7&amp;type=desc"><img class="seeders" src="pic/trans.gif" alt="seeders" title="种子数" /></a></td>
+<td class="colhead"><a href="?sort=8&amp;type=desc"><img class="leechers" src="pic/trans.gif" alt="leechers" title="下载数" /></a></td>
+<td class="colhead"><a href="?sort=6&amp;type=desc"><img class="snatched" src="pic/trans.gif" alt="snatched" title="完成数" /></a></td>
+<td class="colhead"><a href="?sort=9&amp;type=desc">发布者</a></td>
+</tr>
+<tr style="background-color: #75CAF4">
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=405"><img class="c_anime" src="pic/cattrans.gif" alt="动漫" title="动漫" style="background-image: url(pic/category/qw/catsprites.png);" /></a></td>
+<td class="rowfollow" width="100%" align="left" style='padding: 0px'><table class="torrentname" width="100%"><tr style="background-color: #75CAF4"><td class="embedded" style="text-align: center;width: 46px;height: 46px"><img src="pic/misc/spinner.svg" data-src="pic/poster/fixture-anime.jpg" class="nexus-lazy-load" style="max-height: 46px;max-width: 46px" /></td><td class="embedded" style='padding-left: 5px'><img class="sticky" src="pic/trans.gif" alt="Sticky" title="一级置顶" />&nbsp;<img class="sticky" src="pic/trans.gif" alt="Sticky" title="一级置顶" />&nbsp;<a title="Fixture.Anime.S01E04.2026.1080p.WEB-DL.H.264.AAC-FIXTURE"  href="details.php?id=195684&amp;hit=1"><b>Fixture.Anime.S01E04.2026.1080p.WEB-DL.H.264.AAC-FIXTURE</b></a><b> (<font class='new'>新</font>)</b> <b>[<font class='hot'>热门</font>]</b> <span style="display: inline-block; margin: 2px; font-size:10px; color: rgb(255, 255, 255); background-color: #0034EF; padding: 0px 6px; border-radius: 3px;" alt="Free"  onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;free&quot;&gt;免费&lt;/font&gt;&lt;/b&gt;剩余时间：&lt;b&gt;&lt;span title=&quot;2026-07-29 00:47:50&quot;&gt;1天9时&lt;/span&gt;&lt;/b&gt;', 'trail', false, 'delay',500,'lifetime',3000);">Free</span> <font color='#0000FF'>剩余时间：<span title="2026-07-29 00:47:50">1天9时</span></font><span style="margin-left: 6px" title="自动审核通过"><svg viewBox="0 0 1024 1024" width="16" height="16"></svg></span><br /><span style="color:#fff;border-radius:4px;font-size:12px;margin:0 4px 0 0;padding:1px 4px;white-space:nowrap;" title="">官方</span><span style="color:#fff;border-radius:4px;font-size:12px;margin:0 4px 0 0;padding:1px 4px;white-space:nowrap;" title="">中字</span><span style="color:#fff;border-radius:4px;font-size:12px;margin:0 4px 0 0;padding:1px 4px;white-space:nowrap;" title="">分集</span>虚构副标题一 | 类型：动画 喜剧 Sci-Fi &amp; Fantasy | 语言：日本語 | *内封简繁英多国软字幕*  第1季 第04集</td><td class="embedded" style="text-align: right; width: 40px;padding: 4px"><div style="display: flex;flex-direction: column"><img src="pic/imdb2.png" alt="imdb" title="imdb" style="max-width: 16px;max-height: 16px"/><span>7.1</span></div></td><td width="20" class="embedded" style="text-align: right;padding-right: 5px" valign="middle"><a href="download.php?id=195684"><img class="download" src="pic/trans.gif" alt="download" title="下载本种" /></a><br /><a id="bookmark0"  href="javascript: bookmark(195684,0);" ><img class="delbookmark" src="pic/trans.gif" alt="Unbookmarked" title="收藏" /></a></td>
+</tr></table></td><td class="rowfollow"><a href="comment.php?action=add&amp;pid=195684&amp;type=torrent" title="添加评论">0</a></td><td class="rowfollow nowrap"><span title="2026-07-27 00:47:50">14时<br />27分钟</span></td><td class="rowfollow">496.43<br />MB</td><td class="rowfollow" align="center"><b><a href="details.php?id=195684&amp;hit=1&amp;dllist=1#seeders">19</a></b></td>
+<td class="rowfollow">0</td>
+<td class="rowfollow"><a href="viewsnatches.php?id=195684"><b>10</b></a></td>
+<td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr>
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=401"><img class="c_movie" src="pic/cattrans.gif" alt="电影" title="电影" style="background-image: url(pic/category/qw/catsprites.png);" /></a></td>
+<td class="rowfollow" width="100%" align="left" style='padding: 0px'><table class="torrentname" width="100%"><tr><td class="embedded" style="text-align: center;width: 46px;height: 46px"><img src="pic/misc/spinner.svg" data-src="pic/poster/fixture-movie.jpg" class="nexus-lazy-load" style="max-height: 46px;max-width: 46px" /></td><td class="embedded" style='padding-left: 5px'>&nbsp;<span title="置顶促销"><svg viewBox="0 0 1024 1024" width="16" height="16"></svg></span>&nbsp;<a title="Fixture.Movie.2026.2160p.BluRay.x265.DTS-FIXTURE"  href="details.php?id=195705&amp;hit=1"><b>Fixture.Movie.2026.2160p.BluRay.x265.DTS-FIXTURE</b></a><br /><span style="color:#fff;border-radius:4px;font-size:12px;margin:0 4px 0 0;padding:1px 4px;white-space:nowrap;" title="">中字</span>虚构副标题二 | 类型：动作冒险 | 语言：英語</td><td class="embedded" style="text-align: right; width: 40px;padding: 4px"><img src="pic/douban.png" alt="douban" title="douban" style="max-width: 16px;max-height: 16px"/><span>8.2</span></td><td width="20" class="embedded" style="text-align: right;padding-right: 5px" valign="middle"><a href="download.php?id=195705"><img class="download" src="pic/trans.gif" alt="download" title="下载本种" /></a></td>
+</tr></table></td><td class="rowfollow"><a href="comment.php?action=add&amp;pid=195705&amp;type=torrent" title="添加评论">4</a></td><td class="rowfollow nowrap"><span title="2026-05-01 12:00:00">2月<br />26天</span></td><td class="rowfollow">12.35<br />GB</td><td class="rowfollow" align="center"><b><a href="details.php?id=195705&amp;hit=1&amp;dllist=1#seeders">203</a></b></td>
+<td class="rowfollow">2</td>
+<td class="rowfollow"><a href="viewsnatches.php?id=195705"><b>88</b></a></td>
+<td class="rowfollow"><i>匿名</i></td>
+</tr>
+</table>
+</body></html>`
+
+// 详情页：标题/ID 来自 <form> 内的隐藏域（本站保留）；h1 里的促销标记是
+// <font class='free' >（单引号 + 尾部空格），随后是 <font color='#0000FF'>剩余时间：<span title>，
+// 再之后还有一个 title="自动审核通过" 的 span（不能被当成结束时间）；
+// 「基本信息」行使用全角冒号与十进制单位。
+const qingwaptDetailFixture = `<html><body>
+<h1 align="center" id="top">Fixture.Anime.S01E15-E17.2026.1080p.WEB-DL.H.264.AAC-FIXTURE&nbsp;&nbsp;&nbsp; <b>[<font class='free' >免费</font>]</b> <font color='#0000FF'>剩余时间：<span title="2026-07-29 12:01:20">1天20时</span></font><span style="margin-left: 6px" title="自动审核通过"><svg viewBox="0 0 1024 1024" width="16" height="16"></svg></span></h1>
+<table width="97%" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead" width="13%">下载</td><td class="rowfollow" width="87%" align="left"><a class="index" href="download.php?id=195705">[Fixture].Anime.S01.2026.1080p.WEB-DL.H.264.AAC-FIXTURE.torrent</a>&nbsp;&nbsp;&nbsp;由&nbsp;<i>匿名</i>发布于<span title="2026-07-27 12:01:20">3时14分钟前</span></td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">副标题</td><td class="rowfollow" valign="top" align="left">虚构副标题一 | 类型：动作冒险 动画 | 语言：日本語 | *内嵌繁中*  第1季 第15-17集</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">标签</td><td class="rowfollow" valign="top" align="left"><span style="color:#fff;border-radius:4px;padding:1px 4px" title="">官方</span></td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">基本信息</td><td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>1.44 GB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;动漫&nbsp;&nbsp;&nbsp;<b>媒介: </b>WEB-DL&nbsp;&nbsp;&nbsp;<b>视频编码: </b>H.264/AVC&nbsp;&nbsp;&nbsp;<b>音频编码: </b>AAC&nbsp;&nbsp;&nbsp;<b>分辨率: </b>1080p&nbsp;&nbsp;&nbsp;<b>制作组: </b>FIXTURE</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">行为</td><td class="rowfollow" valign="top" align="left"><a title="下载种子" href="download.php?id=195705"><img class="dt_download" src="pic/trans.gif" alt="download" />&nbsp;<b><font class="small">下载种子</font></b></a></td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><table border="0" cellspacing="0"><tr><td class="embedded">该种子暂无字幕</td></tr></table><table border="0" cellspacing="0"><tr><td class="embedded"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Fixture.Anime.S01E15-E17.2026.1080p.WEB-DL.H.264.AAC-FIXTURE" /><input type="hidden" name="detail_torrent_id" value="195705" /><input type="hidden" name="in_detail" value="in_detail" /><input type="submit" value="上传字幕" /></form></td></tr></table></td></tr>
+</table>
+</body></html>`
+
+// 无促销 + 带 H&R 标记的详情页（合成：采集样本未观测到 H&R 种子，
+// 站点也未配置 H&R 规则，此处仅验证解析器的关键字兜底不误伤）。
+const qingwaptDetailWithHRFixture = `<html><body>
+<h1 align="center" id="top">Fixture.HR.Show.S01.WEB-DL.1080p-FIXTURE</h1>
+<table width="97%" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead nowrap" valign="top" align="right">基本信息</td><td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>8.50 GB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;剧集</td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Fixture.HR.Show.S01.WEB-DL.1080p-FIXTURE" /><input type="hidden" name="detail_torrent_id" value="195999" /></form></td></tr>
+</table>
+<img src="pic/hit_run.gif" alt="Hit and Run" />
+</body></html>`
+
+// #info_block：id / name / 蝌蚪（本站魔力值别名）/ 做种下载数均取自这里。
+// 注意 class 属性带空格（class = 'color_bonus'），且「认领」也用 color_bonus，
+// 蝌蚪标签后连着两个方括号链接再跟冒号数值。
+const qingwaptIndexFixture = `<html><body>
+<table id="info_block" cellpadding="4" cellspacing="0" border="0" width="100%"><tr>
+	<td><table width="100%" cellspacing="0" cellpadding="0" border="0"><tr>
+		<td class="bottom" align="left">
+            <span class="medium">
+                欢迎回来, <span class="nowrap"><a  href="https://www.qingwapt.com/userdetails.php?id=708159" class='User_Name'><b>fixture_user</b></a></span>                [<a href="logout.php">退出</a>]
+                [<a href="usercp.php">&nbsp;控制面板&nbsp;</a>]
+                <font class = 'color_bonus'>蝌蚪 </font>[<a href="mybonus.php">详情</a>][<a href="bonusshop.php">使用</a>]: 260,200.3                 <a href="attendance.php" class="">[签到已得100, 补签卡: 0]</a>
+                <font class = 'color_invite'>邀请 </font>[<a href="invite.php?id=708159">发送</a>]: 0(0)                                <br />
+	            <font class="color_ratio">分享率:</font> 3.563                <font class='color_uploaded'>上传量:</font> 285.34 GB                <font class='color_downloaded'> 下载量:</font> 80.09 GB                <font class='color_active'>当前活动</font> [<a href="/clean.php">清除</a>] : <img class="arrowup" alt="Torrents seeding" title="当前做种" src="pic/trans.gif" />370  <img class="arrowdown" alt="Torrents leeching" title="当前下载" src="pic/trans.gif" />0&nbsp;
+                <font class='color_slots'>连接数：</font>无限制                                <font class='color_bonus'>认领: </font> [<a href="claim.php?uid=708159">250/5000</a>]            </span>
+        </td>
+	</tr></table></td>
+</tr></table>
+</body></html>`
+
+// userdetails.php 正文表格：
+//   - 「传输」行是经典的 <strong>上传量</strong> 合并单元格，并额外带
+//     <strong>实际上传量</strong>/<strong>实际下载量</strong>，
+//     以及「（<strong>实际分享率</strong>：0.550）」尾巴
+//   - 「最近动向」之后紧跟同样命中 :contains('最近动向') 的「最近动向(地点)」行，
+//     该行是非时间文本（torrents），必须靠 First() 取到前一行
+const qingwaptUserdetailsFixture = `<html><body>
+<h1 style='margin:0px'><span class="nowrap"><b>fixture_target</b></span></h1>
+<table width="100%" border="1" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead nowrap" valign="top" align="right">ID</td><td class="rowfollow" valign="top" align="left">703646</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">邀请</td><td class="rowfollow" valign="top" align="left">6</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">加入日期</td><td width="99%" class="rowfollow" valign="top" align="left">2024-12-17 23:11:39 (<span title="2024-12-17 23:11:39">1年7月前</span>, 83周)</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">最近动向</td><td width="99%" class="rowfollow" valign="top" align="left">2026-07-27 14:49:58 (<span title="2026-07-27 14:49:58">25分钟前</span>)</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">最近动向(地点)</td><td width="99%" class="rowfollow" valign="top" align="left">torrents</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">传输</td><td width="99%" class="rowfollow" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>分享率</strong>:  <font color="">2.035</font>（<strong>实际分享率</strong>：0.550）</td><td class="embedded">&nbsp;&nbsp;<img src="pic/smilies/3.gif" alt="" /></td></tr><tr><td class="embedded"><strong>上传量</strong>:  3.131 TB</td><td class="embedded">&nbsp;&nbsp;<strong>下载量</strong>:  1.538 TB</td></tr><tr><td class="embedded"><strong>实际上传量</strong>:  2.070 TB</td><td class="embedded">&nbsp;&nbsp;<strong>实际下载量</strong>:  3.758 TB</td><td class="embedded text-muted">&nbsp;&nbsp;实际上传/下载量 (仅用于记录, 不参与分享率计算)</td></tr></table></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">BT时间</td><td width="99%" class="rowfollow" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>做种时间</strong>:  14043天10:29:54</td><td class="embedded">&nbsp;&nbsp;<strong>下载时间</strong>:  105天03:40:01</td></tr></table></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">等级</td><td width="99%" class="rowfollow" valign="top" align="left"><img alt="Crazy User" title="Crazy User" src="pic/crazy.gif" /> </td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">种子评论</td><td width="99%" class="rowfollow" valign="top" align="left">0</td></tr>
+</table>
+</body></html>`
+
+// --- Helpers ---
+
+func getQingwaptDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("qingwapt")
+	require.True(t, ok, "qingwapt definition not found")
+	return def
+}
+
+// --- Suite: Search ---
+
+func testQingwaptSearch(t *testing.T) {
+	def := getQingwaptDef(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(qingwaptSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{
+		BaseURL:   server.URL,
+		Cookie:    "test_cookie=1",
+		Selectors: def.Selectors,
+	})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: "GET"})
+	require.NoError(t, err)
+
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 2, "should parse 2 torrent rows")
+
+	free := items[0]
+	assert.Equal(t, "195684", free.ID)
+	assert.Equal(t, "Fixture.Anime.S01E04.2026.1080p.WEB-DL.H.264.AAC-FIXTURE", free.Title)
+	// 副标题是自绘标签 span 之后的裸文本，需要 SubtitleSelector 才能取到
+	assert.Equal(t, "虚构副标题一 | 类型：动画 喜剧 Sci-Fi & Fantasy | 语言：日本語 | *内封简繁英多国软字幕*  第1季 第04集", free.Subtitle)
+	// 促销标记是 span[alt='Free']，不是 img.pro_free
+	assert.Equal(t, v2.DiscountFree, free.DiscountLevel)
+	// 大小列为 "496.43<br />MB"，parseSize 去空白后按 1024 进制换算
+	assert.Equal(t, int64(520544583), free.SizeBytes)
+	assert.Equal(t, 19, free.Seeders)
+	assert.Equal(t, 0, free.Leechers)
+	assert.Equal(t, 10, free.Snatched)
+	assert.Equal(t, "动漫", free.Category)
+	// 促销结束时间取 <font color='#0000FF'> 内的 span[title]，
+	// 不能误取 title="自动审核通过" 或第 4 列的发布时间
+	require.False(t, free.DiscountEndTime.IsZero(), "discount end time should be parsed")
+	assert.Equal(t, 2026, free.DiscountEndTime.Year())
+	assert.Equal(t, 7, int(free.DiscountEndTime.Month()))
+	assert.Equal(t, 29, free.DiscountEndTime.Day())
+	assert.Positive(t, free.UploadedAt)
+
+	// 合成的无促销行：验证 title="置顶促销" 不会被当成促销结束时间
+	normal := items[1]
+	assert.Equal(t, "195705", normal.ID)
+	assert.Equal(t, "Fixture.Movie.2026.2160p.BluRay.x265.DTS-FIXTURE", normal.Title)
+	assert.Equal(t, "虚构副标题二 | 类型：动作冒险 | 语言：英語", normal.Subtitle)
+	assert.Equal(t, v2.DiscountNone, normal.DiscountLevel)
+	assert.True(t, normal.DiscountEndTime.IsZero(), "no discount -> no end time")
+	assert.Equal(t, int64(13260711526), normal.SizeBytes)
+	assert.Equal(t, 203, normal.Seeders)
+	assert.Equal(t, 2, normal.Leechers)
+	assert.Equal(t, 88, normal.Snatched)
+}
+
+// --- Suite: Detail ---
+
+func testQingwaptDetail(t *testing.T) {
+	def := getQingwaptDef(t)
+
+	t.Run("Free", func(t *testing.T) {
+		doc := FixtureDoc(t, "qingwapt_detail", qingwaptDetailFixture)
+		info := v2.NewNexusPHPParserFromDefinition(def).ParseAll(doc.Selection)
+
+		assert.Equal(t, "195705", info.TorrentID)
+		assert.Equal(t, "Fixture.Anime.S01E15-E17.2026.1080p.WEB-DL.H.264.AAC-FIXTURE", info.Title)
+		assert.Equal(t, v2.DiscountFree, info.DiscountLevel)
+		require.False(t, info.DiscountEnd.IsZero(), "discount end time should be parsed")
+		assert.Equal(t, 2026, info.DiscountEnd.Year())
+		assert.Equal(t, 7, int(info.DiscountEnd.Month()))
+		assert.Equal(t, 29, info.DiscountEnd.Day())
+		// 「基本信息」标签单元格 + .Next() 兄弟节点，全角冒号 + 十进制 GB
+		assert.InDelta(t, 1.44*1024, info.SizeMB, 0.1)
+		assert.False(t, info.HasHR)
+	})
+
+	t.Run("WithHR", func(t *testing.T) {
+		doc := FixtureDoc(t, "qingwapt_detail_hr", qingwaptDetailWithHRFixture)
+		info := v2.NewNexusPHPParserFromDefinition(def).ParseAll(doc.Selection)
+
+		assert.Equal(t, "195999", info.TorrentID)
+		assert.Equal(t, "Fixture.HR.Show.S01.WEB-DL.1080p-FIXTURE", info.Title)
+		assert.Equal(t, v2.DiscountNone, info.DiscountLevel)
+		assert.True(t, info.DiscountEnd.IsZero())
+		assert.InDelta(t, 8.5*1024, info.SizeMB, 0.1)
+		assert.True(t, info.HasHR, "should detect HR from hit_run.gif")
+	})
+}
+
+// --- Suite: UserInfo ---
+
+func testQingwaptUserInfo(t *testing.T) {
+	def := getQingwaptDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	t.Run("IndexPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "qingwapt_index", qingwaptIndexFixture)
+		fields := map[string]string{
+			"id":       "708159",
+			"name":     "fixture_user",
+			"seeding":  "370",
+			"leeching": "0",
+			// 蝌蚪 260,200.3 —— parseNumber 去掉千分位
+			"bonus": "260200.3",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+	})
+
+	t.Run("UserdetailsPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "qingwapt_userdetails", qingwaptUserdetailsFixture)
+		fields := map[string]string{
+			// 3.131 TB / 1.538 TB / 2.070 TB / 3.758 TB 按 1024 进制换算为字节
+			"uploaded":       "3442570906566",
+			"downloaded":     "1691048883519",
+			"trueUploaded":   "2275989069496",
+			"trueDownloaded": "4131964697182",
+			"ratio":          "2.035",
+			"levelName":      "Crazy User",
+			// parseTime 按站点 TimezoneOffset(+0800) 解析：
+			// 2024-12-17 23:11:39 +0800 / 2026-07-27 14:49:58 +0800
+			"joinTime":     "1734448299",
+			"lastAccessAt": "1785134998",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+
+		// 保号探测只读取 UserInfo.LastAccess，必须为正的 Unix 秒
+		sel := def.UserInfo.Selectors["lastAccessAt"]
+		got := driver.ExtractFieldValuePublic(doc, sel)
+		require.NotEmpty(t, got, "lastAccessAt must be parsed for the login probe")
+		assert.Regexp(t, `^\d+$`, got)
+		assert.Greater(t, got, "0")
+	})
+}
+
+// --- Standalone Tests ---
+
+func TestQingwapt_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":      qingwaptSearchFixture,
+		"detail":      qingwaptDetailFixture,
+		"detail_hr":   qingwaptDetailWithHRFixture,
+		"index":       qingwaptIndexFixture,
+		"userdetails": qingwaptUserdetailsFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			RequireNoSecrets(t, name, data)
+		})
+	}
+}

--- a/site/v2/definitions/railgunpt.go
+++ b/site/v2/definitions/railgunpt.go
@@ -1,0 +1,245 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+// RailgunptDefinition 描述 RailgunPT（bilibili.download）站点。
+//
+// 域名与站点自称不一致：域名是 bilibili.download，但页面 <title>、页脚版权链接
+// （<a href="https://bilibili.download">RailgunPT</a>）与官方 TG 群（t.me/RailgunPT）
+// 均自称 RailgunPT，因此站点 ID / Name 取 RailgunPT，URL 取真实域名。
+//
+// 架构为标准 NexusPHP（CHD/scenetorrents 分类图标皮肤），详情页保留
+// input[name='torrent_name'] / input[name='detail_torrent_id'] 隐藏域，
+// 因此大部分选择器与 btschool / eastgame 一致。需要单独适配的地方：
+//  1. 种子列表的名称子表在标题单元格之前多出一个 46x46 海报缩略图 td.embedded，
+//     所以副标题不能直接取 table.torrentname 下第一个 td.embedded，
+//     必须用 :has(a[href*='details.php']) 锁定真正的名称单元格。
+//  2. 副标题是 <br /> 之后的裸文本节点，且前面可能有 1~3 个 <span title="">标签</span>
+//     徽章（官方 / 国语 / 中字 / HDR），纯 CSS 选不中，故走 SubtitleSelector 的
+//     innerHTML + 正则，先吞掉徽章 span 再截取裸文本。
+//  3. 促销剩余时间同时存在于促销图标的 onmouseover 提示与名称单元格的可见
+//     「剩余时间：<span title>」中；但徽章 span 带的是 title=""（空值），
+//     用 span[title] 选择器有误命中风险，因此不设置 DiscountEndTime，
+//     交由驱动的 parseDiscountEndTimeFromOnmouseover() 兜底解析。
+//     实测抓取样本 30 个促销种子全部带 onmouseover 提示，无长期促销。
+//  4. 详情页体积单位混用十进制（基本信息行 2.17 GB）与 IEC（MediaInfo 里的 2.17 GiB），
+//     SizeRegex 的单位组同时接受两种写法（ParseSizeMB 已支持 KiB/MiB/GiB/TiB）。
+//  5. 站点无 H&R（三张抓取页面 hitandrun 出现 0 次），故不设置 HREnabled。
+var RailgunptDefinition = &v2.SiteDefinition{
+	ID:             "railgunpt",
+	Name:           "RailgunPT",
+	Aka:            []string{"bilibili.download"},
+	Description:    "综合性 PT 站点，影视 / 剧集 / 音乐 / 动漫资源较多",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://bilibili.download/"},
+	FaviconURL:     "https://bilibili.download/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "seeding", "leeching", "bonus"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields: []string{
+					"uploaded", "downloaded", "ratio",
+					"trueUploaded", "trueDownloaded",
+					"levelName", "joinTime", "lastAccessAt",
+				},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			// info_block 里的用户链接是绝对地址（https://bilibili.download/userdetails.php?id=...）
+			"id": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php'][class*='Name']",
+					"a[href*='userdetails.php']",
+				},
+				Attr:    "href",
+				Filters: []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			// 勋章 <img> 在 </a> 之外，取 <a> 文本即用户名
+			"name": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php'][class*='Name']",
+				},
+			},
+			// 「传输」行是合并单元格（内嵌 table），须以 html + 正则拆分：
+			// <strong>分享率</strong>: <font>31.453</font>（<strong>实际分享率</strong>：2.541）
+			// <strong>上传量</strong>: 130.393 TB   <strong>下载量</strong>: 4.146 TB
+			// <strong>实际上传量</strong>: 78.269 TB  <strong>实际下载量</strong>: 30.801 TB
+			// 正则要求 <strong> 紧邻标签名，因此不会被「实际上传量 / 实际下载量 / 实际分享率」误命中
+			"uploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>上传量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"downloaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>下载量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"trueUploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>实际上传量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"trueDownloaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>实际下载量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"ratio": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>分享率</strong>[：:\s]*(?:<font[^>]*>)?([\d.,]+|∞|Inf)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"levelName": {
+				Selector: []string{"td.rowhead:contains('等级') + td img", "td.rowhead:contains('等級') + td img"},
+				Attr:     "title",
+			},
+			// 魔力值只在 #info_block 出现：<font class='color_bonus'>魔力值 </font>[使用]: 64,077.7
+			"bonus": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`魔力值\s*</font>\s*\[[^\]]*\]\s*[:：]\s*([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowup"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowdown"[^>]*/>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			// 「加入日期」形如 2025-04-29 16:04:51 (1年3月前, 64周)，正则只取绝对时间
+			"joinTime": {
+				Selector: []string{
+					"td.rowhead:contains('加入日期') + td",
+					"td.rowhead:contains('Join') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+			// 保号探测只读取 UserInfo.LastAccess，缺失会导致线上探测解析失败。
+			// 本站 userdetails.php 只有一个「最近动向」行（无「最近动向(地点)」），无 :contains 冲突。
+			"lastAccessAt": {
+				Selector: []string{
+					"td.rowhead:contains('最近动向') + td",
+					"td.rowhead:contains('最近動向') + td",
+					"td.rowhead:contains('上次访问') + td",
+					"td.rowhead:contains('Last access') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		TableRows: "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:     "table.torrentname a[href*='details.php']",
+		TitleLink: "table.torrentname a[href*='details.php']",
+		// 名称子表的 td.embedded 依次为：海报缩略图 / 名称 / 豆瓣+IMDb 评分 / 下载按钮，
+		// 因此必须用 :has(a[href*='details.php']) 锁定名称单元格（海报单元格排在最前）。
+		// 副标题是 <br /> 之后的裸文本，前面可能有 1~3 个 <span title="">徽章</span>，
+		// 正则先贪婪吞掉整段徽章 span，再截取到下一个标签（inactivity 进度条 <div>）之前。
+		SubtitleSelector: &v2.FieldSelector{
+			Selector: []string{"table.torrentname td.embedded:has(a[href*='details.php'])"},
+			Attr:     "html",
+			Filters: []v2.Filter{
+				{Name: "regex", Args: []any{`(?s)<br\s*/?>(?:\s*<span[^>]*>[^<]*</span>)*\s*([^<]+)`}},
+				// 走 html 取值会保留实体编码，需手动还原；&amp; 必须最后替换以避免二次解码
+				{Name: "replace", Args: []any{"&#39;", "'"}},
+				{Name: "replace", Args: []any{"&#34;", `"`}},
+				{Name: "replace", Args: []any{"&quot;", `"`}},
+				{Name: "replace", Args: []any{"&lt;", "<"}},
+				{Name: "replace", Args: []any{"&gt;", ">"}},
+				{Name: "replace", Args: []any{"&nbsp;", " "}},
+				{Name: "replace", Args: []any{"&amp;", "&"}},
+				{Name: "trim"},
+			},
+		},
+		// 列序（colhead）：1 类型 2 标题 3 评论数 4 存活时间 5 大小 6 种子数 7 下载数 8 完成数 9 发布者
+		Size:     "td.rowfollow:nth-child(5)",
+		Seeders:  "td.rowfollow:nth-child(6)",
+		Leechers: "td.rowfollow:nth-child(7)",
+		Snatched: "td.rowfollow:nth-child(8)",
+		// 实测抓取到 pro_free / pro_free2up / pro_50pctdown / pro_2up，
+		// 其余为 NexusPHP 通用促销图标类名，一并保留
+		DiscountIcon: "img.pro_free, img.pro_free2up, img.pro_2up, img.pro_50pctdown, img.pro_50pctdown2up, img.pro_30pctdown",
+		DownloadLink: "a[href*='download.php']",
+		Category:     "td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:   "td.rowfollow:nth-child(4) span[title]",
+		// 详情页「下载」行给出干净的 download.php?id=；「种子链接」行是带 JWT 的当日临时链接，放在后面兜底
+		DetailDownloadLink: "td.rowhead:contains('下载') + td a[href*='download.php'], td.rowhead:contains('种子链接') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords: []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		// 详情页保留隐藏域，标题 / ID 直接取 value
+		TitleSelector: "input[name='torrent_name']",
+		IDSelector:    "input[name='detail_torrent_id']",
+		// h1 里促销标记形如 <b>[<font class='twoupfree' >2X免费</font>]</b>，
+		// 后面紧跟无 class 的 <font color='#00CC66'>剩余时间：...</font>，故按 font[class] 命中
+		DiscountSelector: "h1 font.free, h1 font[class]",
+		EndTimeSelector:  "h1 span[title]",
+		// ParseSizeMB 读取 SizeSelector 元素的 .Next() 兄弟节点，因此必须指向标签单元格本身；
+		// 「基本信息」行用全角冒号，单位组同时接受十进制（GB）与 IEC（GiB）写法
+		SizeSelector: "td.rowhead:contains('基本信息')",
+		SizeRegex:    `大小[：:][^\d]*([\d.]+)[\s\x{00a0}]*(TiB|TB|GiB|GB|MiB|MB|KiB|KB)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(RailgunptDefinition)
+}

--- a/site/v2/definitions/railgunpt_fixture_test.go
+++ b/site/v2/definitions/railgunpt_fixture_test.go
@@ -1,0 +1,321 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "railgunpt",
+		Search:   testRailgunptSearch,
+		Detail:   testRailgunptDetail,
+		UserInfo: testRailgunptUserInfo,
+	})
+}
+
+// --- Fixtures ---
+//
+// 结构照搬真实抓取页面（CHD/scenetorrents 分类图标皮肤），但所有标题、副标题、种子 ID、
+// 用户名、用户 ID、图床地址均已替换为虚构值。
+//
+// 搜索页需要覆盖的真实特征：
+//   - 名称子表第一个 td.embedded 是 46x46 海报缩略图，真正的名称单元格排在它后面
+//   - 名称单元格前缀可能带多个 img.sticky 与 <b>[热门]</b>
+//   - 促销剩余时间同时出现在促销图标的 onmouseover 提示与可见的「剩余时间：<span title>」中，
+//     后者有时包在 <font color>里、有时是裸文本
+//   - 副标题是 <br /> 之后的裸文本节点，前面可能有 1~3 个 <span title="">徽章</span>
+//   - 存在只有徽章、没有真实副标题的行，以及完全没有 <br /> 的行
+//   - 大小列是 "2.17<br />GB"（数字与单位被 <br /> 分开）
+
+const railgunptSearchFixture = `<html><body>
+<table class="torrents" cellspacing="0" cellpadding="5" width="100%">
+<tr>
+<td class="colhead" style="padding: 0px">类型</td>
+<td class="colhead"><a href="?sort=1&amp;type=asc">标题</a></td>
+<td class="colhead"><a href="?sort=3&amp;type=desc"><img class="comments" src="pic/trans.gif" alt="comments" title="评论数" /></a></td>
+<td class="colhead"><a href="?sort=4&amp;type=desc"><img class="time" src="pic/trans.gif" alt="time" title="存活时间" /></a></td>
+<td class="colhead"><a href="?sort=5&amp;type=desc"><img class="size" src="pic/trans.gif" alt="size" title="大小" /></a></td>
+<td class="colhead"><a href="?sort=7&amp;type=desc"><img class="seeders" src="pic/trans.gif" alt="seeders" title="种子数" /></a></td>
+<td class="colhead"><a href="?sort=8&amp;type=desc"><img class="leechers" src="pic/trans.gif" alt="leechers" title="下载数" /></a></td>
+<td class="colhead"><a href="?sort=6&amp;type=desc"><img class="snatched" src="pic/trans.gif" alt="snatched" title="完成数" /></a></td>
+<td class="colhead"><a href="?sort=9&amp;type=desc">发布者</a></td>
+</tr>
+<tr style="background-color: #89c9e6">
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=410"><img class="c_tv" src="pic/cattrans.gif" alt="剧集" title="剧集" style="background-image: url(pic/category/chd/scenetorrents/chs/tv.png);" /></a></td>
+<td class="rowfollow" width="100%" align="left" style='padding: 0px'><table class="torrentname" width="100%"><tr style="background-color: #89c9e6"><td class="embedded" style="text-align: center;width: 46px;height: 46px"><img src="pic/misc/spinner.svg" data-src="pic/attachments/fixture-poster-1.jpg" class="nexus-lazy-load" style="max-height: 46px;max-width: 46px" /></td><td class="embedded" style='padding-left: 5px'><img class="sticky" src="pic/trans.gif" alt="Sticky" title="一级置顶" />&nbsp;<a title="Fixture.Show.2026.S01E09.1080p.WEB-DL.AVC.AAC-FIXTURE"  href="details.php?id=99001&amp;hit=1"><b>Fixture.Show.2026.S01E09.1080p.WEB-DL.AVC.AAC-FIXTURE</b></a> <b>[<font class='hot'>热门</font>]</b> <img class="pro_free2up" src="pic/trans.gif" alt="2X Free"  onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;twoupfree&quot;&gt;2X免费&lt;/font&gt;&lt;/b&gt;剩余时间：&lt;b&gt;&lt;span title=&quot;2026-08-26 14:35:13&quot;&gt;29天23时&lt;/span&gt;&lt;/b&gt;', 'trail', false, 'delay',500,'lifetime',3000,'fade','both','styleClass','niceTitle', 'fadeMax',87, 'maxWidth', 300);" /> <font color='#00CC66'>剩余时间：<span title="2026-08-26 14:35:13">29天23时</span></font><br /><span style="background-color:#0000ff;color:#ffffff;border-radius:0;font-size:12px;margin:0 4px 0 0;padding:1px 2px" title="">官方</span><span style="background-color:#006400;color:#ffffff;border-radius:0;font-size:12px;margin:0 4px 0 0;padding:1px 2px" title="">中字</span>虚构副标题一 / Fixture Subtitle One<div style="padding: 1px;margin-top: 2px;border: 1px solid #838383" title="inactivity 0%"><div style="width: 0%;background-color: #aaa;height: 2px"></div></div></td><td class="embedded" style="text-align: right; width: 40px;padding: 4px"><div style="display: flex;flex-direction: column"><div><img src="pic/imdb2.png" alt="imdb" title="imdb" style="max-width: 16px;max-height: 16px"/><span>N/A</span></div><div><img src="pic/douban2.png" alt="douban" title="douban" style="max-width: 16px;max-height: 16px"/><span>N/A</span></div></div></td><td width="20" class="embedded" style="text-align: right;padding-right: 5px" valign="middle"><a href="download.php?id=99001"><img class="download" src="pic/trans.gif" style='padding-bottom: 2px;' alt="download" title="下载本种" /></a><br /><a id="bookmark0"  href="javascript: bookmark(99001,0);" ><img class="delbookmark" src="pic/trans.gif" alt="Unbookmarked" title="收藏" /></a></td>
+</tr></table></td><td class="rowfollow"><b><a href="details.php?id=99001&amp;hit=1&amp;cmtpage=1#startcomments" >4</a></b></td><td class="rowfollow nowrap"><span title="2026-07-27 14:35:13">39<br />分</span></td><td class="rowfollow">2.17<br />GB</td><td class="rowfollow" align="center"><b><a href="details.php?id=99001&amp;hit=1&amp;dllist=1#seeders">61</a></b></td>
+<td class="rowfollow">3</td>
+<td class="rowfollow"><a href="viewsnatches.php?id=99001"><b>87</b></a></td>
+<td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr>
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=408"><img class="c_hqaudio" src="pic/cattrans.gif" alt="音乐" title="音乐" style="background-image: url(pic/category/chd/scenetorrents/chs/hqaudio.png);" /></a></td>
+<td class="rowfollow" width="100%" align="left" style='padding: 0px'><table class="torrentname" width="100%"><tr><td class="embedded" style="text-align: center;width: 46px;height: 46px"><img src="pic/misc/spinner.svg" data-src="pic/attachments/fixture-poster-2.jpg" class="nexus-lazy-load" style="max-height: 46px;max-width: 46px" /></td><td class="embedded" style='padding-left: 5px'><a title="Fixture.Album.2026.FLAC-FIXTURE"  href="details.php?id=99002&amp;hit=1"><b>Fixture.Album.2026.FLAC-FIXTURE</b></a> <b>[<font class='hot'>热门</font>]</b></td><td width="20" class="embedded" style="text-align: right;padding-right: 5px" valign="middle"><a href="download.php?id=99002"><img class="download" src="pic/trans.gif" alt="download" title="下载本种" /></a></td>
+</tr></table></td><td class="rowfollow"><b><a href="details.php?id=99002&amp;hit=1&amp;cmtpage=1#startcomments" >1</a></b></td><td class="rowfollow nowrap"><span title="2025-03-27 14:46:44">1年<br />4月</span></td><td class="rowfollow">172.65<br />MB</td><td class="rowfollow" align="center"><b><a href="details.php?id=99002&amp;hit=1&amp;dllist=1#seeders">146</a></b></td>
+<td class="rowfollow">0</td>
+<td class="rowfollow"><a href="viewsnatches.php?id=99002"><b>781</b></a></td>
+<td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr>
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=401"><img class="c_movie" src="pic/cattrans.gif" alt="电影" title="电影" style="background-image: url(pic/category/chd/scenetorrents/chs/movie.png);" /></a></td>
+<td class="rowfollow" width="100%" align="left" style='padding: 0px'><table class="torrentname" width="100%"><tr><td class="embedded" style="text-align: center;width: 46px;height: 46px"><img src="pic/misc/spinner.svg" data-src="pic/attachments/fixture-poster-3.jpg" class="nexus-lazy-load" style="max-height: 46px;max-width: 46px" /></td><td class="embedded" style='padding-left: 5px'><a title="Fixture.Movie.2026.2160p.UHD.BluRay-FIXTURE"  href="details.php?id=99003&amp;hit=1"><b>Fixture.Movie.2026.2160p.UHD.BluRay-FIXTURE</b></a> <img class="pro_50pctdown" src="pic/trans.gif" alt="50%"  onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;halfdown&quot;&gt;50%&lt;/font&gt;&lt;/b&gt;剩余时间：&lt;b&gt;&lt;span title=&quot;2026-12-24 14:17:21&quot;&gt;4月29天&lt;/span&gt;&lt;/b&gt;', 'trail', false, 'delay',500,'lifetime',3000,'fade','both','styleClass','niceTitle', 'fadeMax',87, 'maxWidth', 300);" /> 剩余时间：<span title="2026-12-24 14:17:21">4月29天</span><br /><span style="background-color:#6a3906;color:#ffffff;border-radius:0;font-size:12px;margin:0 4px 0 0;padding:1px 2px" title="">国语</span><div style="padding: 1px;margin-top: 2px;border: 1px solid #838383" title="inactivity 0%"><div style="width: 0%;background-color: #aaa;height: 2px"></div></div></td><td width="20" class="embedded" style="text-align: right;padding-right: 5px" valign="middle"><a href="download.php?id=99003"><img class="download" src="pic/trans.gif" alt="download" title="下载本种" /></a></td>
+</tr></table></td><td class="rowfollow"><b><a href="details.php?id=99003&amp;hit=1&amp;cmtpage=1#startcomments" >0</a></b></td><td class="rowfollow nowrap"><span title="2026-07-25 09:12:00">2天<br />5时</span></td><td class="rowfollow">34.50<br />GB</td><td class="rowfollow" align="center"><b><a href="details.php?id=99003&amp;hit=1&amp;dllist=1#seeders">9</a></b></td>
+<td class="rowfollow">12</td>
+<td class="rowfollow"><a href="viewsnatches.php?id=99003"><b>4</b></a></td>
+<td class="rowfollow"><i>匿名</i></td>
+</tr>
+</table>
+</body></html>`
+
+// 详情页：标题 / ID 取自 <form> 内的隐藏域（本站保留），h1 的促销标记是
+// <font class='twoupfree' >（注意单引号 + 尾随空格），剩余时间在无 class 的 <font color> 里；
+// 「基本信息」行使用全角冒号 + 十进制单位。
+const railgunptDetailFixture = `<html><body>
+<h1 align="center" id="top">Fixture.Show.2026.S01E09.1080p.WEB-DL.AVC.AAC-FIXTURE&nbsp;&nbsp;&nbsp; <b>[<font class='twoupfree' >2X免费</font>]</b> <font color='#00CC66'>剩余时间：<span title="2026-08-26 14:35:13">29天23时</span></font></h1>
+<table class="main" width="100%" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead" width="13%">下载</td><td class="rowfollow" width="87%" align="left"><a class="index" href="download.php?id=99001">[RailgunPT].Fixture.Show.2026.S01E09.1080p.WEB-DL.AVC.AAC-FIXTURE.torrent</a>&nbsp;&nbsp;&nbsp;由&nbsp;<i>匿名</i>发布于<span title="2026-07-27 14:35:13">39分钟前</span></td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">副标题</td><td class="rowfollow" valign="top" align="left">虚构副标题一 / Fixture Subtitle One</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">基本信息</td><td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>2.17 GB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;剧集&nbsp;&nbsp;&nbsp;<b>媒介: </b>WEB-DL&nbsp;&nbsp;&nbsp;<b>编码: </b>H264&nbsp;&nbsp;&nbsp;<b>分辨率: </b>1080p/i&nbsp;&nbsp;&nbsp;<b>音频: </b>Other</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">行为</td><td class="rowfollow" valign="top" align="left"><a title="下载种子" href="download.php?id=99001"><img class="dt_download" src="pic/trans.gif" alt="download" />&nbsp;<b><font class="small">下载种子</font></b></a></td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><table border="0" cellspacing="0"><tr><td class="embedded"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Fixture.Show.2026.S01E09.1080p.WEB-DL.AVC.AAC-FIXTURE" /><input type="hidden" name="detail_torrent_id" value="99001" /></form></td></tr></table></td></tr>
+</table>
+</body></html>`
+
+// 无促销 + IEC 单位（GiB）的详情页：本站「基本信息」行偶尔使用二进制单位，
+// 用于验证 SizeRegex 的单位组同时接受 GB 与 GiB。
+const railgunptDetailIECFixture = `<html><body>
+<h1 align="center" id="top">Fixture.Movie.2026.2160p.UHD.BluRay-FIXTURE</h1>
+<table class="main" width="100%" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead nowrap" valign="top" align="right">基本信息</td><td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>34.50 GiB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;电影&nbsp;&nbsp;&nbsp;<b>媒介: </b>Blu-ray</td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Fixture.Movie.2026.2160p.UHD.BluRay-FIXTURE" /><input type="hidden" name="detail_torrent_id" value="99003" /></form></td></tr>
+</table>
+</body></html>`
+
+// index.php 顶部 #info_block：id / name / 魔力值 / 做种下载数均取自这里。
+// 注意用户链接是绝对地址，且 class 属性带空格（class = 'color_bonus'），与真实页面一致。
+const railgunptIndexFixture = `<html><body>
+<table id="info_block" cellpadding="4" cellspacing="0" border="0" width="100%"><tr>
+	<td><table width="100%" cellspacing="0" cellpadding="0" border="0"><tr>
+		<td class="bottom" align="left">
+            <span class="medium">
+                欢迎回来, <span class="nowrap"><a  href="https://bilibili.download/userdetails.php?id=90001" class='User_Name'><b>fixture_user</b></a><img src="pic/medals/fixture-medal.png" title="虚构勋章" class="nexus-username-medal preview" style="max-height: 11px;max-width: 11px;margin-left: 2pt"/></span>                [<a href="logout.php">退出</a>]
+                [<a href="usercp.php">&nbsp;控制面板&nbsp;</a>]
+                <font class = 'color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 64,077.7                 <a href="attendance.php" class="">[签到已得170, 补签卡: 0]</a>                <a href="medal.php">[勋章]</a>
+                <font class = 'color_invite'>邀请 </font>[<a href="invite.php?id=90001">发送</a>]: 5(0)                                <br />
+	            <font class="color_ratio">分享率:</font> 11.000                <font class='color_uploaded'>上传量:</font> 110.00 GB                <font class='color_downloaded'> 下载量:</font> 10.00 GB                <font class='color_active'>当前活动:</font> <img class="arrowup" alt="Torrents seeding" title="当前做种" src="pic/trans.gif" />14  <img class="arrowdown" alt="Torrents leeching" title="当前下载" src="pic/trans.gif" />0&nbsp;&nbsp;
+                <font class='color_connectable'>可连接:</font><b><font color="green">是</font></b>            </span>
+        </td>
+	</tr></table></td>
+</tr></table>
+</body></html>`
+
+// userdetails.php 正文表格：「传输」行是内嵌小表格，上传/下载量与「实际上传量 / 实际下载量」
+// 并列，分享率后面还跟着「（实际分享率：x）」；本站只有一个「最近动向」行。
+const railgunptUserdetailsFixture = `<html><body>
+<h1 style='margin:0px'><span class="nowrap"><b>fixture_target</b></span><img src="pic/flag/china.gif" alt="中国" style='margin-left: 8pt' /></h1>
+<table class="main" width="100%" border="1" cellspacing="0" cellpadding="5">
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">用户ID/UID</td><td width="99%" class="rowfollow" valign="top" align="left">90002</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">邀请</td><td width="99%" class="rowfollow" valign="top" align="left">没有邀请资格</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">加入日期</td><td width="99%" class="rowfollow" valign="top" align="left">2025-04-29 16:04:51 (<span title="2025-04-29 16:04:51">1年3月前</span>, 64周)</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">最近动向</td><td width="99%" class="rowfollow" valign="top" align="left">2026-07-27 14:35:13 (<span title="2026-07-27 14:35:13">39分钟前</span>)</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">BT客户端</td><td width="99%" class="rowfollow" valign="top" align="left">qBittorrent/5.1.2</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">传输</td><td width="99%" class="rowfollow" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>分享率</strong>:  <font color="">31.453</font>（<strong>实际分享率</strong>：2.541）</td><td class="embedded">&nbsp;&nbsp;<img src="pic/smilies/163.gif" alt="" /></td></tr><tr><td class="embedded"><strong>上传量</strong>:  130.393 TB</td><td class="embedded">&nbsp;&nbsp;<strong>下载量</strong>:  4.146 TB</td></tr><tr><td class="embedded"><strong>实际上传量</strong>:  78.269 TB</td><td class="embedded">&nbsp;&nbsp;<strong>实际下载量</strong>:  30.801 TB</td><td class="embedded text-muted">&nbsp;&nbsp;实际上传/下载量 (仅用于记录, 不参与分享率计算)</td></tr></table></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">BT时间</td><td width="99%" class="rowfollow" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>做种时间</strong>:  420天02:47:36</td><td class="embedded">&nbsp;&nbsp;<strong>下载时间</strong>:  33天17:58:19</td></tr></table></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">性别</td><td width="99%" class="rowfollow" valign="top" align="left">保密</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">等级</td><td width="99%" class="rowfollow" valign="top" align="left"><img alt="Nexus Master" title="Nexus Master" src="pic/nexus.gif" /> </td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">种子评论</td><td width="99%" class="rowfollow" valign="top" align="left">0</td></tr>
+</table>
+</body></html>`
+
+// --- Helpers ---
+
+func getRailgunptDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("railgunpt")
+	require.True(t, ok, "railgunpt definition not found")
+	return def
+}
+
+// --- Suite: Search ---
+
+func testRailgunptSearch(t *testing.T) {
+	def := getRailgunptDef(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(railgunptSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{
+		BaseURL:   server.URL,
+		Cookie:    "test_cookie=1",
+		Selectors: def.Selectors,
+	})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: "GET"})
+	require.NoError(t, err)
+
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 3, "should parse 3 torrent rows")
+
+	twoUpFree := items[0]
+	assert.Equal(t, "99001", twoUpFree.ID)
+	assert.Equal(t, "Fixture.Show.2026.S01E09.1080p.WEB-DL.AVC.AAC-FIXTURE", twoUpFree.Title)
+	// 副标题在 <br /> 之后，且被两个 <span title=""> 徽章挡在前面，必须靠 SubtitleSelector 取到
+	assert.Equal(t, "虚构副标题一 / Fixture Subtitle One", twoUpFree.Subtitle)
+	assert.Equal(t, v2.Discount2xFree, twoUpFree.DiscountLevel)
+	// 大小列为 "2.17<br />GB"，parseSize 去掉空白后按 1024 进制换算
+	assert.Equal(t, int64(2330019758), twoUpFree.SizeBytes)
+	assert.Equal(t, 61, twoUpFree.Seeders)
+	assert.Equal(t, 3, twoUpFree.Leechers)
+	assert.Equal(t, 87, twoUpFree.Snatched)
+	assert.Equal(t, "剧集", twoUpFree.Category)
+	// 未配置 DiscountEndTime 选择器，结束时间来自促销图标的 onmouseover 提示
+	require.False(t, twoUpFree.DiscountEndTime.IsZero(), "discount end time should come from onmouseover tooltip")
+	assert.Equal(t, "2026-08-26 14:35:13", twoUpFree.DiscountEndTime.Format("2006-01-02 15:04:05"))
+	assert.Positive(t, twoUpFree.UploadedAt)
+
+	plain := items[1]
+	assert.Equal(t, "99002", plain.ID)
+	assert.Equal(t, "Fixture.Album.2026.FLAC-FIXTURE", plain.Title)
+	// 该行完全没有 <br />，副标题为空
+	assert.Empty(t, plain.Subtitle)
+	assert.Equal(t, v2.DiscountNone, plain.DiscountLevel)
+	assert.True(t, plain.DiscountEndTime.IsZero(), "no discount -> no end time")
+	assert.Equal(t, int64(181036646), plain.SizeBytes)
+	assert.Equal(t, 146, plain.Seeders)
+	assert.Equal(t, 0, plain.Leechers)
+	assert.Equal(t, 781, plain.Snatched)
+
+	halfDown := items[2]
+	assert.Equal(t, "99003", halfDown.ID)
+	assert.Equal(t, "Fixture.Movie.2026.2160p.UHD.BluRay-FIXTURE", halfDown.Title)
+	// 只有徽章 span、没有真实副标题的行不能把徽章文字当成副标题
+	assert.Empty(t, halfDown.Subtitle)
+	assert.Equal(t, v2.DiscountPercent50, halfDown.DiscountLevel)
+	assert.Equal(t, "2026-12-24 14:17:21", halfDown.DiscountEndTime.Format("2006-01-02 15:04:05"))
+	assert.Equal(t, int64(37044092928), halfDown.SizeBytes)
+	assert.Equal(t, 9, halfDown.Seeders)
+	assert.Equal(t, 12, halfDown.Leechers)
+	assert.Equal(t, 4, halfDown.Snatched)
+	assert.Equal(t, "电影", halfDown.Category)
+}
+
+// --- Suite: Detail ---
+
+func testRailgunptDetail(t *testing.T) {
+	def := getRailgunptDef(t)
+
+	t.Run("TwoUpFree", func(t *testing.T) {
+		doc := FixtureDoc(t, "railgunpt_detail", railgunptDetailFixture)
+		info := v2.NewNexusPHPParserFromDefinition(def).ParseAll(doc.Selection)
+
+		assert.Equal(t, "99001", info.TorrentID)
+		assert.Equal(t, "Fixture.Show.2026.S01E09.1080p.WEB-DL.AVC.AAC-FIXTURE", info.Title)
+		// h1 里的促销 class 是 twoupfree（不是 free），必须映射为 2X免费
+		assert.Equal(t, v2.Discount2xFree, info.DiscountLevel)
+		require.False(t, info.DiscountEnd.IsZero(), "discount end time should be parsed")
+		assert.Equal(t, "2026-08-26 14:35:13", info.DiscountEnd.Format("2006-01-02 15:04:05"))
+		// 「基本信息」标签单元格 + .Next() 兄弟节点，全角冒号 + 十进制 GB
+		assert.InDelta(t, 2.17*1024, info.SizeMB, 0.1)
+		assert.False(t, info.HasHR, "站点无 H&R")
+	})
+
+	t.Run("IECUnitNoDiscount", func(t *testing.T) {
+		doc := FixtureDoc(t, "railgunpt_detail_iec", railgunptDetailIECFixture)
+		info := v2.NewNexusPHPParserFromDefinition(def).ParseAll(doc.Selection)
+
+		assert.Equal(t, "99003", info.TorrentID)
+		assert.Equal(t, "Fixture.Movie.2026.2160p.UHD.BluRay-FIXTURE", info.Title)
+		assert.Equal(t, v2.DiscountNone, info.DiscountLevel)
+		assert.True(t, info.DiscountEnd.IsZero())
+		// 单位组同时接受 GiB
+		assert.InDelta(t, 34.5*1024, info.SizeMB, 0.1)
+		assert.False(t, info.HasHR)
+	})
+}
+
+// --- Suite: UserInfo ---
+
+func testRailgunptUserInfo(t *testing.T) {
+	def := getRailgunptDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	t.Run("IndexPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "railgunpt_index", railgunptIndexFixture)
+		fields := map[string]string{
+			// 用户链接是绝对地址，querystring 过滤器仍能取到 id
+			"id":       "90001",
+			"name":     "fixture_user",
+			"seeding":  "14",
+			"leeching": "0",
+			"bonus":    "64077.7",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+	})
+
+	t.Run("UserdetailsPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "railgunpt_userdetails", railgunptUserdetailsFixture)
+		fields := map[string]string{
+			// 130.393 TB / 4.146 TB / 78.269 TB / 30.801 TB 按 1024 进制换算为字节
+			"uploaded":       "143368619680595",
+			"downloaded":     "4558575208759",
+			"trueUploaded":   "86057675594399",
+			"trueDownloaded": "33866057647128",
+			// 分享率取 31.453，不能被后面的「（实际分享率：2.541）」抢走
+			"ratio":     "31.453",
+			"levelName": "Nexus Master",
+			// parseTime 按站点 TimezoneOffset(+0800) 解析
+			"joinTime":     "1745913891",
+			"lastAccessAt": "1785134113",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+
+		// 保号探测只读取 UserInfo.LastAccess，必须为正的 Unix 秒
+		sel := def.UserInfo.Selectors["lastAccessAt"]
+		got := driver.ExtractFieldValuePublic(doc, sel)
+		require.NotEmpty(t, got, "lastAccessAt must be parsed for the login probe")
+		assert.Regexp(t, `^\d+$`, got)
+		assert.Greater(t, got, "0")
+	})
+}
+
+// --- Standalone Tests ---
+
+func TestRailgunpt_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":      railgunptSearchFixture,
+		"detail":      railgunptDetailFixture,
+		"detail_iec":  railgunptDetailIECFixture,
+		"index":       railgunptIndexFixture,
+		"userdetails": railgunptUserdetailsFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			RequireNoSecrets(t, name, data)
+		})
+	}
+}

--- a/tools/browser-extension/src/core/constants.ts
+++ b/tools/browser-extension/src/core/constants.ts
@@ -535,6 +535,42 @@ export const KNOWN_SITES: KnownSite[] = [
     cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
     syncField: "cookie",
   },
+  {
+    id: "luckpt",
+    name: "LuckPT",
+    domains: ["pt.luckpt.de"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
+  {
+    id: "qingwapt",
+    name: "青蛙",
+    domains: ["www.qingwapt.com"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
+  {
+    id: "railgunpt",
+    name: "RailgunPT",
+    domains: ["bilibili.download"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
+  {
+    id: "hdarea",
+    name: "HDArea",
+    domains: ["hdarea.club"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
 ];
 
 export const PAGE_PATTERNS: Array<{ pattern: RegExp; pageType: PageType }> = [

--- a/tools/browser-extension/src/modules/collector/sanitizer.test.ts
+++ b/tools/browser-extension/src/modules/collector/sanitizer.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeHtml } from "./sanitizer";
+
+/**
+ * Counts `<tr` start tags that a real HTML tokenizer would see, i.e. tags that are
+ * NOT sitting inside an attribute value. Mirrors how a parser handles quoted
+ * attributes: once a quote opens inside a tag, everything up to the matching quote
+ * belongs to the attribute value, `<tr>` included.
+ *
+ * Used instead of DOMParser because this package's vitest environment is plain
+ * node (no jsdom/happy-dom dependency). Sanitization must never change this count.
+ */
+function countRowsOutsideAttributes(html: string): number {
+  let count = 0;
+  let inTag = false;
+  let quote: string | null = null;
+
+  for (let i = 0; i < html.length; i++) {
+    const ch = html[i];
+
+    if (quote !== null) {
+      if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (inTag) {
+      if (ch === '"' || ch === "'") {
+        quote = ch;
+      } else if (ch === ">") {
+        inTag = false;
+      }
+      continue;
+    }
+
+    if (ch === "<") {
+      inTag = true;
+      if (/^<tr[\s>]/i.test(html.slice(i, i + 4))) {
+        count++;
+      }
+    }
+  }
+
+  return count;
+}
+
+type SanitizeCase = {
+  name: string;
+  html: string;
+  /** Secret fragments that must not survive sanitization (privacy control). */
+  mustNotContain: string[];
+  /** Structural fragments that must survive sanitization (document integrity). */
+  mustContain: string[];
+};
+
+const cases: SanitizeCase[] = [
+  {
+    name: "single-quoted attribute keeps its closing quote and bracket",
+    html: `<a class="index" href='download.php?id=113372&passkey=abcdef0123456789'>torrent</a>`,
+    mustNotContain: ["abcdef0123456789"],
+    mustContain: ["'>", "torrent</a>"],
+  },
+  {
+    name: "double-quoted attribute keeps its closing quote and bracket",
+    html: `<a class="index" href="download.php?id=113372&passkey=abcdef0123456789">torrent</a>`,
+    mustNotContain: ["abcdef0123456789"],
+    mustContain: ['">', "torrent</a>"],
+  },
+  {
+    name: "unquoted attribute keeps its closing bracket",
+    html: `<a href=download.php?id=113372&passkey=abcdef0123456789>torrent</a>`,
+    mustNotContain: ["abcdef0123456789"],
+    mustContain: [">torrent</a>"],
+  },
+  {
+    name: "json passkey keeps its surrounding quotes",
+    html: `{"passkey":"abcdef0123456789","id":113372}`,
+    mustNotContain: ["abcdef0123456789"],
+    mustContain: [`"passkey":"REMOVED"`, `"id":113372`],
+  },
+  {
+    name: "json passkey value containing an apostrophe is fully redacted",
+    html: `{"passkey":"ab'cdef0123456789","id":113372}`,
+    mustNotContain: ["ab'cdef0123456789", "cdef0123456789"],
+    mustContain: [`"passkey":"REMOVED"`, `"id":113372`],
+  },
+  {
+    name: "bare query string keeps the following parameters",
+    html: `<a href='rss.php?passkey=abcdef0123456789&other=1'>rss</a>`,
+    mustNotContain: ["abcdef0123456789"],
+    mustContain: ["&other=1", "'>", "rss</a>"],
+  },
+  {
+    name: "authkey in a single-quoted attribute keeps its closing quote",
+    html: `<a href='download.php?id=1&authkey=deadbeefcafe1234'>dl</a>`,
+    mustNotContain: ["deadbeefcafe1234"],
+    mustContain: ["'>", "dl</a>"],
+  },
+  {
+    name: "json authkey keeps its surrounding quotes",
+    html: `{"authkey":"deadbeefcafe1234"}`,
+    mustNotContain: ["deadbeefcafe1234"],
+    mustContain: [`"authkey":"REMOVED"`],
+  },
+  {
+    name: "apikey in a single-quoted attribute keeps its closing quote",
+    html: `<a href='api.php?apikey=deadbeefcafe1234'>api</a>`,
+    mustNotContain: ["deadbeefcafe1234"],
+    mustContain: ["'>", "api</a>"],
+  },
+  {
+    name: "json apikey keeps its surrounding quotes",
+    html: `{"apikey":"deadbeefcafe1234"}`,
+    mustNotContain: ["deadbeefcafe1234"],
+    mustContain: [`"apikey":"REMOVED"`],
+  },
+  {
+    name: "json token keeps its surrounding quotes",
+    html: `{"token":"deadbeefcafe1234","id":1}`,
+    mustNotContain: ["deadbeefcafe1234"],
+    mustContain: [`"token":"REMOVED"`, `"id":1`],
+  },
+];
+
+describe("sanitizeHtml", () => {
+  it.each(cases)("$name", ({ html, mustNotContain, mustContain }) => {
+    const sanitized = sanitizeHtml(html);
+
+    for (const secret of mustNotContain) {
+      expect(sanitized).not.toContain(secret);
+    }
+    expect(sanitized).toContain("REMOVED");
+    for (const fragment of mustContain) {
+      expect(sanitized).toContain(fragment);
+    }
+  });
+
+  // Regression for the pt.eastgame.org capture (issue #502): the passkey regex
+  // consumed the closing `'>` of the download link, so the parser absorbed the
+  // rows that followed and 副标题 / 基本信息 / 行为 disappeared from the export.
+  const detailPage = [
+    `<table class="main">`,
+    `<tr><td class="rowhead">下载直链</td><td class="rowfollow"><a class="index" href='download.php?id=113372&passkey=abcdef0123456789'>Witch.from.Nepal.1986.mkv.torrent</a></td></tr>`,
+    `<tr><td class="rowhead">副标题</td><td class="rowfollow">奇缘</td></tr>`,
+    `<tr><td class="rowhead">基本信息</td><td class="rowfollow"><b>大小：</b>1.95 GB</td></tr>`,
+    `<tr><td class="rowhead">行为</td><td class="rowfollow"><input name="torrent_name" value="Witch.from.Nepal.1986.mkv" /></td></tr>`,
+    `</table>`,
+  ].join("\n");
+
+  it("does not swallow the rows following a single-quoted passkey link", () => {
+    const sanitized = sanitizeHtml(detailPage);
+
+    expect(countRowsOutsideAttributes(sanitized)).toBe(countRowsOutsideAttributes(detailPage));
+    expect(countRowsOutsideAttributes(sanitized)).toBe(4);
+    expect(sanitized).toContain("副标题");
+    expect(sanitized).toContain("基本信息");
+    expect(sanitized).toContain(`<input name="torrent_name"`);
+    expect(sanitized).not.toContain("abcdef0123456789");
+  });
+});

--- a/tools/browser-extension/src/modules/collector/sanitizer.ts
+++ b/tools/browser-extension/src/modules/collector/sanitizer.ts
@@ -7,9 +7,13 @@ export function sanitizeHtml(html: string): string {
     sanitized = sanitized.replace(pattern, replacement);
   }
 
+  // Two value terminators, one per form. `key=value`: any quote, `&`, whitespace, `<`
+  // or `>` ends it, so the tag's closing `'>` / `">` / `>` survives (swallowing it left
+  // the attribute open and the parser absorbed the following rows). `"key":"value"`:
+  // only the closing double quote ends it, so `'` and `&` inside JSON are redacted too.
   sanitized = sanitized.replace(
-    /(passkey|authkey|apikey)("\s*:\s*"|=)([^"&\s<]+)/gi,
-    "$1$2REMOVED",
+    /(passkey|authkey|apikey)(?:(=)[^"'&\s<>]+|("\s*:\s*")[^"<>]*("))/gi,
+    "$1$2$3REMOVED$4",
   );
   sanitized = sanitized.replace(/("token"\s*:\s*")([^"]+)(")/gi, "$1REMOVED$3");
 


### PR DESCRIPTION
## Summary

新增四个 NexusPHP 站点适配（issue #495、#498、#500、#501），并修复一个导致采集数据静默损坏的脱敏器缺陷。

| 站点 | ID | 域名 | Issue |
|---|---|---|---|
| LuckPT | `luckpt` | pt.luckpt.de | #498 |
| 青蛙 | `qingwapt` | www.qingwapt.com | #501 |
| RailgunPT | `railgunpt` | bilibili.download | #500 |
| HDArea | `hdarea` | hdarea.club | #495 |

四站均为 NexusPHP 表格布局、Cookie 认证、无 H&R。全部使用现有共享解析能力，**未修改任何共享解析代码**。

## 脱敏器缺陷修复

`sanitizer.ts` 的 passkey 脱敏正则会吞掉单引号属性的闭合 `'>`，使属性未终止，HTML 解析器随后吞并若干后续 `<tr>` 行——副标题、基本信息、行为、字幕整行消失。

**这不是假设**。`pt.eastgame.org`（#502）的采集数据实际中招：

```
href='download.php?id=113372&passkey=REMOVED&passkey=REMOVED</a></td></tr> ...
```

该文件属性外只剩 8 行 `<tr>`（完整应为 23 行）。适配时首次探针得到 `ID="" Title="" SizeMB=0`，在内存中修补那一处字符串后才全部解析成功。

### 根因

```js
/(passkey|authkey|apikey)("\s*:\s*"|=)([^"&\s<]+)/gi
```

值字符类排除了双引号、`&`、空白、`<`，但**未排除单引号 `'` 和 `>`**。对 `href='...&passkey=HEX'>下载</a>`，贪婪匹配一路吃到下一个 `<`。

### 修复

按值的终止符拆成两个分支——单一字符类无法兼顾两种形式：

- `=` 形式（查询串/属性）：排除所有引号与 `>`，标签闭合得以保留
- JSON 形式：强制匹配闭合双引号，引号始终平衡，`'` 与 `&` 也一并脱敏

关键取舍：若只把字符类改成 `[^"'&\s<>]+` 一刀切，`{"passkey":"ab'cdef0123456789"}` 会输出 `"REMOVED'cdef0123456789"` —— **泄漏尾段**。拆分支后 JSON 路径反而比原来更严格。已有专门用例锁定该决策。

畸形 JSON（如 `data-cfg='{"passkey":"abc}'`）现在直接不匹配 —— 不脱敏但也不破坏结构，这是正确的失败方向。

### 量化验证

用还原后的脱敏前数据对比两套正则：

| 指标 | 修复前 | 修复后 |
|---|---|---|
| 属性外 `<tr>` 行数 | **1** | **4** |
| 保留 `'>` 闭合 | 否 | 是 |
| 泄漏 passkey 明文 | 否 | 否 |

隐私控制未退化：两者都未泄漏明文。

## 各站特殊点

**HDArea** — 搜索页含**两个** `table.torrents`，其中一个是「预告区/搜索箱」面板。行选择器仅绑定真实列表，解析出恰好 100 条，与 100 个 `download.php?id=` 完全吻合。采集时段为真实全站免费活动（99 FREE + 1 2XFREE）。

**青蛙** — 不使用标准 `img.pro_free` 图标，而是自定义样式的 `<span alt="Free" onmouseover="...">` 徽章。逐行核对确认 52/52 行各有一个 `alt="Free"`，是真实全站免费而非解析器误判。

**RailgunPT** — 站点自称 RailgunPT 而域名是 `bilibili.download`，故 ID 按站名取。详情页样本优惠为 `twoupfree`（2X 免费）而非普通 FREE。50 行中 16 行确实无副标题——已 dump DOM 逐一确认站点本身未提供，非选择器问题。

**LuckPT / RailgunPT** — 详情页混用 `GiB` 二进制单位，`SizeRegex` 单位组已放宽（依赖 v0.44.0 落地的二进制换算能力）。

## Verification

**真实页面探针**（关键验证，非手写 fixture）

| 站点 | 详情 SizeMB | 换算 | 优惠 | 列表条数 vs 下载链接 |
|---|---|---|---|---|
| LuckPT | `47216.64` | 46.11×1024 | FREE | 20 = 20 |
| 青蛙 | `1474.56` | 1.44×1024 | FREE | 52 = 52 |
| RailgunPT | `2222.08` | 2.17×1024 | 2XFREE | 50 = 50 |
| HDArea | `482.76` | MB 基准单位 | FREE | 100 = 100 |

四站空 ID、零大小均为 0，`lastAccessAt` 全部非空（保号探针可用）。

**自动化检查**

- `node --experimental-strip-types scripts/check-sites.ts` → Go 与扩展**双侧 61**，`✅ in sync`
- `go test ./... -count=1` → exit 0，40 个包通过，0 FAIL
- `TestAllSites_FixtureCoverage/{luckpt,qingwapt,railgunpt,hdarea}` → 三项测试全通过
- `make lint-go` → 0 issues
- `make fmt-check` → 全部文件格式正确
- 扩展 `pnpm test` → 2 个文件 / **19 个测试**通过（原 7 + 新增 12）
- 扩展 `pnpm typecheck` → exit 0

fixture 全部脱敏，各站含 `NoSecrets` 测试。

## 已知遗留（本 PR 未处理）

脱敏器仍有覆盖盲区，属覆盖面问题而非破坏性缺陷，按最小修复原则未扩大范围：

- `passkey="HEX"`（等号后紧跟双引号）与 `passkey = "HEX"`（等号带空格）两段均不匹配
- `<input name="passkey" value="HEX">` 表单形态未覆盖
- `token` 仅认 JSON 形式，查询串中的 `token=` 不脱敏

四站均未配置 `LevelRequirements`（采集数据无等级门槛表）、未开启 H&R（`hitandrun` 全部 0 次出现）。