### PR TITLE
feat(site): 新增财神、HHCLUB、U2 三个站点适配

### DIFF
--- a/docs/sites.md
+++ b/docs/sites.md
@@ -1,68 +1,71 @@
 ## 支持站点
 
-当前已适配 **61** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
+当前已适配 **64** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
 
-### NexusPHP 系列（57）
+### NexusPHP 系列（60）
 
-| 站点                  | 认证方式 | 支持功能                      | 适配情况 | 备注                                                             |
-| --------------------- | -------- | ----------------------------- | -------- | ---------------------------------------------------------------- |
-| **HDSky**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 完全适配                                                         |
-| **SpringSunday**      | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 完全适配                                                         |
-| **NovaHD**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **OpenCD**            | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（繁体界面/自定义模板）                                    |
-| **PTT (pttime)**      | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（PTT-NP 分支）                                            |
-| **Farmm (pt.0ff.cc)** | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（基本信息行内嵌大小）                                     |
-| **AGSVPT**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **XingYunGe**         | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **HDHome**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **HDTime**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **HDFans**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **LemonHD**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **BTSCHOOL**          | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **BYRPT**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **Audiences**         | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **CarPT**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **52PT**              | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **HXPT**              | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **MyPTCC**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **PTLover**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **PTSKIT**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **RainGFH**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **SoulVoice**         | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **TMPT**              | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **UBits**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **CrabPT**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 蟹黄堡（crabpt.vip）                                             |
-| **GameGamePT**        | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | GGPT（gamegamept.com）                                           |
-| **Dubhe**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 天枢（dubhe.site）                                               |
-| **PTCafe**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 咖啡（ptcafe.club）                                              |
-| **CyanBug**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 大青虫（cyanbug.net）                                            |
-| **DuckBoobee**        | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 鸭鸭（duckboobee.org）                                           |
-| **LongPT**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 龙PT（longpt.org）                                               |
-| **HDVideo**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | HD视频（hdvideo.top）                                            |
-| **GTKPW**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 多镜像（pt.gtkpw.xyz / pt.gtk.pw / pt.gtk.xyz / t.myaltbox.com） |
-| **NicePT**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 好趣（www.nicept.net，繁体）                                     |
-| **OurBits**           | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（ourbits.club，issue #329）                               |
-| **Mua**               | Cookie   | RSS、搜索、用户信息           | ✅       | 二次元站点（mua.xloli.cc，userdetails 走 uuid，issue #339）      |
-| **1PTBar**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **lajidui**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                       |
-| **PTLGS**             | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（ptlgs.org，issue #377）                                  |
-| **ZmPT**              | Cookie   | RSS、搜索、用户信息           | ✅       | 织梦（zmpt.cc，电力值=魔力值）                                   |
-| **PandaPT**           | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（pandapt.net，info_block 取上传/下载/魔力，issue #416）   |
-| **PTFans**            | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（ptfans.cc，含 H&R，info_block 取数据，issue #417）       |
-| **KamePT**            | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（kamept.com，info_block 含做种积分，issue #418）          |
-| **PTCHDBits**         | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（ptchdbits.co，详情页 img.pro_free 促销，issue 请求）     |
-| **PTerClub**          | Cookie   | RSS、搜索、用户信息           | ✅       | 猫站（pterclub.net，魔力值=猫粮，info_block 取数据）             |
-| **PTHome**            | Cookie   | RSS、搜索、用户信息           | ✅       | 铂金家（pthome.net，info_block 取上传/下载/魔力/做种积分）       |
-| **TangPT**            | Cookie   | RSS、搜索、用户信息           | ✅       | 糖果（www.tangpt.top，CHD 模板，issue #456）                     |
-| **T-Baozi**           | Cookie   | RSS、搜索、用户信息           | ✅       | 包子（p.t-baozi.cc，info_block 取数据，issue #457）              |
-| **PT@KEEPFRDS**       | Cookie   | RSS、搜索、用户信息           | ✅       | 朋友/FRDS（pt.keepfrds.com，issue #449）                         |
-| **DiscFan**           | Cookie   | RSS、搜索、用户信息           | ✅       | 碟粉（discfan.net，繁体界面，issue #494）                        |
-| **TCCF**              | Cookie   | RSS、搜索、用户信息           | ✅       | TorrentCCF（et8.org，种子列表含进度列，issue #496）              |
-| **TLFBits**           | Cookie   | RSS、搜索、用户信息           | ✅       | TLF / The Last Fantasy（pt.eastgame.org，issue #502）            |
-| **LuckPT**            | Cookie   | RSS、搜索、用户信息           | ✅       | pt.luckpt.de（issue #498）                                       |
-| **青蛙**              | Cookie   | RSS、搜索、用户信息           | ✅       | QingWaPT（www.qingwapt.com，自定义 span 优惠标签，issue #501）   |
-| **RailgunPT**         | Cookie   | RSS、搜索、用户信息           | ✅       | 站名与域名不一致（bilibili.download，issue #500）                |
-| **HDArea**            | Cookie   | RSS、搜索、用户信息           | ✅       | 高清视界（hdarea.club，issue #495）                              |
+| 站点                  | 认证方式 | 支持功能                      | 适配情况 | 备注                                                                         |
+| --------------------- | -------- | ----------------------------- | -------- | ---------------------------------------------------------------------------- |
+| **HDSky**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 完全适配                                                                     |
+| **SpringSunday**      | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 完全适配                                                                     |
+| **NovaHD**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **OpenCD**            | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（繁体界面/自定义模板）                                                |
+| **PTT (pttime)**      | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（PTT-NP 分支）                                                        |
+| **Farmm (pt.0ff.cc)** | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（基本信息行内嵌大小）                                                 |
+| **AGSVPT**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **XingYunGe**         | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **HDHome**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **HDTime**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **HDFans**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **LemonHD**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **BTSCHOOL**          | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **BYRPT**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **Audiences**         | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **CarPT**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **52PT**              | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **HXPT**              | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **MyPTCC**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **PTLover**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **PTSKIT**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **RainGFH**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **SoulVoice**         | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **TMPT**              | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **UBits**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **CrabPT**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 蟹黄堡（crabpt.vip）                                                         |
+| **GameGamePT**        | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | GGPT（gamegamept.com）                                                       |
+| **Dubhe**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 天枢（dubhe.site）                                                           |
+| **PTCafe**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 咖啡（ptcafe.club）                                                          |
+| **CyanBug**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 大青虫（cyanbug.net）                                                        |
+| **DuckBoobee**        | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 鸭鸭（duckboobee.org）                                                       |
+| **LongPT**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 龙PT（longpt.org）                                                           |
+| **HDVideo**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | HD视频（hdvideo.top）                                                        |
+| **GTKPW**             | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 多镜像（pt.gtkpw.xyz / pt.gtk.pw / pt.gtk.xyz / t.myaltbox.com）             |
+| **NicePT**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 好趣（www.nicept.net，繁体）                                                 |
+| **OurBits**           | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（ourbits.club，issue #329）                                           |
+| **Mua**               | Cookie   | RSS、搜索、用户信息           | ✅       | 二次元站点（mua.xloli.cc，userdetails 走 uuid，issue #339）                  |
+| **1PTBar**            | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **lajidui**           | Cookie   | RSS、搜索、用户信息、等级要求 | ✅       | 已适配，有问题请提交 issue                                                   |
+| **PTLGS**             | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（ptlgs.org，issue #377）                                              |
+| **ZmPT**              | Cookie   | RSS、搜索、用户信息           | ✅       | 织梦（zmpt.cc，电力值=魔力值）                                               |
+| **PandaPT**           | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（pandapt.net，info_block 取上传/下载/魔力，issue #416）               |
+| **PTFans**            | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（ptfans.cc，含 H&R，info_block 取数据，issue #417）                   |
+| **KamePT**            | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（kamept.com，info_block 含做种积分，issue #418）                      |
+| **PTCHDBits**         | Cookie   | RSS、搜索、用户信息           | ✅       | 已适配（ptchdbits.co，详情页 img.pro_free 促销，issue 请求）                 |
+| **PTerClub**          | Cookie   | RSS、搜索、用户信息           | ✅       | 猫站（pterclub.net，魔力值=猫粮，info_block 取数据）                         |
+| **PTHome**            | Cookie   | RSS、搜索、用户信息           | ✅       | 铂金家（pthome.net，info_block 取上传/下载/魔力/做种积分）                   |
+| **TangPT**            | Cookie   | RSS、搜索、用户信息           | ✅       | 糖果（www.tangpt.top，CHD 模板，issue #456）                                 |
+| **T-Baozi**           | Cookie   | RSS、搜索、用户信息           | ✅       | 包子（p.t-baozi.cc，info_block 取数据，issue #457）                          |
+| **PT@KEEPFRDS**       | Cookie   | RSS、搜索、用户信息           | ✅       | 朋友/FRDS（pt.keepfrds.com，issue #449）                                     |
+| **DiscFan**           | Cookie   | RSS、搜索、用户信息           | ✅       | 碟粉（discfan.net，繁体界面，issue #494）                                    |
+| **TCCF**              | Cookie   | RSS、搜索、用户信息           | ✅       | TorrentCCF（et8.org，种子列表含进度列，issue #496）                          |
+| **TLFBits**           | Cookie   | RSS、搜索、用户信息           | ✅       | TLF / The Last Fantasy（pt.eastgame.org，issue #502）                        |
+| **LuckPT**            | Cookie   | RSS、搜索、用户信息           | ✅       | pt.luckpt.de（issue #498）                                                   |
+| **青蛙**              | Cookie   | RSS、搜索、用户信息           | ✅       | QingWaPT（www.qingwapt.com，自定义 span 优惠标签，issue #501）               |
+| **RailgunPT**         | Cookie   | RSS、搜索、用户信息           | ✅       | 站名与域名不一致（bilibili.download，issue #500）                            |
+| **HDArea**            | Cookie   | RSS、搜索、用户信息           | ✅       | 高清视界（hdarea.club，issue #495）                                          |
+| **财神**              | Cookie   | RSS、搜索、用户信息           | ✅       | cspt.top（种子列表为 div 布局，issue #499）                                  |
+| **HHCLUB**            | Cookie   | RSS、搜索、用户信息           | ✅       | hhanclub.net（列表与详情页均为 div 布局，优惠标签为自定义 span，issue #492） |
+| **U2分享園@動漫花園** | Cookie   | RSS、搜索、用户信息           | ✅       | U2 / 動漫花園（u2.dmhy.org，详情页无隐藏标题域，标题走文本解析，issue #497） |
 
 ### 其他架构（4）
 

--- a/site/v2/definitions/cspt.go
+++ b/site/v2/definitions/cspt.go
@@ -1,0 +1,229 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+// CsptDefinition 描述财神（cspt.top）站点。
+//
+// 站点内核为标准 NexusPHP，但套用了 Tailwind 皮肤，因此呈现出「列表页 div、详情页 table」
+// 的混合结构，是目前唯一需要 div 版行选择器的站点：
+//
+//  1. torrents.php 的种子列表完全由 div 组成：外层 div.torrents 内每行是
+//     div.torrent-table-sub-info，其下并列 div.torrent-cat（分类）、div.torrent-title
+//     （标题/副标题/评分/标签）、包裹 div.torrent-info 的统计列以及 div.torrent-manage
+//     （收藏/下载）。表头行是另一个 div（bg-[main_tittle]），同样带 torrent-cat /
+//     torrent-title / torrent-info，但**不带** torrent-table-sub-info，因此行选择器
+//     必须锚定 torrent-table-sub-info，并额外用 :has(a[href*='details.php']) 兜底。
+//  2. 统计列有稳定的语义类名（torrent-info-text-size / -seeders / -leechers /
+//     -finished / -added），优先用类名而非 nth-child，避免站点调整列序后失配。
+//  3. details.php 仍是常规 table 布局，且保留 input[name='torrent_name'] /
+//     input[name='detail_torrent_id'] 隐藏域，因此详情解析与 btschool/eastgame 一致。
+//  4. 站点没有 #info_block（源码里被注释掉了），顶部个人信息改为 div.menu-base-info，
+//     做种/下载数藏在 svg <title> 之后的 <a> 里，只能用 html + 正则取值。
+//  5. 魔力值在本站叫「金元宝」，userdetails.php 的行标签同名。
+var CsptDefinition = &v2.SiteDefinition{
+	ID:             "cspt",
+	Name:           "财神",
+	Description:    "综合性 PT 站点（NexusPHP + Tailwind 皮肤）",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://cspt.top/"},
+	FaviconURL:     "https://cspt.top/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "seeding", "leeching", "bonus"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields: []string{
+					"uploaded", "downloaded", "ratio", "trueUploaded", "trueDownloaded",
+					"levelName", "joinTime", "lastAccessAt",
+				},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			// 顶栏用户名链接位于 span.user-id 内，class 形如 PowerUser_Name；
+			// 先按 span.user-id 限定，避免在 userdetails.php 上误取「邀请人」那一行的
+			// EliteUser_Name 链接。
+			"id": {
+				Selector: []string{
+					"span.user-id a[href*='userdetails.php'][class*='Name']",
+					"#user-info-pannl a[href*='userdetails.php']",
+					"a[href*='userdetails.php']",
+				},
+				Attr:    "href",
+				Filters: []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{
+					"span.user-id a[href*='userdetails.php'][class*='Name']",
+					"a[href*='userdetails.php'][class*='Name']",
+				},
+			},
+			// 顶栏没有 img.arrowup/arrowdown，做种/下载数是
+			// <svg ...><title id="downing">当前做种</title>...</svg>&nbsp;<a href="userdetails.php?id=...">329</a>
+			// 的结构，只能取 div.menu-base-info 的 html 后按 svg 标题文案定位。
+			"seeding": {
+				Selector: []string{"div.menu-base-info"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?s)当前做种</title>.*?<a[^>]*>\s*([\d,]+)\s*</a>`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"leeching": {
+				Selector: []string{"div.menu-base-info"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(?s)正在下载</title>.*?<a[^>]*>\s*([\d,]+)\s*</a>`}},
+					{Name: "parseNumber"},
+				},
+			},
+			// 本站魔力值命名为「金元宝」：顶栏是 mybonus.php 链接，
+			// userdetails.php 上是同名行标签。
+			"bonus": {
+				Selector: []string{
+					"div.menu-base-info a[href*='mybonus.php']",
+					"td.rowhead:contains('金元宝') + td",
+					"td.rowhead:contains('魔力值') + td",
+				},
+				Filters: []v2.Filter{{Name: "parseNumber"}},
+			},
+			// 「传输」行是合并单元格（内嵌 table），需以 html + regex 拆分。
+			// 单元格内同时存在 上传量/实际上传量、下载量/实际下载量、分享率/实际分享率，
+			// 正则以 <strong> 紧跟标签名的方式区分，不会被「实际」前缀串味。
+			"uploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>上传量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"downloaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>下载量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"trueUploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>实际上传量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"trueDownloaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>实际下载量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"ratio": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>分享率</strong>[：:\s]*(?:<font[^>]*>)?([\d.,]+|∞|Inf)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"levelName": {
+				Selector: []string{"td.rowhead:contains('等级') + td img", "td.rowhead:contains('等級') + td img"},
+				Attr:     "title",
+			},
+			"joinTime": {
+				Selector: []string{
+					"td.rowhead:contains('加入日期') + td",
+					"td.rowhead:contains('Join') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+			// 保号探测只读取 UserInfo.LastAccess，缺失会导致线上探测解析失败。
+			"lastAccessAt": {
+				Selector: []string{
+					"td.rowhead:contains('最近动向') + td",
+					"td.rowhead:contains('最近動向') + td",
+					"td.rowhead:contains('上次访问') + td",
+					"td.rowhead:contains('Last access') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		// div 版行选择器：torrent-table-sub-info 只出现在真实种子行上（表头行只有
+		// torrent-cat / torrent-title / torrent-info），:has 再兜一层保证行内确有种子链接。
+		TableRows: "div.torrent-table-sub-info:has(a[href*='details.php'])",
+		// 标题链接自带 torrent-info-text-name 类，<b> 内文本即完整标题（title 属性同值）。
+		Title:     "a.torrent-info-text-name",
+		TitleLink: "a.torrent-info-text-name",
+		// 副标题有独立类名，无需 SubtitleSelector 的 html + 正则方案。
+		Subtitle: "div.torrent-info-text-small_name",
+		// 统计列按语义类名取值，均为纯文本（种子数外层包 <b><a><font>，Text() 后仍是数字）。
+		Size:         "div.torrent-info-text-size",
+		Seeders:      "div.torrent-info-text-seeders",
+		Leechers:     "div.torrent-info-text-leechers",
+		Snatched:     "div.torrent-info-text-finished",
+		DiscountIcon: "img.pro_free, img.pro_free2up, img.pro_2up, img.pro_50pctdown, img.pro_50pctdown2up, img.pro_30pctdown",
+		// 促销结束时间以 <font color='#0000FF'>剩余时间：<span title="..."> 真实渲染，
+		// 限定 font[color] 可避免误取 div.torrent-info 内的发布时间 span；
+		// 若某些页面不渲染该 span，驱动会回退解析促销图标的 onmouseover 提示。
+		DiscountEndTime:    "div.torrent-title font[color] span[title]",
+		DownloadLink:       "div.torrent-manage a[href*='download.php']",
+		Category:           "div.torrent-cat img[alt]",
+		UploadTime:         "div.torrent-info-text-added span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下载') + td a[href*='download.php'], td.rowhead:contains('行为') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		// 顶栏有 [H&R]: [0/0/10] 计数器，若把 "H&R" 列为关键字会让每个种子都被判定为 H&R，
+		// 因此只保留 NexusPHP 的图标/文案关键字。
+		HRKeywords: []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		// 详情页保留隐藏域，标题/ID 直接取 value
+		TitleSelector: "input[name='torrent_name']",
+		IDSelector:    "input[name='detail_torrent_id']",
+		// h1 内促销标记为 <font class='free'>（单引号 class，goquery 已归一化）
+		DiscountSelector: "h1 font.free, h1 font[class]",
+		// h1 里还有一个 <span title="通过"> 状态图标，限定 font[color] 只命中剩余时间 span
+		EndTimeSelector: "h1 font[color] span[title]",
+		// ParseSizeMB 读取 SizeSelector 元素的 .Next() 兄弟节点，因此必须指向标签单元格；
+		// 标签文本包在 <span class="td-text"> 内，:contains 匹配后代文本仍然命中。
+		// 本站正文体积为十进制单位 + 全角冒号（大小：12.98 GB），但页内他处混用 GiB，
+		// 故单位组同时接受十进制与 IEC 写法。
+		SizeSelector: "td.rowhead:contains('基本信息')",
+		SizeRegex:    `大小[：:]\s*([\d.]+)\s*(TiB|GiB|MiB|KiB|TB|GB|MB|KB)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(CsptDefinition)
+}

--- a/site/v2/definitions/cspt_fixture_test.go
+++ b/site/v2/definitions/cspt_fixture_test.go
@@ -1,0 +1,335 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "cspt",
+		Search:   testCsptSearch,
+		Detail:   testCsptDetail,
+		UserInfo: testCsptUserInfo,
+	})
+}
+
+// --- Fixtures ---
+//
+// 结构照搬真实页面（Tailwind 皮肤），但所有标题、副标题、种子 ID、用户名、用户 ID
+// 与统计数值均已替换为虚构值，勋章图片与邮箱/IP 行整段移除。
+//
+// 搜索页是 div 布局，需要覆盖的真实特征：
+//   - 表头行同样带 torrent-cat / torrent-title / torrent-info，但不带
+//     torrent-table-sub-info，也没有 details.php 链接 —— 必须被行选择器排除
+//   - 每行三个并列单元格：div.torrent-cat、div.torrent-title、包裹
+//     div.torrent-info 的统计列，另有 div.torrent-manage 放收藏/下载
+//   - 促销结束时间同时出现在 img.pro_free 的 onmouseover 提示与
+//     <font color>剩余时间：<span title> 中
+//   - 永久免费的行只有 img.pro_free[title=免费]，既无 onmouseover 也无剩余时间
+//   - 标题单元格内还有 <span title="通过"> 状态图标，不能被当成促销结束时间
+//   - 副标题有独立类名 torrent-info-text-small_name
+
+const csptSearchFixture = `<html><body>
+<div class="torrents">
+<div class="flex h-[30px] bg-[main_tittle] m-auto radius-[3px]"><div class="torrent-cat"><span class="text-[fff] font-bold text-[16px] m-auto ">类型</span></div><div class="torrent-title items-center justify-center a:tittle-[fff] a "><a class="text-[fff] text-[16px] font-bold m-auto" href="?sort=1&amp;type=asc">标题</a></div><div class="flex w-[20%] items-center"><div class="torrent-info"><a class="torrent-info-icon" href="?sort=3&amp;type=desc"><img class="comments" src="pic/icc/chat-message.png" alt="comments" title="评论数"/></a><a class="torrent-info-icon" href="?sort=5&amp;type=desc"><img class="size" src="pic/icc/wealth-1.png" alt="size" title="大小"/></a></div></div><div class="torrent-manage"></div> </div>
+<div class="flex flex-col w-[100%] m-auto torrent-table-for-spider"><div class="flex bg-[green] position-r torrent-table-sub-info "  style="background-color: #89c9e6"><div class="torrent-cat" >
+<div class="rounded-md"><a href="?cat=405"><img class="c_anime" src="pic/cattrans.gif" alt="动漫" title="动漫" style="background-image: url(pic/category/chs/catsprites.png);" /></a></div>
+</div><div class="flex torrent-table-for-spider-info torrent-title items-center gap-x-[15px] justify-between"><div class="flex flex-col gap-y-1 w-[calc(100%-40px)]" ><div class="flex items-center flex-wrap"><img class="sticky position-a" src="pic/icc/top-zhiding.png" alt="置顶图标" title="一级置顶" /><a target="_blank" class="flex items-center gap-x-[5px] font-bold text-[fff] text-[9pt] torrent-info-text-name text-start" title="Fixture.Anime.Movie.2026.1080p.WEB-DL.H.265.DDP.5.1-FIXTURE"  href="details.php?id=88801&amp;hit=1"><b class="flex items-center truncate"  >Fixture.Anime.Movie.2026.1080p.WEB-DL.H.265.DDP.5.1-FIXTURE</b></a><div class="flex items-center gap-x-[5px]"><b> (<font class='new'>新</font>)</b> <img class="pro_free" src="pic/trans.gif" alt="Free"  onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;free&quot;&gt;免费&lt;/font&gt;&lt;/b&gt;剩余时间：&lt;b&gt;&lt;span title=&quot;2026-07-31 12:00:00&quot;&gt;2天22时&lt;/span&gt;&lt;/b&gt;', 'trail', false, 'delay',500,'lifetime',3000);" /> <font color='#0000FF'>剩余时间：<span title="2026-07-31 12:00:00">2天22时</span></font><span style="margin-left: 6px" title="通过"><svg t="1655145688503" class="icon" viewBox="0 0 1413 1024" width="16" height="16"><path d="M1381 107L1274 0 465 809 142 487 35 594l430 430z" fill="#1afa29"></path></svg></span></div> </div><div class='flex items-center gap-x-[8px]'><div class='overflow-hidden truncate text-[9pt] font-[500] flex-1 text-start torrent-info-text-small_name' >虚构副标题一 | 类型：喜剧/动画 | [英/国]音轨</div></div><div class="flex gap-x-[5px] text-[9pt] items-center pr-5"><div class="flex text-[9pt] text-[000] font-bold items-center"><img src="pic/imdb2.png" alt="imdb" title="imdb" /><span>&nbsp; N/A</span></div><span style="background-color:#0000ff;color:#FFFFFF" title="">官种</span><div class="flex items-center torrent-info-text-author"><i>匿名</i></div>
+</div><div class="w-full pr-[10px] mb-[5px]" ></div></div></div><div class="flex w-[20%] items-center" ><div class="torrent-info"><div class="torrent-info-text torrent-info-text-comments"><a href="comment.php?action=add&amp;pid=88801&amp;type=torrent" title="添加评论">0</a></div><div class="torrent-info-text torrent-info-text-added"><span title="2026-07-27 14:07:42">1时6分钟</span></div><div class="torrent-info-text torrent-info-text-size" >12.98 GB</div><div class="torrent-info-text torrent-info-text-seeders" align="center"><b><a href="details.php?id=88801&amp;hit=1&amp;dllist=1#seeders"><font color="#ee0000">1</font></a></b></div>
+<div class="torrent-info-text torrent-info-text-leechers"><b><a href="details.php?id=88801&amp;hit=1&amp;dllist=1#leechers">35</a></b></div>
+<div class="torrent-info-text torrent-info-text-finished">0</div>
+</div></div><div class="torrent-manage"><a id="bookmark0"  href="javascript: bookmark(88801,0);" ><img class="delbookmark" src="pic/icc/cart-add.png" alt="Unbookmarked" title="收藏" /></a><a class="inline-flex" href="download.php?id=88801"><img class="download" src="pic/icc/install-black.png" alt="download" title="下载本种" /></a></div>
+</div>
+</div>
+<div class="flex flex-col w-[100%] m-auto torrent-table-for-spider"><div class="flex bg-[green] position-r torrent-table-sub-info "><div class="torrent-cat" >
+<div class="rounded-md"><a href="?cat=401"><img class="c_movie" src="pic/cattrans.gif" alt="电影" title="电影" /></a></div>
+</div><div class="flex torrent-table-for-spider-info torrent-title items-center gap-x-[15px] justify-between"><div class="flex flex-col gap-y-1 w-[calc(100%-40px)]" ><div class="flex items-center flex-wrap"><a target="_blank" class="flex items-center gap-x-[5px] font-bold text-[fff] text-[9pt] torrent-info-text-name text-start" title="Fixture.Guide.v2.0-FIXTURE"  href="details.php?id=88802&amp;hit=1"><b class="flex items-center truncate"  >Fixture.Guide.v2.0-FIXTURE</b></a><div class="flex items-center gap-x-[5px]"><span style="margin-left: 6px" title="通过"><svg t="1655145688503" class="icon" viewBox="0 0 1413 1024" width="16" height="16"><path d="M1381 107L1274 0 465 809z" fill="#1afa29"></path></svg></span></div> </div><div class='flex items-center gap-x-[8px]'><div class='overflow-hidden truncate text-[9pt] font-[500] flex-1 text-start torrent-info-text-small_name' >虚构副标题二</div></div><div class="flex items-center torrent-info-text-author"><i>匿名</i></div></div></div><div class="flex w-[20%] items-center" ><div class="torrent-info"><div class="torrent-info-text torrent-info-text-comments"><a href="comment.php?action=add&amp;pid=88802&amp;type=torrent" title="添加评论">3</a></div><div class="torrent-info-text torrent-info-text-added"><span title="2026-05-01 12:00:00">2月26天</span></div><div class="torrent-info-text torrent-info-text-size" >816.30 MB</div><div class="torrent-info-text torrent-info-text-seeders" align="center"><b><a href="details.php?id=88802&amp;hit=1&amp;dllist=1#seeders">206</a></b></div>
+<div class="torrent-info-text torrent-info-text-leechers"><b><a href="details.php?id=88802&amp;hit=1&amp;dllist=1#leechers">1</a></b></div>
+<div class="torrent-info-text torrent-info-text-finished">0</div>
+</div></div><div class="torrent-manage"><a class="inline-flex" href="download.php?id=88802"><img class="download" src="pic/icc/install-black.png" alt="download" title="下载本种" /></a></div>
+</div>
+</div>
+<div class="flex flex-col w-[100%] m-auto torrent-table-for-spider"><div class="flex bg-[green] position-r torrent-table-sub-info "><div class="torrent-cat" >
+<div class="rounded-md"><a href="?cat=402"><img class="c_tvseries" src="pic/cattrans.gif" alt="剧集" title="剧集" /></a></div>
+</div><div class="flex torrent-table-for-spider-info torrent-title items-center gap-x-[15px] justify-between"><div class="flex flex-col gap-y-1 w-[calc(100%-40px)]" ><div class="flex items-center flex-wrap"><a target="_blank" class="flex items-center gap-x-[5px] font-bold text-[fff] text-[9pt] torrent-info-text-name text-start" title="Fixture.Forever.Free.Pack-FIXTURE"  href="details.php?id=88803&amp;hit=1"><b class="flex items-center truncate"  >Fixture.Forever.Free.Pack-FIXTURE</b></a><div class="flex items-center gap-x-[5px]"><img class="pro_free" src="pic/trans.gif" alt="Free" title="免费" /><span style="margin-left: 6px" title="通过"><svg t="1655145688503" class="icon" viewBox="0 0 1413 1024" width="16" height="16"><path d="M1381 107L1274 0 465 809z" fill="#1afa29"></path></svg></span></div> </div><div class='flex items-center gap-x-[8px]'><div class='overflow-hidden truncate text-[9pt] font-[500] flex-1 text-start torrent-info-text-small_name' >虚构副标题三</div></div></div></div><div class="flex w-[20%] items-center" ><div class="torrent-info"><div class="torrent-info-text torrent-info-text-comments">0</div><div class="torrent-info-text torrent-info-text-added"><span title="2025-12-31 08:00:00">6月27天</span></div><div class="torrent-info-text torrent-info-text-size" >1.57 GB</div><div class="torrent-info-text torrent-info-text-seeders" align="center"><b><a href="details.php?id=88803&amp;hit=1&amp;dllist=1#seeders">12</a></b></div>
+<div class="torrent-info-text torrent-info-text-leechers"><b><a href="details.php?id=88803&amp;hit=1&amp;dllist=1#leechers">4</a></b></div>
+<div class="torrent-info-text torrent-info-text-finished">88</div>
+</div></div><div class="torrent-manage"><a class="inline-flex" href="download.php?id=88803"><img class="download" src="pic/icc/install-black.png" alt="download" title="下载本种" /></a></div>
+</div>
+</div>
+</div>
+</body></html>`
+
+// 详情页：常规 table 布局，标题/ID 来自隐藏域；h1 内促销标记是单引号 class='free'，
+// 剩余时间包在 <font color> 里，后面紧跟 <span title="通过"> 状态图标；
+// 「基本信息」标签文本被 <span class="td-text"> 包裹，值单元格类名为 rowfollow main_rowfollw。
+// 顶栏刻意保留 [H&R]: [0/0/10] 计数器，用于验证 HRKeywords 不会把它误判为 H&R 种子。
+const csptDetailFixture = `<html><body>
+<div class="menu-base-info"><div class="menu-base-info-items">[H&amp;R]:
+    [<a href="myhr.php">0/<font color="red">0</font>/10</a>]</div></div>
+<h1 align="center" id="top">Fixture.Anime.Movie.2026.1080p.WEB-DL.H.265.DDP.5.1-FIXTURE&nbsp;&nbsp;&nbsp; <b>[<font class='free' >免费</font>]</b> <font color='#0000FF'>剩余时间：<span title="2026-07-31 12:00:00">2天22时</span></font><span style="margin-left: 6px" title="通过"><svg t="1655145688503" class="icon" viewBox="0 0 1413 1024" width="16" height="16"><path d="M1381 107L1274 0 465 809z" fill="#1afa29"></path></svg></span></h1>
+<table width="100%" cellspacing="0" cellpadding="5" class="main_table">
+<tr><td class="rowhead nowrap main_rowhead" valign="center" align="right"><span class="td-text main_td_text">下载</span></td><td class="rowfollow main_rowfollw" valign="center" align="left"><a class="index" href="download.php?id=88801">[FIXTURE].Fixture.Anime.Movie.2026.1080p.WEB-DL.torrent</a>&nbsp;&nbsp;&nbsp;由&nbsp;<i>匿名</i>发布</td></tr>
+<tr><td class="rowhead nowrap main_rowhead" valign="center" align="right"><span class="td-text main_td_text">副标题</span></td><td class="rowfollow main_rowfollw" valign="center" align="left">虚构副标题一 | 类型：喜剧/动画 | [英/国]音轨</td></tr>
+<tr><td class="rowhead nowrap main_rowhead" valign="center" align="right"><span class="td-text main_td_text">基本信息</span></td><td class="rowfollow main_rowfollw" valign="center" align="left"><b><b>大小：</b></b>12.98 GB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;动漫&nbsp;&nbsp;&nbsp;<b>媒介: </b>WEB-DL&nbsp;&nbsp;&nbsp;<b>编码: </b>H.265/HEVC&nbsp;&nbsp;&nbsp;<b>分辨率: </b>1080p</td></tr>
+<tr><td class="rowhead nowrap main_rowhead" valign="center" align="right"><span class="td-text main_td_text">行为</span></td><td class="rowfollow main_rowfollw" valign="center" align="left"><a title="下载种子" href="download.php?id=88801"><img class="dt_download" src="pic/trans.gif" alt="download" />&nbsp;<b><font class="small">下载种子</font></b></a></td></tr>
+<tr><td class="rowhead nowrap main_rowhead" valign="center" align="right"><span class="td-text main_td_text">字幕</span></td><td class="rowfollow main_rowfollw" valign="center" align="left">该种子暂无字幕<form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Fixture.Anime.Movie.2026.1080p.WEB-DL.H.265.DDP.5.1-FIXTURE" /><input class="button-black" type="hidden" name="detail_torrent_id" value="88801" /></form></td></tr>
+</table>
+</body></html>`
+
+// 无促销的详情页：h1 里没有 font.free，也没有剩余时间。
+const csptDetailPlainFixture = `<html><body>
+<div class="menu-base-info"><div class="menu-base-info-items">[H&amp;R]:
+    [<a href="myhr.php">0/<font color="red">0</font>/10</a>]</div></div>
+<h1 align="center" id="top">Fixture.Guide.v2.0-FIXTURE<span style="margin-left: 6px" title="通过"><svg viewBox="0 0 1413 1024" width="16" height="16"><path d="M1381 107L1274 0z" fill="#1afa29"></path></svg></span></h1>
+<table width="100%" cellspacing="0" cellpadding="5" class="main_table">
+<tr><td class="rowhead nowrap main_rowhead" valign="center" align="right"><span class="td-text main_td_text">基本信息</span></td><td class="rowfollow main_rowfollw" valign="center" align="left"><b><b>大小：</b></b>816.30 MB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;资料</td></tr>
+<tr><td class="rowhead nowrap main_rowhead" valign="center" align="right"><span class="td-text main_td_text">字幕</span></td><td class="rowfollow main_rowfollw" valign="center" align="left"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Fixture.Guide.v2.0-FIXTURE" /><input type="hidden" name="detail_torrent_id" value="88802" /></form></td></tr>
+</table>
+</body></html>`
+
+// index.php 顶栏：站点没有 #info_block（源码已注释），个人信息全在 div.menu-base-info。
+// 做种/下载数没有 img.arrowup/arrowdown，只能靠 svg <title> 文案定位随后的 <a>；
+// 魔力值在本站叫「金元宝」，链接指向 mybonus.php。
+const csptIndexFixture = `<html><body>
+<div class="user-info-container">
+<span class="user-id"><span class="nowrap"><a href="https://cspt.top/userdetails.php?id=90101" class='PowerUser_Name'><b>cspt_fixture_user</b></a></span><span class="uname-medal"></span></span>
+<p class="user-Uid">UID：90101</p>
+<div class="user-info">
+<div class="menu-base-info">
+<div class="menu-base-info-items"><div><a href="attendance.php" class="">[签到已得170]</a></div></div>
+<div class="menu-base-info-items">[H&amp;R]: [<a href="myhr.php">0/<font color="red">0</font>/10</a>]</div>
+<div class="menu-base-info-items"><svg role="img" width="16px" height="16px" viewBox="0 0 24 24" aria-labelledby="arrowUpIconTitle" fill="none"><title id="arrowUpIconTitle">上传量</title><path d="M18 9l-6-6-6 6"/></svg>&nbsp;<a href="userdetails.php?id=90101"><font class="color_uploaded" style="display: none;">上传量:</font> 512.00 GB </a></div>
+<div class="menu-base-info-items"><svg role="img" width="16px" height="16px" viewBox="0 0 24 24" aria-labelledby="arrowDownIconTitle" fill="none"><title id="arrowDownIconTitle">下载量</title><path d="M6 15l6 6 6-6"/></svg>&nbsp;<a href="userdetails.php?id=90101"><font class="color_downloaded" style="display: none;"> 下载量:</font> 128.00 GB </a></div>
+<div class="menu-base-info-items"><svg role="img" width="16px" height="16px" viewBox="0 0 24 24" aria-labelledby="shareAndroidIconTitle" fill="none"><title id="shareAndroidIconTitle">分享率</title><circle cx="6" cy="12" r="2"/></svg>&nbsp;<a href="userdetails.php?id=90101"><font class="color_ratio" style="display: none;">分享率:</font>4.000</a></div>
+<div class="menu-base-info-items"><svg t="1746456215620" class="icon" viewBox="0 0 1380 1024" width="18" height="18"><title id="dolarIconTitle">元宝</title><path d="M391 327C407 208 516 116 647 116z" fill="#FFDB60"></path></svg>&nbsp;<a href="mybonus.php?id=90101">12,345.6</a></div>
+<div class="menu-base-info-items"><svg t="1742174330017" class="icon" viewBox="0 0 1024 1024" width="16" height="16"><title id="downing">当前做种</title><path d="M799 352C786 212 667 102 523 102z" fill="#1afa29"></path></svg>&nbsp;<a href="userdetails.php?id=90101">128</a></div>
+<div class="menu-base-info-items"><svg t="1742174528229" class="icon" viewBox="0 0 1024 1024" width="16" height="16"><title id="downing">正在下载</title><path d="M874 789c0 46-37 85-85 85z" fill="#d81e06"></path></svg>&nbsp;<a href="userdetails.php?id=90101">3</a></div>
+</div>
+</div>
+</div>
+</body></html>`
+
+// userdetails.php 正文表格：「传输」行是合并单元格（内嵌 table），同时存在
+// 上传量/实际上传量、下载量/实际下载量、分享率/实际分享率，正则必须靠
+// <strong> 紧跟标签名来区分；顶栏同样保留，用于验证「邀请人」行的 EliteUser_Name
+// 不会被 span.user-id 限定的 name 选择器误取。
+const csptUserdetailsFixture = `<html><body>
+<span class="user-id"><span class="nowrap"><a href="https://cspt.top/userdetails.php?id=90101" class='PowerUser_Name'><b>cspt_fixture_user</b></a></span></span>
+<div class="menu-base-info">
+<div class="menu-base-info-items"><svg class="icon" viewBox="0 0 1380 1024" width="18" height="18"><title id="dolarIconTitle">元宝</title></svg>&nbsp;<a href="mybonus.php?id=90101">12,345.6</a></div>
+<div class="menu-base-info-items"><svg class="icon" viewBox="0 0 1024 1024" width="16" height="16"><title id="downing">当前做种</title></svg>&nbsp;<a href="userdetails.php?id=90101">128</a></div>
+<div class="menu-base-info-items"><svg class="icon" viewBox="0 0 1024 1024" width="16" height="16"><title id="downing">正在下载</title></svg>&nbsp;<a href="userdetails.php?id=90101">3</a></div>
+</div>
+<table width="100%" border="1" cellspacing="0" cellpadding="5" class="main_table">
+<tr><td width="1%" class="rowhead nowrap main_rowhead" valign="top" align="right">用户ID/UID</td><td width="99%" class="rowfollow main_rowfollw" valign="top" align="left">90101</td></tr>
+<tr><td width="1%" class="rowhead nowrap main_rowhead" valign="top" align="right">邀请人</td><td width="99%" class="rowfollow main_rowfollw" valign="top" align="left"><span class="nowrap"><a  href="https://cspt.top/userdetails.php?id=90999" class='EliteUser_Name'><b>cspt_fixture_inviter</b></a></span></td></tr>
+<tr><td width="1%" class="rowhead nowrap main_rowhead" valign="top" align="right">加入日期</td><td width="99%" class="rowfollow main_rowfollw" valign="top" align="left">2025-03-04 09:10:11 (<span title="2025-03-04 09:10:11">1年4月前</span>, 60周)</td></tr>
+<tr><td width="1%" class="rowhead nowrap main_rowhead" valign="top" align="right">最近动向</td><td width="99%" class="rowfollow main_rowfollw" valign="top" align="left">2026-07-20 08:30:00 (<span title="2026-07-20 08:30:00">7天前</span>)</td></tr>
+<tr><td width="1%" class="rowhead nowrap main_rowhead" valign="top" align="right">传输</td><td width="99%" class="rowfollow main_rowfollw" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>分享率</strong>:  <font color="">4.000</font>（<strong>实际分享率</strong>：1.600）</td><td class="embedded">&nbsp;&nbsp;<img src="pic/smilies/5.gif" alt="" /></td></tr><tr><td class="embedded"><strong>上传量</strong>:  512.00 GB <span class="text-muted">(当月: 100.00 GB)</span></td><td class="embedded">&nbsp;&nbsp;<strong>下载量</strong>:  128.00 GB <span class="text-muted">(当月: 20.00 GB)</span></td></tr><tr><td class="embedded"><strong>实际上传量</strong>:  400.50 GB</td><td class="embedded">&nbsp;&nbsp;<strong>实际下载量</strong>:  250.25 GB</td><td class="embedded text-muted">&nbsp;&nbsp;实际上传/下载量 (仅用于记录, 不参与分享率计算)</td></tr></table></td></tr>
+<tr><td width="1%" class="rowhead nowrap main_rowhead" valign="top" align="right">BT时间</td><td width="99%" class="rowfollow main_rowfollw" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>做种时间</strong>:  120天02:47:36</td><td class="embedded">&nbsp;&nbsp;<strong>下载时间</strong>:  30天17:58:19</td></tr></table></td></tr>
+<tr><td width="1%" class="rowhead nowrap main_rowhead" valign="top" align="right">等级</td><td width="99%" class="rowfollow main_rowfollw" valign="top" align="left"><img alt="Power User" title="Power User" src="pic/power.gif" style="max-width: 100px;" /> </td></tr>
+<tr><td width="1%" class="rowhead nowrap main_rowhead" valign="top" align="right">金元宝</td><td width="99%" class="rowfollow main_rowfollw" valign="top" align="left">12,345.6</td></tr>
+<tr><td width="1%" class="rowhead nowrap main_rowhead" valign="top" align="right">做种积分</td><td width="99%" class="rowfollow main_rowfollw" valign="top" align="left">193,370.8</td></tr>
+</table>
+</body></html>`
+
+// --- Helpers ---
+
+func getCsptDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("cspt")
+	require.True(t, ok, "cspt definition not found")
+	return def
+}
+
+// --- Suite: Search ---
+
+func testCsptSearch(t *testing.T) {
+	def := getCsptDef(t)
+
+	// 先证明行选择器排除了表头行：表头同样带 torrent-title / torrent-cat / torrent-info，
+	// 但没有 torrent-table-sub-info，也没有 details.php 链接。
+	t.Run("HeaderRowExcluded", func(t *testing.T) {
+		doc := FixtureDoc(t, "cspt_search", csptSearchFixture)
+		assert.Equal(t, 4, doc.Find("div.torrent-title").Length(), "1 表头 + 3 种子行都带 torrent-title")
+		assert.Equal(t, 4, doc.Find("div.torrent-info").Length(), "1 表头 + 3 种子行都带 torrent-info")
+		assert.Equal(t, 3, doc.Find(def.Selectors.TableRows).Length(), "行选择器只能命中 3 个真实种子行")
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(csptSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{
+		BaseURL:   server.URL,
+		Cookie:    "test_cookie=1",
+		Selectors: def.Selectors,
+	})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: "GET"})
+	require.NoError(t, err)
+
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 3, "表头行必须被排除，只解析 3 个种子行")
+
+	free := items[0]
+	assert.Equal(t, "88801", free.ID)
+	assert.Equal(t, "Fixture.Anime.Movie.2026.1080p.WEB-DL.H.265.DDP.5.1-FIXTURE", free.Title)
+	assert.Equal(t, "虚构副标题一 | 类型：喜剧/动画 | [英/国]音轨", free.Subtitle)
+	assert.Equal(t, v2.DiscountFree, free.DiscountLevel)
+	assert.Equal(t, int64(13937168875), free.SizeBytes)
+	assert.Equal(t, 1, free.Seeders)
+	assert.Equal(t, 35, free.Leechers)
+	assert.Equal(t, 0, free.Snatched)
+	assert.Equal(t, "动漫", free.Category)
+	// 促销结束时间取 <font color> 内的 span，不能误取 title="通过" 或统计列的发布时间
+	require.False(t, free.DiscountEndTime.IsZero(), "discount end time should be parsed")
+	assert.Equal(t, "2026-07-31 12:00:00", free.DiscountEndTime.Format("2006-01-02 15:04:05"))
+	// 发布时间来自 div.torrent-info-text-added 的 span[title]
+	assert.Equal(t, int64(1785161262), free.UploadedAt)
+
+	normal := items[1]
+	assert.Equal(t, "88802", normal.ID)
+	assert.Equal(t, "Fixture.Guide.v2.0-FIXTURE", normal.Title)
+	assert.Equal(t, "虚构副标题二", normal.Subtitle)
+	assert.Equal(t, v2.DiscountNone, normal.DiscountLevel)
+	assert.True(t, normal.DiscountEndTime.IsZero(), "无促销 -> 无结束时间；title=\"通过\" 不得被误解析")
+	assert.Equal(t, int64(855952588), normal.SizeBytes)
+	assert.Equal(t, 206, normal.Seeders)
+	assert.Equal(t, 1, normal.Leechers)
+	assert.Equal(t, 0, normal.Snatched)
+
+	// 永久免费：只有 img.pro_free[title=免费]，既无 onmouseover 也无剩余时间 span
+	forever := items[2]
+	assert.Equal(t, "88803", forever.ID)
+	assert.Equal(t, "虚构副标题三", forever.Subtitle)
+	assert.Equal(t, v2.DiscountFree, forever.DiscountLevel)
+	assert.True(t, forever.DiscountEndTime.IsZero(), "永久免费无结束时间")
+	assert.Equal(t, int64(1685774663), forever.SizeBytes)
+	assert.Equal(t, 12, forever.Seeders)
+	assert.Equal(t, 4, forever.Leechers)
+	assert.Equal(t, 88, forever.Snatched)
+	assert.Equal(t, "剧集", forever.Category)
+}
+
+// --- Suite: Detail ---
+
+func testCsptDetail(t *testing.T) {
+	def := getCsptDef(t)
+
+	t.Run("Free", func(t *testing.T) {
+		doc := FixtureDoc(t, "cspt_detail", csptDetailFixture)
+		info := v2.NewNexusPHPParserFromDefinition(def).ParseAll(doc.Selection)
+
+		assert.Equal(t, "88801", info.TorrentID)
+		assert.Equal(t, "Fixture.Anime.Movie.2026.1080p.WEB-DL.H.265.DDP.5.1-FIXTURE", info.Title)
+		assert.Equal(t, v2.DiscountFree, info.DiscountLevel)
+		require.False(t, info.DiscountEnd.IsZero(), "discount end time should be parsed")
+		assert.Equal(t, "2026-07-31 12:00:00", info.DiscountEnd.Format("2006-01-02 15:04:05"))
+		// 「基本信息」标签单元格 + .Next() 兄弟节点，全角冒号 + 十进制 GB
+		assert.InDelta(t, 12.98*1024, info.SizeMB, 0.1)
+		// 顶栏有 [H&R]: [0/0/10] 计数器，不能被 HRKeywords 误判
+		assert.False(t, info.HasHR, "顶栏 H&R 计数器不得被识别为 H&R 种子")
+	})
+
+	t.Run("Plain", func(t *testing.T) {
+		doc := FixtureDoc(t, "cspt_detail_plain", csptDetailPlainFixture)
+		info := v2.NewNexusPHPParserFromDefinition(def).ParseAll(doc.Selection)
+
+		assert.Equal(t, "88802", info.TorrentID)
+		assert.Equal(t, "Fixture.Guide.v2.0-FIXTURE", info.Title)
+		assert.Equal(t, v2.DiscountNone, info.DiscountLevel)
+		assert.True(t, info.DiscountEnd.IsZero())
+		assert.InDelta(t, 816.30, info.SizeMB, 0.1)
+		assert.False(t, info.HasHR)
+	})
+}
+
+// --- Suite: UserInfo ---
+
+func testCsptUserInfo(t *testing.T) {
+	def := getCsptDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	t.Run("IndexPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "cspt_index", csptIndexFixture)
+		fields := map[string]string{
+			"id":   "90101",
+			"name": "cspt_fixture_user",
+			// 做种/下载数靠 svg <title> 文案定位，两个 svg 的 title id 都是 downing
+			"seeding":  "128",
+			"leeching": "3",
+			// 金元宝：顶栏 mybonus.php 链接
+			"bonus": "12345.6",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+	})
+
+	t.Run("UserdetailsPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "cspt_userdetails", csptUserdetailsFixture)
+		fields := map[string]string{
+			// 512.00 GB / 128.00 GB / 400.50 GB / 250.25 GB 按 1024 进制换算为字节
+			"uploaded":       "549755813888",
+			"downloaded":     "137438953472",
+			"trueUploaded":   "430033600512",
+			"trueDownloaded": "268703891456",
+			"ratio":          "4",
+			"levelName":      "Power User",
+			// name 被 span.user-id 限定，不会取到「邀请人」行的 EliteUser_Name
+			"name": "cspt_fixture_user",
+			// parseTime 按站点 TimezoneOffset(+0800) 解析
+			"joinTime":     "1741050611",
+			"lastAccessAt": "1784507400",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+
+		// 保号探测只读取 UserInfo.LastAccess，必须为正的 Unix 秒
+		sel := def.UserInfo.Selectors["lastAccessAt"]
+		got := driver.ExtractFieldValuePublic(doc, sel)
+		require.NotEmpty(t, got, "lastAccessAt must be parsed for the login probe")
+		assert.Regexp(t, `^\d+$`, got)
+		assert.Greater(t, got, "0")
+	})
+}
+
+// --- Standalone Tests ---
+
+func TestCspt_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":       csptSearchFixture,
+		"detail":       csptDetailFixture,
+		"detail_plain": csptDetailPlainFixture,
+		"index":        csptIndexFixture,
+		"userdetails":  csptUserdetailsFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			RequireNoSecrets(t, name, data)
+		})
+	}
+}

--- a/site/v2/definitions/hhanclub.go
+++ b/site/v2/definitions/hhanclub.go
@@ -1,0 +1,244 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+// HhanclubDefinition 描述 HHCLUB（hhanclub.net）站点。
+//
+// 站点内核仍是 NexusPHP（<title>HHCLUB :: 种子 - Powered by NexusPHP</title>），
+// 但皮肤（styles/HHan）用 Tailwind 全量重写了 DOM：**列表页与详情页都没有任何
+// table/tr/td**，且促销标记不是 NexusPHP 通用的 img.pro_* 图标。三处关键适配：
+//
+//  1. 列表行是纯 div。页面内 `class="torrents"` 出现 0 次，`<table>`/`<tr>` 出现 0 次。
+//     真实行的公共父元素是 `div.torrent-table-sub-info`（100 个，与 download.php?id=
+//     的 100 次出现一一对应）；表头行是同级的另一个 div（携带 torrent-cat /
+//     torrent-title 但**没有** torrent-table-sub-info），因此按该 class 选行即天然
+//     排除表头，无需 :has() 判别。列内统计值都带语义 class
+//     （torrent-info-text-size / -added / -seeders / -leechers / -finished），
+//     一律用 class 选择器而非 nth-child。
+//
+//  2. 促销标记是站点自定义 span：<span class="promotion-tag promotion-tag-free">免费</span>。
+//     页面内嵌的 tailwindcss 声明只定义了 4 种：-free / -50 / -30 / -2xfree。
+//     搜索侧 parseDiscountFromElement 用 class+src+alt 的**子串**匹配，映射 key 采用
+//     完整 class 名后互不为子串（"promotion-tag-free" 不是
+//     "promotion-tag promotion-tag-2xfree" 的子串，反之亦然），因此 map 遍历顺序
+//     随机也不会出现 free 覆盖 2xfree；详情侧 ParseDiscount 按空白拆分 class 后做
+//     **精确**查表，同一份映射同时满足两条路径。
+//
+//  3. 详情页体积在嵌套 div 里：
+//     <span class="font-bold"><b>大小：</b></span><span class="">17.33 GB</span>
+//     ParseSizeMB 取 SizeSelector 元素的 .Next() 兄弟节点文本，所以 SizeSelector 必须
+//     指向**外层 span**（其下一个兄弟正是数值 span），且正则里不能再带「大小：」前缀，
+//     否则匹配不到（兄弟节点文本只有 "17.33 GB"）。
+//
+// 已知限制（无法由选择器解决，非本站定义可控）：列表页标题锚点内嵌新种角标
+// <a class='... torrent-info-text-name'>标题<span class='new'>[新]</span></a>（实测 100 行中 91 行携带），
+// 而 ParseSearch 取标题走 strings.TrimSpace(titleElem.Text())，没有 Attr/Filters 钩子
+// （SiteSelectors 只为副标题提供了 SubtitleSelector *FieldSelector），CSS 也无法排除子元素，
+// 因此搜索结果标题会带 "[新]" 后缀。行内不存在任何携带干净标题的备选元素（锚点无 title 属性）。
+// 影响面有限：详情页走 input[name='torrent_name'] 的 value，标题干净，
+// 因此 RSS 下载、免费到期监控与 .torrent 文件名均不受影响，仅搜索列表展示带角标。
+//
+// 已核对：三个页面均无 hitandrun / hit_run / Hit and Run 痕迹，故不声明 H&R；
+// 采集数据未包含等级门槛页面，故不声明 LevelRequirements。
+var HhanclubDefinition = &v2.SiteDefinition{
+	ID:             "hhanclub",
+	Name:           "HHCLUB",
+	Description:    "综合性 PT 站点（NexusPHP 内核 + Tailwind 皮肤）",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://hhanclub.net/"},
+	FaviconURL:     "https://hhanclub.net/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				// 全站左侧用户面板（userdetails.php 页面上位于文档最前的
+				// a[href*='userdetails.php'][class*='Name']）在 index.php 同样渲染，
+				// id / name / 做种数 / 下载数 均取自这里。
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "seeding", "leeching"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields: []string{
+					"name", "uploaded", "downloaded", "ratio", "levelName",
+					"bonus", "seedingBonus", "joinTime", "lastAccessAt",
+				},
+			},
+		},
+		// 正文字段统一是 <span class="font-bold">标签：</span><值元素> 结构。
+		// 「上传量：」是「实际上传量：」的子串，:contains 会同时命中两者，因此首选
+		// :matchesOwn 做整串精确匹配；若某些页面标签带额外空白导致 :matchesOwn 落空，
+		// 再回退 :contains —— 取值走 First()，文档顺序上「上传量」先于「实际上传量」，
+		// 回退路径同样取到正确值。
+		Selectors: map[string]v2.FieldSelector{
+			"id": {
+				Selector: []string{
+					"a[href*='userdetails.php'][class*='Name']",
+					"a[href*='userdetails.php']",
+				},
+				Attr:    "href",
+				Filters: []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{
+					"a[href*='userdetails.php'][class*='Name']",
+					"a[href*='userdetails.php']",
+				},
+			},
+			"uploaded": {
+				Selector: []string{
+					`span.font-bold:matchesOwn(^\s*上传量：\s*$) + span`,
+					"span.font-bold:contains('上传量：') + span",
+				},
+				Filters: []v2.Filter{{Name: "parseSize"}},
+			},
+			"downloaded": {
+				Selector: []string{
+					`span.font-bold:matchesOwn(^\s*下载量：\s*$) + span`,
+					"span.font-bold:contains('下载量：') + span",
+				},
+				Filters: []v2.Filter{{Name: "parseSize"}},
+			},
+			// 分享率单元格形如 <font>6.300</font>（<strong>实际分享率</strong>：0.785），
+			// 取 font 内的官方分享率，避免把实际分享率一起吃进来。
+			"ratio": {
+				Selector: []string{
+					`span.font-bold:matchesOwn(^\s*分享率：\s*$) + span font`,
+					"span.font-bold:contains('分享率：') + span font",
+					`span.font-bold:matchesOwn(^\s*分享率：\s*$) + span`,
+				},
+				Filters: []v2.Filter{{Name: "parseNumber"}},
+			},
+			// 等级：<span>...<img title="Crazy User(...)"><b class='XXX_Name'>Crazy User(...)</b></span>
+			"levelName": {
+				Selector: []string{
+					`span.font-bold:matchesOwn(^\s*等级：\s*$) + span b`,
+					`span.font-bold:matchesOwn(^\s*等级：\s*$) + span img`,
+					"span.font-bold:contains('等级：') + span b",
+				},
+			},
+			// 憨豆（魔力值）。正文里精确到小数位；侧边栏只有千分位整数，作为兜底。
+			"bonus": {
+				Selector: []string{
+					`span.font-bold:matchesOwn(^\s*憨豆：\s*$) + div`,
+					"span.font-bold:contains('憨豆：') + div",
+					"a[href*='mybonus.php'] div",
+				},
+				Filters: []v2.Filter{{Name: "parseNumber"}},
+			},
+			"seedingBonus": {
+				Selector: []string{
+					`span.font-bold:matchesOwn(^\s*做种积分：\s*$) + span`,
+					"span.font-bold:contains('做种积分：') + span",
+				},
+				Filters: []v2.Filter{{Name: "parseNumber"}},
+			},
+			// 侧边栏做种/下载数：<div><img alt="做种数">&nbsp;140</div>。
+			// 必须用 :haschild（cascadia 的直接子元素判定）；:has(> img) 语法 cascadia v1.3.3
+			// 不支持（实测匹配 0 个），而裸 :has(img) 会连外层祖先 div 一起命中。
+			// 备选按 action 参数锚定侧边栏链接（个人中心导航里同名链接在文档顺序之后）。
+			"seeding": {
+				Selector: []string{
+					"div:haschild(img[alt='做种数'])",
+					"a[href*='userdetails.php'][href*='action=2'] div",
+				},
+				Filters: []v2.Filter{{Name: "parseNumber"}},
+			},
+			"leeching": {
+				Selector: []string{
+					"div:haschild(img[alt='下载数'])",
+					"a[href*='userdetails.php'][href*='action=3'] div",
+				},
+				Filters: []v2.Filter{{Name: "parseNumber"}},
+			},
+			// 加入日期/最近动向文本形如 "2025-08-19 22:40:26 (11月11天前, 48周)"，
+			// 直接用正则截首个完整时间戳再交给 parseTime（按 TimezoneOffset 解析）。
+			"joinTime": {
+				Selector: []string{
+					`span.font-bold:matchesOwn(^\s*加入日期：\s*$) + span`,
+					"span.font-bold:contains('加入日期：') + span",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+			// 保号探测只读取 UserInfo.LastAccess，缺失会导致线上探测解析失败。
+			"lastAccessAt": {
+				Selector: []string{
+					`span.font-bold:matchesOwn(^\s*最近动向：\s*$) + span`,
+					"span.font-bold:contains('最近动向：') + span",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		// 真实种子行；表头行没有该 class，天然被排除。
+		TableRows: "div.torrent-table-sub-info",
+		Title:     "a.torrent-info-text-name",
+		TitleLink: "a.torrent-info-text-name",
+		Subtitle:  "div.torrent-info-text-small_name",
+		// 统计列都有语义 class，不依赖 grid 中的列序。
+		Size:     "div.torrent-info-text-size",
+		Seeders:  "div.torrent-info-text-seeders",
+		Leechers: "div.torrent-info-text-leechers",
+		Snatched: "div.torrent-info-text-finished",
+		// 站点自定义促销 span，取代 NexusPHP 通用 img.pro_*。
+		DiscountIcon: "span.promotion-tag",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"promotion-tag-free":   v2.DiscountFree,
+			"promotion-tag-2xfree": v2.Discount2xFree,
+			"promotion-tag-50":     v2.DiscountPercent50,
+			"promotion-tag-30":     v2.DiscountPercent30,
+		},
+		// 促销剩余时间是可见 span：<span>[ 剩余时间：<span title="...">7时21分钟</span> ]</span>。
+		// 本站促销标记没有 onmouseover，驱动的 onmouseover 兜底不可用，必须命中这个 span；
+		// 同时必须限定在「剩余时间」外层 span 之内，否则会误取
+		// div.torrent-info-text-added 里同样是 span[title] 的发布时间。
+		DiscountEndTime: "span:contains('剩余时间') > span[title]",
+		DownloadLink:    "a[href*='download.php']",
+		// 分类图标的 alt 恒为列头字样「类型」，无法反映真实分类，故不配置 Category，
+		// 以免所有行都被写入同一个无意义取值。
+		UploadTime: "div.torrent-info-text-added span[title]",
+		// 详情页同为 div 布局：标签 div 与取值 div 是相邻兄弟。
+		DetailDownloadLink: "a.index[href*='download.php'], a[href*='download.php?id=']",
+		DetailSubtitle:     `div.font-bold:matchesOwn(^\s*副标题\s*$) + div`,
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		// 与搜索侧共用同一份映射：ParseDiscount 按 class token 精确查表。
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"promotion-tag-free":   v2.DiscountFree,
+			"promotion-tag-2xfree": v2.Discount2xFree,
+			"promotion-tag-50":     v2.DiscountPercent50,
+			"promotion-tag-30":     v2.DiscountPercent30,
+		},
+		HRKeywords: []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		// 详情页保留了隐藏域，标题/ID 直接取 value（不含列表页的 [新] 角标）。
+		TitleSelector:    "input[name='torrent_name']",
+		IDSelector:       "input[name='detail_torrent_id']",
+		DiscountSelector: "span.promotion-tag",
+		EndTimeSelector:  "span:contains('剩余时间') > span[title]",
+		// ParseSizeMB 取 .Next() 兄弟节点，所以指向「大小：」所在的外层 span，
+		// 其兄弟文本仅为 "17.33 GB"，正则不能再要求「大小：」前缀。
+		// 单位类只列 ParseSizeMB 能正确换算的 K/M/G/T（含 KiB/MiB/GiB/TiB）。
+		SizeSelector: `span.font-bold:contains('大小：')`,
+		SizeRegex:    `([\d.]+)\s*([KMGT]i?B)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(HhanclubDefinition)
+}

--- a/site/v2/definitions/hhanclub_fixture_test.go
+++ b/site/v2/definitions/hhanclub_fixture_test.go
@@ -1,0 +1,524 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "hhanclub",
+		Search:   testHhanclubSearch,
+		Detail:   testHhanclubDetail,
+		UserInfo: testHhanclubUserInfo,
+	})
+}
+
+// --- Fixtures ---
+//
+// 结构照搬真实页面（styles/HHan Tailwind 皮肤，列表页与详情页都没有 table/tr/td），
+// 但标题、副标题、种子 ID、用户名、用户 ID、头像地址均已替换为虚构值，
+// download.php 链接不带 passkey 参数。
+//
+// 搜索页刻意覆盖的真实特征：
+//   - 首个同级 div 是表头（带 torrent-cat / torrent-title，但没有 torrent-table-sub-info），
+//     用于证明行选择器排除表头
+//   - 标题锚点内嵌 <span class='new'>[新]</span>（真实页面 100 行中 91 行携带）
+//   - 促销标记是站点自定义 span.promotion-tag-*，且每行内联一段 <style type="text/tailwindcss">
+//     声明这些 class（该 style 文本会出现在行的 HTML 里，不能干扰选择器）
+//   - 促销结束时间是可见 span[title]，与 torrent-info-text-added 里的发布时间同为 span[title]
+//   - 统计列使用语义 class，而非固定列序
+
+const hhanclubSearchHeaderFixture = `<div class="flex w-[95%]  bg-[#4F5879]/[0.7] opacity-[0.7] h-[30px] m-auto z-20 !rounded-[3px]">
+    <div class="torrent-cat"><span class="!text-[#FFFFFF] text-[16px] font-bold leading-6 m-auto">类型</span></div>
+    <div class="torrent-title items-center justify-center"><a class="!text-[#FFFFFF] text-[16px] font-bold leading-6 m-auto" href="?sort=1&amp;type=asc">标题</a></div>
+    <div class="flex w-[20%] items-center">
+        <hr class="w-[2.5px] h-[80%] bg-[#9B9B9B] opacity-[0.7]"/>
+        <div class="torrent-info">
+            <a class="torrent-info-icon" href="?sort=5&amp;type=desc"><img src="styles/HHan/icons/icon-torrent-size.svg" alt="size" title="大小"/></a>
+            <a class="torrent-info-icon" href="?sort=4&amp;type=desc"><img src="styles/HHan/icons/icon-new-time.svg" alt="time" title="存活时间"/></a>
+            <a class="torrent-info-icon" href="?sort=7&amp;type=desc"><img src="styles/HHan/icons/icon-seed-num.svg" alt="seeders" title="种子数"/></a>
+            <a class="torrent-info-icon" href="?sort=8&amp;type=desc"><img src="styles/HHan/icons/icon-now-down.svg" alt="leechers" title="下载数"/></a>
+            <a class="torrent-info-icon" href="?sort=6&amp;type=desc"><img src="styles/HHan/icons/icon-finished.svg" alt="完成数" title="完成数"></a>
+        </div>
+        <hr class="w-[2.5px] h-[80%] bg-[#9B9B9B]/[0.7] "/>
+    </div>
+    <div class="torrent-manage"></div>
+</div>`
+
+// 行内促销样式声明，真实页面每行都会重复输出一份。
+const hhanclubPromotionStyleFixture = `<style type="text/tailwindcss">
+    .promotion-tag { @apply !text-[#FFFFFF] text-[12px] px-[5px] !rounded-md py-[2px]; }
+    .promotion-tag-free { @apply bg-[#1FABB4]; }
+    .promotion-tag-50 { @apply bg-[#87B05D]; }
+    .promotion-tag-30 { @apply bg-[#2C86DA]; }
+    .promotion-tag-2xfree { @apply bg-[#109e61]; }
+</style>`
+
+const hhanclubSearchFixture = `<html><body>
+<div class="flex flex-col w-[95%] m-auto torrent-table-for-spider">
+` + hhanclubSearchHeaderFixture + `
+<div class="w-full bg-[#11e5e380] flex z-10 !rounded-[3px] torrent-table-sub-info">
+    <div class="torrent-cat"><a href='?cat[]=402'><img class='!rounded-md ' src='styles/HHan/icons/icon-tv.svg' alt='类型'></a></div>
+    <div class="flex torrent-table-for-spider-info torrent-title items-center gap-x-[15px] justify-between">
+        <div class="flex-col flex  w-[calc(100%-15px)] gap-y-1">
+            <a href='details.php?id=99001&hit=1' class='!text-[#000000] hover:!text-orange-400 font-bold text-[9pt] torrent-info-text-name'>Fixture.Show.S01.2026.2160p.WEB-DL.H.265-FIXTURE<span class='new'>[新]</span></a>
+            <div class="flex items-center gap-x-[8px}">
+                <div class='text-[#000000]/[0.9] text-[9pt] font-[500] w-20 flex-1 overflow-hidden truncate torrent-info-text-small_name'>虚构副标题一 | 第01-04集 | 4K 60帧</div>
+            </div>
+            <div class="flex gap-x-[5px] text-[9pt] items-center pr-5">
+                <span class="flex !text-[9pt] !font-bold !text-[#000000] items-center"><img src="styles/HHan/icons/icon-douban.svg" alt="douban" title="douban">&nbsp;6.1</span>
+                <a href="?tag_id3=1"><span style="background-color:#0000ff" class="tag">官方</span></a>
+` + hhanclubPromotionStyleFixture + `
+                <div class='whitespace-nowrap'><span class="promotion-tag promotion-tag-free" >免费</span></div>
+                <div class="flex"><span class='flex text-[12px]  text-[#000000]'>[&nbsp;剩余时间：<span title="2026-07-27 22:05:11">7时21分钟</span>&nbsp;]</span></div>
+                <div class="flex torrent-info-text-author"><div class='flex text-[#000000]' ><b>匿名</b></div></div>
+            </div>
+        </div>
+    </div>
+    <div class="flex w-[20%] items-center">
+        <div class="torrent-info">
+            <div class="torrent-info-text torrent-info-text-size">
+                17.33 GB                        </div>
+            <div class="torrent-info-text torrent-info-text-added">
+                <span title="2026-07-27 14:05:11">38分钟</span>                        </div>
+            <div class="torrent-info-text torrent-info-text-seeders"><a href="details.php?id=99001&amp;hit=1&amp;dllist=1#seeders">1</a></div>
+            <div class="torrent-info-text torrent-info-text-leechers"><a class='!text-[#000000]' href="details.php?id=99001&amp;hit=1&amp;dllist=1#leechers">119</a></div>
+            <div class="torrent-info-text torrent-info-text-finished"><a href='/viewsnatches.php?id=99001'>0</a></div>
+        </div>
+    </div>
+    <div class="torrent-manage">
+        <a class='inline-flex' id="bookmark0" href="javascript: mark(99001,0);"><img style="width: 35px" src="styles/HHan/icons/icon-collection-off-new.svg" alt="Unbookmarked" title="收藏" /></a>
+        <div class="flex flex-col gap-y-[5px]"><a class='xl:px-[5px] text-[14px] bg-[#549DF7] !text-[#FFFFFF] rounded-[5px] ' href="download.php?id=99001">下载</a></div>
+    </div>
+</div>
+<hr class="w-full h-[2px] bg-[#191E32]/[0.6]"/>
+<div class="w-full bg-[#11e5e380] flex z-10 !rounded-[3px] torrent-table-sub-info">
+    <div class="torrent-cat"><a href='?cat[]=401'><img class='!rounded-md ' src='styles/HHan/icons/icon-movie.svg' alt='类型'></a></div>
+    <div class="flex torrent-table-for-spider-info torrent-title items-center gap-x-[15px] justify-between">
+        <div class="flex-col flex  w-[calc(100%-15px)] gap-y-1">
+            <a href='details.php?id=99002&hit=1' class='!text-[#000000] hover:!text-orange-400 font-bold text-[9pt] torrent-info-text-name'>Fixture.Movie.2026.1080p.BluRay.x264-FIXTURE</a>
+            <div class="flex items-center gap-x-[8px]">
+                <div class='text-[#000000]/[0.9] text-[9pt] font-[500] truncate torrent-info-text-small_name'>虚构副标题二 | 国语中字</div>
+            </div>
+            <div class="flex gap-x-[5px] text-[9pt] items-center pr-5">
+` + hhanclubPromotionStyleFixture + `
+                <div class='whitespace-nowrap'><span class="promotion-tag promotion-tag-2xfree" >2X免费</span></div>
+                <div class="flex"><span class='flex text-[12px]  text-[#000000]'>[&nbsp;剩余时间：<span title="2026-07-28 09:30:00">19时25分钟</span>&nbsp;]</span></div>
+                <div class="flex torrent-info-text-author"><div class='flex text-[#000000]' ><b>匿名</b></div></div>
+            </div>
+        </div>
+    </div>
+    <div class="flex w-[20%] items-center">
+        <div class="torrent-info">
+            <div class="torrent-info-text torrent-info-text-size">816.30 MB</div>
+            <div class="torrent-info-text torrent-info-text-added"><span title="2026-07-20 08:00:00">7天</span></div>
+            <div class="torrent-info-text torrent-info-text-seeders"><a href="details.php?id=99002&amp;hit=1&amp;dllist=1#seeders">206</a></div>
+            <div class="torrent-info-text torrent-info-text-leechers"><a class='!text-[#000000]' href="details.php?id=99002&amp;hit=1&amp;dllist=1#leechers">3</a></div>
+            <div class="torrent-info-text torrent-info-text-finished"><a href='/viewsnatches.php?id=99002'>412</a></div>
+        </div>
+    </div>
+    <div class="torrent-manage"><a class='xl:px-[5px] text-[14px]' href="download.php?id=99002">下载</a></div>
+</div>
+<hr class="w-full h-[2px] bg-[#191E32]/[0.6]"/>
+<div class="w-full bg-[#11e5e380] flex z-10 !rounded-[3px] torrent-table-sub-info">
+    <div class="torrent-cat"><a href='?cat[]=404'><img class='!rounded-md ' src='styles/HHan/icons/icon-music.svg' alt='类型'></a></div>
+    <div class="flex torrent-table-for-spider-info torrent-title items-center gap-x-[15px] justify-between">
+        <div class="flex-col flex  w-[calc(100%-15px)] gap-y-1">
+            <a href='details.php?id=99003&hit=1' class='!text-[#000000] font-bold text-[9pt] torrent-info-text-name'>Fixture.Album.2026.FLAC.24bit-FIXTURE<span class='new'>[新]</span></a>
+            <div class="flex items-center gap-x-[8px]">
+                <div class='text-[#000000]/[0.9] truncate torrent-info-text-small_name'>虚构副标题三 | Hi-Res</div>
+            </div>
+            <div class="flex gap-x-[5px] text-[9pt] items-center pr-5">
+` + hhanclubPromotionStyleFixture + `
+                <div class='whitespace-nowrap'><span class="promotion-tag promotion-tag-50" >50%</span></div>
+                <div class="flex"><span class='flex text-[12px]  text-[#000000]'>[&nbsp;剩余时间：<span title="2026-07-29 12:00:00">2天</span>&nbsp;]</span></div>
+            </div>
+        </div>
+    </div>
+    <div class="flex w-[20%] items-center">
+        <div class="torrent-info">
+            <div class="torrent-info-text torrent-info-text-size">1.24 GB</div>
+            <div class="torrent-info-text torrent-info-text-added"><span title="2026-07-26 20:15:00">18时</span></div>
+            <div class="torrent-info-text torrent-info-text-seeders"><a href="details.php?id=99003&amp;hit=1&amp;dllist=1#seeders">18</a></div>
+            <div class="torrent-info-text torrent-info-text-leechers"><a class='!text-[#000000]' href="details.php?id=99003&amp;hit=1&amp;dllist=1#leechers">0</a></div>
+            <div class="torrent-info-text torrent-info-text-finished"><a href='/viewsnatches.php?id=99003'>7</a></div>
+        </div>
+    </div>
+    <div class="torrent-manage"><a class='xl:px-[5px] text-[14px]' href="download.php?id=99003">下载</a></div>
+</div>
+<hr class="w-full h-[2px] bg-[#191E32]/[0.6]"/>
+<div class="w-full bg-[#11e5e380] flex z-10 !rounded-[3px] torrent-table-sub-info">
+    <div class="torrent-cat"><a href='?cat[]=405'><img class='!rounded-md ' src='styles/HHan/icons/icon-doc.svg' alt='类型'></a></div>
+    <div class="flex torrent-table-for-spider-info torrent-title items-center gap-x-[15px] justify-between">
+        <div class="flex-col flex  w-[calc(100%-15px)] gap-y-1">
+            <a href='details.php?id=99004&hit=1' class='!text-[#000000] font-bold text-[9pt] torrent-info-text-name'>Fixture.Doc.2026.2160p.HDR-FIXTURE</a>
+            <div class="flex items-center gap-x-[8px]">
+                <div class='text-[#000000]/[0.9] truncate torrent-info-text-small_name'>虚构副标题四 | 纪录片</div>
+            </div>
+            <div class="flex gap-x-[5px] text-[9pt] items-center pr-5">
+` + hhanclubPromotionStyleFixture + `
+                <div class='whitespace-nowrap'><span class="promotion-tag promotion-tag-30" >30%</span></div>
+                <div class="flex"><span class='flex text-[12px]  text-[#000000]'>[&nbsp;剩余时间：<span title="2026-08-01 00:00:00">4天</span>&nbsp;]</span></div>
+            </div>
+        </div>
+    </div>
+    <div class="flex w-[20%] items-center">
+        <div class="torrent-info">
+            <div class="torrent-info-text torrent-info-text-size">42.80 GB</div>
+            <div class="torrent-info-text torrent-info-text-added"><span title="2026-07-01 00:00:00">26天</span></div>
+            <div class="torrent-info-text torrent-info-text-seeders"><a href="details.php?id=99004&amp;hit=1&amp;dllist=1#seeders">9</a></div>
+            <div class="torrent-info-text torrent-info-text-leechers"><a class='!text-[#000000]' href="details.php?id=99004&amp;hit=1&amp;dllist=1#leechers">1</a></div>
+            <div class="torrent-info-text torrent-info-text-finished"><a href='/viewsnatches.php?id=99004'>33</a></div>
+        </div>
+    </div>
+    <div class="torrent-manage"><a class='xl:px-[5px] text-[14px]' href="download.php?id=99004">下载</a></div>
+</div>
+<hr class="w-full h-[2px] bg-[#191E32]/[0.6]"/>
+<div class="w-full bg-[#11e5e380] flex z-10 !rounded-[3px] torrent-table-sub-info">
+    <div class="torrent-cat"><a href='?cat[]=403'><img class='!rounded-md ' src='styles/HHan/icons/icon-tv.svg' alt='类型'></a></div>
+    <div class="flex torrent-table-for-spider-info torrent-title items-center gap-x-[15px] justify-between">
+        <div class="flex-col flex  w-[calc(100%-15px)] gap-y-1">
+            <a href='details.php?id=99005&hit=1' class='!text-[#000000] font-bold text-[9pt] torrent-info-text-name'>Fixture.Variety.S03.2026.1080p.WEB-DL-FIXTURE</a>
+            <div class="flex items-center gap-x-[8px]">
+                <div class='text-[#000000]/[0.9] truncate torrent-info-text-small_name'>虚构副标题五 | 综艺</div>
+            </div>
+            <div class="flex gap-x-[5px] text-[9pt] items-center pr-5">
+                <div class="flex torrent-info-text-author"><div class='flex text-[#000000]' ><b>匿名</b></div></div>
+            </div>
+        </div>
+    </div>
+    <div class="flex w-[20%] items-center">
+        <div class="torrent-info">
+            <div class="torrent-info-text torrent-info-text-size">5.61 GB</div>
+            <div class="torrent-info-text torrent-info-text-added"><span title="2026-06-15 10:20:30">42天</span></div>
+            <div class="torrent-info-text torrent-info-text-seeders"><a href="details.php?id=99005&amp;hit=1&amp;dllist=1#seeders">77</a></div>
+            <div class="torrent-info-text torrent-info-text-leechers"><a class='!text-[#000000]' href="details.php?id=99005&amp;hit=1&amp;dllist=1#leechers">2</a></div>
+            <div class="torrent-info-text torrent-info-text-finished"><a href='/viewsnatches.php?id=99005'>901</a></div>
+        </div>
+    </div>
+    <div class="torrent-manage"><a class='xl:px-[5px] text-[14px]' href="download.php?id=99005">下载</a></div>
+</div>
+</div>
+</body></html>`
+
+// 详情页同样是 div 布局：标签 div 与取值 div 相邻；标题/ID 来自 subtitles.php 表单的隐藏域；
+// 「基本信息」体积是 <span class="font-bold"><b>大小：</b></span> 的下一个兄弟 span。
+const hhanclubDetailFixture = `<html><head><title>HHCLUB :: 种子详情 &quot;Fixture.Show.S01.2026.2160p.WEB-DL.H.265-FIXTURE&quot; - Powered by NexusPHP</title></head><body>
+<div class="xl:w-[90%] w-full m-auto p-10"><div class="bg-content_bg rounded-md py-10 px-20 text-black">
+<div class="grid gap-y-5 grid-cols-[100px,calc(100%-100px-1.25rem)] justify-items-start">
+    <div class="font-bold leading-6 text-center h-full flex items-center">下载</div>
+    <div class="font-bold leading-6 flex flex-row justify-between w-full items-center"><div class="flex gap-x-[10px] items-center"><a class="index" href="download.php?id=99001">[HHC].Fixture.Show.S01.2026.2160p.WEB-DL.H.265-FIXTURE.torrent</a>
+` + hhanclubPromotionStyleFixture + `
+<div class='whitespace-nowrap'><span class="promotion-tag promotion-tag-free" >免费</span></div> <span class='flex text-[12px]  text-[#000000]'>[&nbsp;剩余时间：<span title="2026-07-27 22:05:11">7时21分钟</span>&nbsp;]</span></div><div class='leading-6'><a class='flex flex-row items-center' href='report.php?torrent=99001'><span class='text-md'>举报</span></a></div></div>
+    <div class='font-bold leading-6'>标题</div><div class='font-bold leading-6'>Fixture.Show.S01.2026.2160p.WEB-DL.H.265-FIXTURE</div>
+    <div class="font-bold leading-6">副标题</div>
+    <div class="font-bold leading-6">虚构副标题一 | 第01-04集 | 4K 60帧</div>
+    <div class="font-bold leading-6">基本信息</div><div class="grid gap-y-5 grid-cols-4 justify-items-start items-center w-full leading-6"><div><span class="font-bold"><b>大小：</b></span><span class="">17.33 GB</span></div><div><span class="font-bold">类型:&nbsp;&nbsp;</span><span class="">电视剧</span></div><div><span class="font-bold">媒介:&nbsp;&nbsp;</span><span class="">WEB-DL</span></div><div><span class="font-bold">分辨率:&nbsp;&nbsp;</span><span class="">2160p/4K</span></div><div class='flex items-center'><span class='font-bold'>发布时间:&nbsp;&nbsp;</span><span>2026-07-27 14:05:11</span></div></div>
+    <div class="font-bold leading-6">种子链接</div><span><a class="btn-basic" href="https://hhanclub.net/download.php?id=99001">点击复制</a></span>
+    <div class="font-bold leading-6">字幕</div>
+    <div class="inline-flex flex-col gap-y-[15px]"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Fixture.Show.S01.2026.2160p.WEB-DL.H.265-FIXTURE" /><input type="hidden" name="detail_torrent_id" value="99001" /><input type="hidden" name="in_detail" value="in_detail" /></form></div>
+    <div class="font-bold leading-6">文件列表</div><div class="grid gap-y-1"><div class="text-[13px] grid grid-cols-[60px,1fr]"><span class="w-[100px] ">体　积: </span><span>4.76 GiB</span></div></div>
+</div>
+</div></div>
+</body></html>`
+
+// 无促销 + 体积使用二进制单位（GiB）的变体：验证 SizeRegex 的单位分组已放宽，
+// 且 ParseSizeMB 能按 1024 换算 GiB。
+const hhanclubDetailGiBFixture = `<html><body>
+<div class="grid gap-y-5 grid-cols-[100px,calc(100%-100px-1.25rem)] justify-items-start">
+    <div class="font-bold leading-6">基本信息</div><div class="grid gap-y-5 grid-cols-4 justify-items-start items-center w-full leading-6"><div><span class="font-bold"><b>大小：</b></span><span class="">4.32 GiB</span></div><div><span class="font-bold">类型:&nbsp;&nbsp;</span><span class="">电影</span></div></div>
+    <div class="font-bold leading-6">副标题</div>
+    <div class="font-bold leading-6">虚构副标题六</div>
+    <div class="font-bold leading-6">字幕</div>
+    <div class="inline-flex"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Fixture.NoPromo.2026.1080p.Remux-FIXTURE" /><input type="hidden" name="detail_torrent_id" value="99006" /></form></div>
+</div>
+</body></html>`
+
+// 全站左侧用户面板（index.php 与 userdetails.php 共用）：
+// id / name 取自 a[class*='Name']，做种/下载数取自带 img[alt] 的 div。
+const hhanclubIndexFixture = `<html><body>
+<div class="absolute z-30 hidden bg-[#FFFFFF] flex flex-col rounded-lg w-[280px]">
+    <div class="flex flex-col w-full items-center mt-[150px] gap-y-[5px]">
+        <div class="!text-base"><div class="flex flex-wrap items-center"><a  href="https://hhanclub.net/userdetails.php?id=90001" class='CrazyUser_Name'><b>fixture_user</b></a></div></div>
+    </div>
+    <div class="flex flex-col divide-y-[1px] mt-[25px] items-center w-[calc(100%-30px)]">
+        <div class="flex flex-col w-full items-start gap-y-[15px] mb-[25px]">
+            <div class="flex flex-row items-center gap-x-[10px]">
+                <img loading="lazy" class="w-[15px] h-[15px]" src="styles/HHan/icons/icon-ratio.svg" alt="分享率">
+                <div class="text-sm flex items-center justify-start gap-x-[10px] ">[分享率]:&nbsp;6.299</div>
+            </div>
+        </div>
+        <div class="grid grid-cols-[50%_50%] gap-y-[15px] gap-x-[5px] pb-[25px] w-[100%] pt-[25px]">
+            <div class="flex flex-row items-center ">
+                <img src="styles/HHan/icons/icon-bean.svg" class="w-[18px] h-[18px]" alt="憨豆">
+                <a href="mybonus.php"><div class="text-sm flex flex-wrap break-all">1,068,858</div></a>
+            </div>
+            <div class="text-sm flex items-center justify-start"><img class="w-[15px] h-[15px]" src="styles/HHan/icons/icon-user-upload.svg" alt="上传">&nbsp;12.755 TB</div>
+            <a href="userdetails.php?id=90001&action=2"><div class="text-sm flex items-center justify-start"><img class="w-[15px] h-[15px]" src="styles/HHan/icons/icon-now-upload.svg" alt="做种数">&nbsp;140</div></a>
+            <div class="text-sm flex items-center justify-start"><img class="w-[15px] h-[15px]" src="styles/HHan/icons/icon-user-download.svg" alt="下载">&nbsp;2.025 TB</div>
+            <a href="userdetails.php?id=90001&action=3"><div class="text-sm flex items-center justify-start"><img class="w-[15px] h-[15px]" src="styles/HHan/icons/icon-downloading.svg" alt="下载数">&nbsp;0</div></a>
+        </div>
+    </div>
+</div>
+</body></html>`
+
+// userdetails.php 正文：标签统一是 <span class="font-bold">标签：</span>，
+// 刻意保留「实际上传量：」「实际下载量：」「实际分享率」等易误命中的兄弟字段，
+// 用于验证 :matchesOwn 的整串精确匹配。
+const hhanclubUserdetailsFixture = `<html><body>
+<div class="absolute z-30 hidden bg-[#FFFFFF] flex flex-col rounded-lg w-[280px]">
+    <div class="!text-base"><div class="flex flex-wrap items-center"><a  href="https://hhanclub.net/userdetails.php?id=90001" class='CrazyUser_Name'><b>fixture_user</b></a></div></div>
+    <a href="userdetails.php?id=90001&action=2"><div class="text-sm flex items-center"><img class="w-[15px] h-[15px]" src="styles/HHan/icons/icon-now-upload.svg" alt="做种数">&nbsp;140</div></a>
+    <a href="userdetails.php?id=90001&action=3"><div class="text-sm flex items-center"><img class="w-[15px] h-[15px]" src="styles/HHan/icons/icon-downloading.svg" alt="下载数">&nbsp;0</div></a>
+</div>
+<div class="w-[max(85%,1000px)] m-auto p-10 bg-[#191E32]">
+    <div class="flex flex-row items-center">
+        <div class="font-bold text-xl leading-8 text-primary">个人中心</div>
+        <a href="userdetails.php?id=90001"><div class="ml-6 font-medium text-lg leading-7">个人信息</div></a>
+        <a href="userdetails.php?id=90001&action=2"><div class="ml-4 text-gray-500 font-medium text-lg leading-7">当前做种</div></a>
+        <a href="userdetails.php?id=90001&action=3"><div class="ml-4 text-gray-500 font-medium text-lg leading-7">当前下载</div></a>
+    </div>
+    <div class="grid grid-cols-3 justify-items-start gap-4 leading-6 text-base mt-12">
+        <div class="flex"><span class="font-bold m-auto">用户名：</span><div class="flex flex-wrap items-center"><a  href="https://hhanclub.net/userdetails.php?id=90001" class='CrazyUser_Name'><b>fixture_user</b></a></div></div>
+        <div class="flex"><span class="font-bold">性别：</span><span>男</span></div>
+        <div class="flex items-center"><span class="font-bold">憨豆：</span><div class="text-base text-black leading-6 flex items-center w-28"><img class="w-5 h-5" src="/styles/HHan/icon-bean.svg" alt="">1068857.7</div></div>
+        <div class="flex"><span class="font-bold m-auto">等级：</span><span class='flex items-end text-[14px] gap-x-3'><img alt="Crazy User(虚构等级)" title="Crazy User(虚构等级)" src="pic/crazy.gif" /> <b class='CrazyUser_Name'>Crazy User(虚构等级)</b></span></div>
+    </div>
+    <hr class="w-full h-px bg-gray-200 my-5" />
+    <div class="grid grid-cols-3 justify-items-start gap-4 leading-6 text-base">
+        <div><span class="font-bold">H&amp;R：</span><span><a href="myhr.php?userid=90001" target="_blank">0/<font color="red">0</font>/5</a></span></div>
+        <div><span class="font-bold">做种积分：</span><span>445,418.0</span></div>
+    </div>
+    <hr class="w-full h-px bg-gray-200 my-5" />
+    <div class="grid grid-cols-3 justify-items-start gap-4 leading-6 text-base">
+        <div><span class="font-bold">邀请：</span><span>没有邀请资格</span></div>
+        <div><span class="font-bold">加入日期：</span><span>2025-08-19 22:40:26 (<span title="2025-08-19 22:40:26">11月11天前</span>, 48周)</span></div>
+        <div><span class="font-bold">最近动向：</span><span>2026-07-27 14:43:26 (<span title="2026-07-27 14:43:26">&lt; 1分钟前</span>)</span></div>
+        <div><span class="font-bold">最近访问记录：</span><a class="cursor-pointer" href="userloginlogs.php?uid=90001">共&nbsp;7&nbsp;条记录</a></div>
+    </div>
+    <hr class="w-full h-px bg-gray-200 my-5" />
+    <div class="grid grid-cols-3 justify-items-start gap-4 leading-6 text-base">
+        <div><span class="font-bold">上传量：</span><span>12.755 TB</span></div>
+        <div><span class="font-bold">下载量：</span><span>2.025 TB</span></div>
+        <div><span class="font-bold">分享率：</span><span><font color="">6.300</font>（<strong>实际分享率</strong>：0.785）</span></div>
+        <div><span class="font-bold">实际上传量：</span><span>12.315 TB</span></div>
+        <div><span class="font-bold">实际下载量：</span><span>15.684 TB</span></div>
+    </div>
+</div>
+</body></html>`
+
+// --- Helpers ---
+
+func getHhanclubDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("hhanclub")
+	require.True(t, ok, "hhanclub definition not found")
+	return def
+}
+
+// --- Suite: Search ---
+
+func testHhanclubSearch(t *testing.T) {
+	def := getHhanclubDef(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(hhanclubSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{
+		BaseURL:   server.URL,
+		Cookie:    "test_cookie=1",
+		Selectors: def.Selectors,
+	})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: "GET"})
+	require.NoError(t, err)
+
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	// 表头 div 不带 torrent-table-sub-info，必须被排除，只剩 5 个真实行
+	require.Len(t, items, 5, "header row must be excluded, only real torrent rows parsed")
+
+	free := items[0]
+	assert.Equal(t, "99001", free.ID)
+	// 标题锚点内嵌 <span class='new'>[新]</span>；ParseSearch 走 Text() 且无 Filters 钩子，
+	// 无法用选择器剔除，因此角标会保留在标题里（详情页走隐藏域 value，标题干净）。
+	assert.Equal(t, "Fixture.Show.S01.2026.2160p.WEB-DL.H.265-FIXTURE[新]", free.Title)
+	assert.Equal(t, "虚构副标题一 | 第01-04集 | 4K 60帧", free.Subtitle)
+	assert.Equal(t, v2.DiscountFree, free.DiscountLevel)
+	assert.Equal(t, int64(18607945809), free.SizeBytes)
+	assert.Equal(t, 1, free.Seeders)
+	assert.Equal(t, 119, free.Leechers)
+	assert.Equal(t, 0, free.Snatched)
+	// 促销结束时间必须取「剩余时间」内的 span[title]，而不是 torrent-info-text-added 的发布时间
+	require.False(t, free.DiscountEndTime.IsZero(), "discount end time should be parsed")
+	assert.Equal(t, "2026-07-27 22:05:11", free.DiscountEndTime.Format("2006-01-02 15:04:05"))
+	assert.Equal(t, int64(1785161111), free.UploadedAt)
+	// 分类图标 alt 恒为「类型」，未配置 Category，避免写入无意义取值
+	assert.Empty(t, free.Category)
+
+	twoXFree := items[1]
+	assert.Equal(t, "99002", twoXFree.ID)
+	// 无 [新] 角标时标题干净
+	assert.Equal(t, "Fixture.Movie.2026.1080p.BluRay.x264-FIXTURE", twoXFree.Title)
+	// promotion-tag-2xfree 不能被 promotion-tag-free 抢先命中（两者互不为子串）
+	assert.Equal(t, v2.Discount2xFree, twoXFree.DiscountLevel)
+	assert.Equal(t, int64(855952588), twoXFree.SizeBytes)
+	assert.Equal(t, 206, twoXFree.Seeders)
+	assert.Equal(t, 3, twoXFree.Leechers)
+	assert.Equal(t, 412, twoXFree.Snatched)
+
+	half := items[2]
+	assert.Equal(t, "99003", half.ID)
+	assert.Equal(t, v2.DiscountPercent50, half.DiscountLevel)
+	assert.Equal(t, int64(1331439861), half.SizeBytes)
+
+	third := items[3]
+	assert.Equal(t, "99004", third.ID)
+	assert.Equal(t, v2.DiscountPercent30, third.DiscountLevel)
+	assert.Equal(t, int64(45956150067), third.SizeBytes)
+
+	none := items[4]
+	assert.Equal(t, "99005", none.ID)
+	assert.Equal(t, v2.DiscountNone, none.DiscountLevel)
+	assert.True(t, none.DiscountEndTime.IsZero(), "no promotion -> no end time")
+	assert.Equal(t, int64(6023691632), none.SizeBytes)
+	assert.Equal(t, 77, none.Seeders)
+	assert.Equal(t, 901, none.Snatched)
+	assert.Positive(t, none.UploadedAt)
+}
+
+// --- Suite: Detail ---
+
+func testHhanclubDetail(t *testing.T) {
+	def := getHhanclubDef(t)
+
+	t.Run("Free", func(t *testing.T) {
+		doc := FixtureDoc(t, "hhanclub_detail", hhanclubDetailFixture)
+		info := v2.NewNexusPHPParserFromDefinition(def).ParseAll(doc.Selection)
+
+		assert.Equal(t, "99001", info.TorrentID)
+		// 隐藏域 value，不含列表页的 [新] 角标
+		assert.Equal(t, "Fixture.Show.S01.2026.2160p.WEB-DL.H.265-FIXTURE", info.Title)
+		assert.Equal(t, v2.DiscountFree, info.DiscountLevel)
+		require.False(t, info.DiscountEnd.IsZero(), "discount end time should be parsed")
+		assert.Equal(t, "2026-07-27 22:05:11", info.DiscountEnd.Format("2006-01-02 15:04:05"))
+		// 「大小：」外层 span 的 .Next() 兄弟为 "17.33 GB"，按 1024 换算
+		assert.InDelta(t, 17.33*1024, info.SizeMB, 0.1)
+		assert.False(t, info.HasHR)
+	})
+
+	t.Run("NoPromotionBinaryUnit", func(t *testing.T) {
+		doc := FixtureDoc(t, "hhanclub_detail_gib", hhanclubDetailGiBFixture)
+		info := v2.NewNexusPHPParserFromDefinition(def).ParseAll(doc.Selection)
+
+		assert.Equal(t, "99006", info.TorrentID)
+		assert.Equal(t, "Fixture.NoPromo.2026.1080p.Remux-FIXTURE", info.Title)
+		assert.Equal(t, v2.DiscountNone, info.DiscountLevel)
+		assert.True(t, info.DiscountEnd.IsZero())
+		assert.InDelta(t, 4.32*1024, info.SizeMB, 0.1)
+		assert.False(t, info.HasHR)
+	})
+
+	t.Run("DownloadLinkAndSubtitle", func(t *testing.T) {
+		doc := FixtureDoc(t, "hhanclub_detail", hhanclubDetailFixture)
+		// newTestNexusPHPDriver 不注入 Selectors，DetailSubtitle 会退回默认的 td.rowhead 选择器，
+		// 本站没有 table，必须显式传入站点选择器。
+		driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{
+			BaseURL:   def.URLs[0],
+			Cookie:    "test_cookie=1",
+			Selectors: def.Selectors,
+		})
+		driver.SetSiteDefinition(def)
+		detail, err := driver.ParseDetail(v2.NexusPHPResponse{Document: doc, StatusCode: http.StatusOK})
+		require.NoError(t, err)
+		assert.Equal(t, "download.php?id=99001", detail.DownloadURL)
+		// 详情页副标题是相邻兄弟 div，无 td.rowhead 可用
+		assert.Equal(t, "虚构副标题一 | 第01-04集 | 4K 60帧", detail.Subtitle)
+	})
+}
+
+// --- Suite: UserInfo ---
+
+func testHhanclubUserInfo(t *testing.T) {
+	def := getHhanclubDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	t.Run("SidebarOnIndexPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "hhanclub_index", hhanclubIndexFixture)
+		fields := map[string]string{
+			"id":       "90001",
+			"name":     "fixture_user",
+			"seeding":  "140",
+			"leeching": "0",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+	})
+
+	t.Run("UserdetailsPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "hhanclub_userdetails", hhanclubUserdetailsFixture)
+		fields := map[string]string{
+			// 12.755 TB / 2.025 TB 按 1024 进制换算为字节；
+			// 「实际上传量/实际下载量」不得被误命中
+			"uploaded":   "14024270812282",
+			"downloaded": "2226511046246",
+			// 官方分享率取 <font> 内的 6.300，而非括号里的实际分享率 0.785
+			"ratio":        "6.3",
+			"levelName":    "Crazy User(虚构等级)",
+			"bonus":        "1.0688577e+06",
+			"seedingBonus": "445418",
+			// parseTime 按站点 TimezoneOffset(+0800) 解析
+			"joinTime":     "1755614426",
+			"lastAccessAt": "1785134606",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+
+		// 保号探测只读取 UserInfo.LastAccess，必须为正的 Unix 秒
+		got := driver.ExtractFieldValuePublic(doc, def.UserInfo.Selectors["lastAccessAt"])
+		require.NotEmpty(t, got, "lastAccessAt must be parsed for the login probe")
+		assert.Regexp(t, `^\d+$`, got)
+		assert.Greater(t, got, "0")
+	})
+}
+
+// --- Standalone Tests ---
+
+func TestHhanclub_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search_header":   hhanclubSearchHeaderFixture,
+		"promotion_style": hhanclubPromotionStyleFixture,
+		"search":          hhanclubSearchFixture,
+		"detail":          hhanclubDetailFixture,
+		"detail_gib":      hhanclubDetailGiBFixture,
+		"index":           hhanclubIndexFixture,
+		"userdetails":     hhanclubUserdetailsFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			RequireNoSecrets(t, name, data)
+		})
+	}
+}

--- a/site/v2/definitions/u2dmhy.go
+++ b/site/v2/definitions/u2dmhy.go
@@ -1,0 +1,220 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+// U2DMHYDefinition 描述 U2分享園@動漫花園（u2.dmhy.org）站点。
+//
+// 站点名称取自页面 <title>「U2分享園@動漫花園 :: 种子」，保留繁体字「園」。
+// 搜索页是标准 NexusPHP <table class="torrents"> 布局，但详情页与用户页有四处需要专门适配：
+//  1. 详情页没有 input[name='torrent_name'] 隐藏域（只有 detail_torrent_id），
+//     标题只存在于 h1#top 文本中，须走共享解析器的文本兜底路径。
+//  2. 「基本信息」行的第一个字段是「发布时间:」而非「大小:」，且冒号为半角、
+//     体积单位为二进制形式（GiB / TiB），因此 SizeRegex 必须同时放宽冒号与单位。
+//  3. 促销状态在详情页由 img.pro_* 图标表示（而非 <font class="free">），
+//     搜索页的促销剩余时间使用 <time title="..."> 而非 <span title="...">。
+//  4. 用户页标签为简体（加入日期 / 最近动向 / 传输 / 等级），
+//     站点货币是 UCoin 而非魔力值，「原积分」行只有历史链接、没有数值。
+var U2DMHYDefinition = &v2.SiteDefinition{
+	ID:             "u2dmhy",
+	Name:           "U2分享園@動漫花園",
+	Aka:            []string{"U2", "動漫花園"},
+	Description:    "以动漫资源为主的 PT 站点，使用 UCoin 经济体系",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://u2.dmhy.org/"},
+	FaviconURL:     "https://u2.dmhy.org/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "seeding", "leeching"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields: []string{
+					"uploaded", "downloaded", "ratio",
+					"trueUploaded", "trueDownloaded",
+					"bonus", "levelName", "joinTime", "lastAccessAt",
+				},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			// #info_block 中用户名链接的 class 形如 NexusMaster_Name（等级名 + _Name），
+			// 优先用它命中，避免误取同一区块内的 clientlist / ullist 链接
+			"id": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php'][class*='_Name']",
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php']",
+				},
+				Attr:    "href",
+				Filters: []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php'][class*='_Name']",
+					"#info_block a[href*='userdetails.php']",
+				},
+			},
+			// 做种数是 img.arrowup 之后的 <a href="...&ullist=1#seedlist">数字</a>
+			"seeding": {
+				Selector: []string{"#info_block a[href*='ullist=1']"},
+				Filters:  []v2.Filter{{Name: "parseNumber"}},
+			},
+			// 下载数是 img.arrowdown 之后的裸文本节点，无法用 CSS 直接命中，
+			// 只能对 #info_block 取 html 后用正则截取
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowdown"[^>]*>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			// 「传输」行是内嵌 table 的合并单元格，标签为 <strong>xxx</strong> + 半角冒号 + 两个空格；
+			// 实际上传/下载的标签是「实际上传」「实际下载」（没有「量」字）
+			"uploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>上传量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"downloaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>下载量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"ratio": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>分享率</strong>[：:\s]*(?:<font[^>]*>)?([\d.,]+|∞|Inf)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"trueUploaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>实际上传</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"trueDownloaded": {
+				Selector: []string{"td.rowhead:contains('传输') + td", "td.rowhead:contains('傳輸') + td"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>实际下载</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			// 本站货币是 UCoin：「原积分」行只有历史链接没有数值，
+			// UCoin 行在图形化符号之后用括号给出精确值 (9,999,999.999)
+			"bonus": {
+				Selector: []string{"td.rowhead:contains('UCoin') + td"},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`\(([\d.,]+)\)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"levelName": {
+				Selector: []string{"td.rowhead:contains('等级') + td img", "td.rowhead:contains('等級') + td img"},
+				Attr:     "title",
+			},
+			// 时间行形如 <time>2018-01-24 20:00:03</time> (<time title="...">8年6月前</time>/443 周 4 天 前)
+			"joinTime": {
+				Selector: []string{
+					"td.rowhead:contains('加入日期') + td",
+					"td.rowhead:contains('Join') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+			// 保号探测只读取 UserInfo.LastAccess，缺失会导致线上探测解析失败
+			"lastAccessAt": {
+				Selector: []string{
+					"td.rowhead:contains('最近动向') + td",
+					"td.rowhead:contains('最近動向') + td",
+					"td.rowhead:contains('Last access') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		TableRows: "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		// 列顺序（由 colhead 行确认）：1 分类 / 2 名称 / 3 评论数 / 4 生存时间 / 5 大小 / 6 种子数 / 7 下载数 / 8 完成数
+		Title:     "table.torrentname a.tooltip[href*='details.php']",
+		TitleLink: "table.torrentname a.tooltip[href*='details.php']",
+		// 副标题在名称子表第二行的 <span class="tooltip">（标题链接同样带 tooltip，故限定 span）
+		Subtitle: "table.torrentname span.tooltip",
+		// 大小列写作 "9.328<br />GiB"，parseSize 去空白后按二进制单位换算
+		Size:     "td.rowfollow:nth-child(5)",
+		Seeders:  "td.rowfollow:nth-child(6)",
+		Leechers: "td.rowfollow:nth-child(7)",
+		Snatched: "td.rowfollow:nth-child(8)",
+		// 实际抓取到的促销图标只有 pro_free2up / pro_2up / pro_50pctdown，
+		// 其余为 NexusPHP 通用类名，一并保留以便站点后续启用
+		DiscountIcon: "img.pro_free, img.pro_free2up, img.pro_2up, img.pro_50pctdown, img.pro_30pctdown",
+		// 故意不配置 DiscountMapping：搜索页解析走 parseDiscountFromElement，它用
+		// strings.Contains 遍历 map，而 "pro_free" 是 "pro_free2up" 的前缀，
+		// 显式映射会因 map 遍历顺序随机而把 2X Free 误判为 Free。
+		// 驱动内置的兜底判定按 free2up → free → 50pct → 2up 顺序短路，结果确定。
+		// 促销剩余时间在名称子表内的 [剩余 <time title="...">]，用 <time> 而非 <span>；
+		// 限定在 table.torrentname 内，避免误取第 4 列的生存时间
+		DiscountEndTime: "table.torrentname time[title]",
+		// 分类单元格是纯文本链接 <a href="?cat=40">Other</a>，没有 img[alt]；
+		// 驱动只读取 alt 属性，因此本站分类字段会保持为空
+		Category:           "td.rowfollow:nth-child(1) a[href*='cat=']",
+		UploadTime:         "td.rowfollow:nth-child(4) time[title]",
+		DetailDownloadLink: "td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		// 详情页「流量优惠」行用 img.pro_* 表示促销，映射键即图标类名
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"pro_free2up":   v2.Discount2xFree,
+			"pro_free":      v2.DiscountFree,
+			"pro_2up":       v2.Discount2xUp,
+			"pro_50pctdown": v2.DiscountPercent50,
+			"pro_30pctdown": v2.DiscountPercent30,
+		},
+		HRKeywords: []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		// 详情页无 torrent_name 隐藏域：标题取 h1#top 文本（共享解析器的文本兜底路径），
+		// 种子 ID 仍可从字幕上传表单的 input[name='detail_torrent_id'] 取得
+		TitleSelector:    "h1#top",
+		IDSelector:       "input[name='detail_torrent_id']",
+		DiscountSelector: "td.rowhead:contains('流量优惠') + td img[class*='pro_'], td.rowhead:contains('流量優惠') + td img[class*='pro_']",
+		// 促销剩余时间同样限定在「流量优惠」行内，避免误取「基本信息」行的发布时间 <time>。
+		// 采集样本是永久 2X，该行未渲染剩余时间，故此选择器尚未在真实数据上验证过；
+		// 形态参照搜索页已确认的 [剩余 <time title="...">] 标记
+		EndTimeSelector: "td.rowhead:contains('流量优惠') + td time[title], td.rowhead:contains('流量優惠') + td time[title]",
+		SizeSelector:    "td.rowhead:contains('基本信息')",
+		// 「基本信息」行首字段是「发布时间:」，须跳到后面的「大小:」；
+		// 冒号为半角、单位为二进制形式（9.328 GiB），默认正则两处都不匹配
+		SizeRegex: `大小[：:][^\d]*([\d.]+)\s*([KMGTP]i?B)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(U2DMHYDefinition)
+}

--- a/site/v2/definitions/u2dmhy_fixture_test.go
+++ b/site/v2/definitions/u2dmhy_fixture_test.go
@@ -1,0 +1,315 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "u2dmhy",
+		Search:   testU2DMHYSearch,
+		Detail:   testU2DMHYDetail,
+		UserInfo: testU2DMHYUserInfo,
+	})
+}
+
+// --- Fixtures ---
+//
+// 结构照搬真实页面，但标题、副标题、种子 ID、用户名与用户 ID 均已替换为虚构值。
+//
+// 搜索页需要覆盖的真实特征：
+//   - 标题链接与副标题都带 class="tooltip"（前者是 <a>，后者是 <span>）
+//   - 促销剩余时间是 [剩余 <time title="...">] 而非 <span title="...">
+//   - pro_free2up / pro_2up / pro_50pctdown 三种促销图标共存，且 pro_free 是 pro_free2up 的前缀
+//   - 大小列写作 "9.328<br />GiB"（数字与二进制单位被 <br /> 分开）
+//   - 生存时间列同样用 <time title="...">，内含 &shy; 软连字符
+//   - 分类单元格是纯文本链接，没有 img[alt]
+
+const u2dmhySearchFixture = `<html><body>
+<table class="torrents" cellspacing="0" cellpadding="5" width="100%">
+<tr><td class="colhead" style="padding: 0">分类</td><td class="colhead"><a href="?sort=1&amp;type=asc">名称</a></td><td class="colhead"><img class="comments" src="pic/trans.gif" alt="comments" title="评论数" /></td><td class="colhead"><img class="time" src="pic/trans.gif" alt="time" title="生存时间" /></td><td class="colhead"><img class="size" src="pic/trans.gif" alt="Size" title="大小" /></td><td class="colhead"><img class="seeders" src="pic/trans.gif" alt="Seeders" title="种子数" /></td><td class="colhead"><img class="leechers" src="pic/trans.gif" alt="Leechers" title="下载数" /></td><td class="colhead"><img class="snatched" src="pic/trans.gif" alt="Snatched" title="完成数" /></td></tr>
+<tr>
+<td class="rowfollow nowrap" valign="middle"><a style='' href="?cat=16">BDMV</a></td><td class="rowfollow" width="100%" align="left"><table class="torrentname" width="100%">
+<tr><td class="embedded overflow-control"><img class="sticky" src="pic/trans.gif" alt="Sticky" title="置顶" />&nbsp;<a class="tooltip" href="details.php?id=770001&amp;hit=1">[示例动画剧场版][Sample Anime Movie][サンプル劇場版][BDMV][1080p][MOVIE][AVC FLAC][JPN]</a></td><td width="40" class="embedded" style="text-align: right;" valign="middle"><a href="download.php?id=770001"><img class="download" src="pic/trans.gif" style="padding-bottom: 2px;" alt="download" title="下载种子" /></a><a id="bookmark0" href="javascript: bookmark(770001,0);" ><img class="delbookmark" src="pic/trans.gif" alt="Unbookmarked" title="收藏" /></a></td></tr><tr><td class="embedded overflow-control"><b>[<span class="new">新！</span>]</b>&nbsp;<b>[<span class="hot">热门</span>]</b>&nbsp; <img class="pro_free2up" src="pic/trans.gif" alt="2X Free" />[<b>剩余 <time title="2026-07-28 11:46:31">20&shy;小时&shy;34&shy;分钟</time></b>]&nbsp;<span class="tooltip">虚构副标题一 | 自购自抓</span></td><td class="embedded" style="text-align: right;" valign="middle"><a target="_blank" href="http://anidb.net/a90001"><span style="padding-top: 2px;font-size:7pt;color:#3C4954;">8.85</span></a></td></tr></table></td><td class="rowfollow"><a href="comment.php?action=add&amp;pid=770001&amp;type=torrent" title="添加评论">0</a></td><td class="rowfollow nowrap"><time title="2026-07-27 10:58:20">4&shy;小时<br />14&shy;分钟</time></td><td class="rowfollow">46.717<br />GiB</td><td class="rowfollow " align="center"><b><a href="details.php?id=770001&amp;hit=1&amp;dllist=1#seeders">74</a></b></td><td class="rowfollow ">7</td><td class="rowfollow "><a href="viewsnatches.php?id=770001"><b>142</b></a></td></tr>
+<tr>
+<td class="rowfollow nowrap" valign="middle"><a style='' href="?cat=40">Other</a></td><td class="rowfollow" width="100%" align="left"><table class="torrentname" width="100%">
+<tr><td class="embedded overflow-control"><a class="tooltip" href="details.php?id=770002&amp;hit=1">[示例特别篇][Sample TV Special][サンプルSP][HDTVraw][1440x1080i][MPEG2-TS AAC][Sample-Team]</a></td><td width="40" class="embedded" style="text-align: right;" valign="middle"><a href="download.php?id=770002"><img class="download" src="pic/trans.gif" style="padding-bottom: 2px;" alt="download" title="下载种子" /></a></td></tr><tr><td class="embedded overflow-control"><b>[<span class="hot">热门</span>]</b>&nbsp; <img class="pro_2up" src="pic/trans.gif" alt="2X" />&nbsp;<span class="tooltip">虚构副标题二｜禁转</span></td><td class="embedded" style="text-align: right;" valign="middle"></td></tr></table></td><td class="rowfollow"><b><a href="details.php?id=770002&amp;hit=1&amp;cmtpage=1#startcomments">4</a></b></td><td class="rowfollow nowrap"><time title="2019-12-01 00:37:29">6&shy;年<br />7&shy;月</time></td><td class="rowfollow">9.328<br />GiB</td><td class="rowfollow " align="center"><b><a href="details.php?id=770002&amp;hit=1&amp;dllist=1#seeders">28</a></b></td><td class="rowfollow ">0</td><td class="rowfollow "><a href="viewsnatches.php?id=770002"><b>220</b></a></td></tr>
+<tr>
+<td class="rowfollow nowrap" valign="middle"><a style='' href="?cat=12">BDRip</a></td><td class="rowfollow" width="100%" align="left"><table class="torrentname" width="100%">
+<tr><td class="embedded overflow-control"><a class="tooltip" href="details.php?id=770003&amp;hit=1">[示例电视动画][Sample TV Anime][サンプルTV][BDRip][1920x1080][TV 01-12 Fin][H264 FLAC MKV]</a></td><td width="40" class="embedded" style="text-align: right;" valign="middle"><a href="download.php?id=770003"><img class="download" src="pic/trans.gif" style="padding-bottom: 2px;" alt="download" title="下载种子" /></a></td></tr><tr><td class="embedded overflow-control"><b>[<span class="hot">热门</span>]</b>&nbsp; <img class="pro_50pctdown" src="pic/trans.gif" alt="50%" />&nbsp;<span class="tooltip"></span></td><td class="embedded" style="text-align: right;" valign="middle"></td></tr></table></td><td class="rowfollow"><a href="comment.php?action=add&amp;pid=770003&amp;type=torrent" title="添加评论">0</a></td><td class="rowfollow nowrap"><time title="2026-07-20 08:15:00">7&shy;天<br />6&shy;小时</time></td><td class="rowfollow">816.30<br />MiB</td><td class="rowfollow " align="center"><b><a href="details.php?id=770003&amp;hit=1&amp;dllist=1#seeders">74</a></b></td><td class="rowfollow ">10</td><td class="rowfollow "><a href="viewsnatches.php?id=770003"><b>189</b></a></td></tr>
+<tr>
+<td class="rowfollow nowrap" valign="middle"><a style='' href="?cat=30">Lossless<br />Music</a></td><td class="rowfollow" width="100%" align="left"><table class="torrentname" width="100%">
+<tr><td class="embedded overflow-control"><a class="tooltip" href="details.php?id=770004&amp;hit=1">[示例原声集][Sample Original Soundtrack][FLAC+CUE][WEB]</a></td><td width="40" class="embedded" style="text-align: right;" valign="middle"><a href="download.php?id=770004"><img class="download" src="pic/trans.gif" style="padding-bottom: 2px;" alt="download" title="下载种子" /></a></td></tr><tr><td class="embedded overflow-control"><span class="tooltip">虚构副标题四</span></td><td class="embedded" style="text-align: right;" valign="middle"></td></tr></table></td><td class="rowfollow"><a href="comment.php?action=add&amp;pid=770004&amp;type=torrent" title="添加评论">1</a></td><td class="rowfollow nowrap"><time title="2026-06-30 22:00:00">27&shy;天</time></td><td class="rowfollow">1.971<br />GiB</td><td class="rowfollow " align="center"><b><a href="details.php?id=770004&amp;hit=1&amp;dllist=1#seeders">5</a></b></td><td class="rowfollow ">1</td><td class="rowfollow "><a href="viewsnatches.php?id=770004"><b>33</b></a></td></tr>
+</table>
+</body></html>`
+
+// 详情页：本站没有 input[name='torrent_name']，标题只在 h1#top 文本里（走共享解析器的文本兜底），
+// 种子 ID 仍来自字幕上传表单的 detail_torrent_id；
+// 「基本信息」行首字段是「发布时间:」、冒号半角、体积为二进制单位；
+// 促销状态由「流量优惠」行的 img.pro_* 表示，而非 <font class="free">。
+const u2dmhyDetailFixture = `<html><body>
+<h1 align="center" id="top">[示例特别篇][Sample TV Special][サンプルSP][HDTVraw][1440x1080i][MPEG2-TS AAC][Sample-Team]</h1><h3>(#770002)</h3>
+<table width="90%" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead" width="13%">下载</td><td class="rowfollow" width="87%" align="left"><a class="index" href="download.php?id=770002">[U2].Sample.TV.Special.ts.torrent</a>&nbsp;<a class="index" href="download.php?id=770002&amp;zip=1">[ZIP]</a></td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">副标题</td><td class="rowfollow" valign="top" align="left">虚构副标题二｜禁转</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">基本信息</td><td class="rowfollow" valign="top" align="left"><b>发布时间:</b>&nbsp;<time title="2019-12-01 00:37:29">6&shy;年&shy;7&shy;月&shy;前</time>&nbsp;&nbsp;&nbsp;<b>大小:</b>&nbsp;9.328 GiB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;Other</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">流量优惠</td><td class="rowfollow" valign="top" align="left"> <img class="pro_2up" src="pic/trans.gif" alt="2X" />&nbsp;&nbsp;&nbsp;<a href="promotion.php?action=torrent&amp;id=770002" class="faqlink">优惠历史</a></td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><form method="post" action="subtitles.php"><input type="hidden" name="detail_torrent_id" value="770002" /><button>上传字幕</button></form></td></tr>
+</table>
+</body></html>`
+
+// 限时 2X 免费的详情页：h1#top 尾部带 [免费] 促销标记（应被剥离），
+// 「流量优惠」行渲染出 [剩余 <time title>]（结束时间应被解析）。
+const u2dmhyDetailPromoFixture = `<html><body>
+<h1 align="center" id="top">[示例动画剧场版][Sample Anime Movie][BDMV][1080p][JPN] [免费]</h1><h3>(#770001)</h3>
+<table width="90%" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead nowrap" valign="top" align="right">基本信息</td><td class="rowfollow" valign="top" align="left"><b>发布时间:</b>&nbsp;<time title="2026-07-27 10:58:20">4&shy;小时&shy;前</time>&nbsp;&nbsp;&nbsp;<b>大小:</b>&nbsp;46.717 GiB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;BDMV</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">流量优惠</td><td class="rowfollow" valign="top" align="left"> <img class="pro_free2up" src="pic/trans.gif" alt="2X Free" />[<b>剩余 <time title="2026-07-28 11:46:31">20&shy;小时&shy;34&shy;分钟</time></b>]</td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><form method="post" action="subtitles.php"><input type="hidden" name="detail_torrent_id" value="770001" /></form></td></tr>
+</table>
+</body></html>`
+
+// 无促销的详情页：标题尾部是合法的规格方括号，必须保留而不能被促销剥离逻辑吃掉。
+const u2dmhyDetailPlainFixture = `<html><body>
+<h1 align="center" id="top">[示例电视动画 第一季 / Sample Show S01]中日双语字幕  [1080p BluRay]</h1><h3>(#770003)</h3>
+<table width="90%" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead nowrap" valign="top" align="right">基本信息</td><td class="rowfollow" valign="top" align="left"><b>发布时间:</b>&nbsp;<time title="2026-07-20 08:15:00">7&shy;天&shy;前</time>&nbsp;&nbsp;&nbsp;<b>大小:</b>&nbsp;816.30 MiB&nbsp;&nbsp;&nbsp;<b>类型:</b>&nbsp;BDRip</td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><form method="post" action="subtitles.php"><input type="hidden" name="detail_torrent_id" value="770003" /></form></td></tr>
+</table>
+</body></html>`
+
+// index.php 顶部 #info_block：用户名链接的 class 是「等级名_Name」；
+// 做种数在 img.arrowup 之后的 <a ...ullist=1#seedlist>，下载数是 img.arrowdown 之后的裸文本节点。
+const u2dmhyIndexFixture = `<html><body>
+<table id="info_block" cellpadding="4" cellspacing="0" border="0" width="100%"><tr><td><table width="100%" cellspacing="0" cellpadding="0" border="0"><tr><td class="bottom" align="left"><span class="medium">欢迎回来, <span class="nowrap"><a  href='userdetails.php?id=90042' style="color:#;" class="NexusMaster_Name"><b><bdo dir='ltr'>fixture_user</bdo></b></a></span> [<a href="logout.php">退出</a>] [<a href="promotion.php?action=my">魔法</a>]<br /><span class="color_ratio">分享率:</span> 4.639 <span class="color_uploaded">上传量:</span> 13.923 TiB <span class="color_downloaded">下载量:</span> 3.001 TiB <a href="ucoin.php" class="faqlink">UCoin</a>: <span class="ucoin-notation ucoin-collapsed" title="0.0010 逸"><span class="ucoin-symbol ucoin-gem">9</span><span class="ucoin-symbol ucoin-gold">69</span></span> <a href="invite.php?id=90042" class="faqlink">邀请</a>: 0 <span class="color_active">客户端</span>: <a href="userdetails.php?id=90042&amp;clientlist=1#btclients">3</a> (<img class="arrowup" alt="Torrents seeding" title="当前做种" src="pic/trans.gif" /><a href="userdetails.php?id=90042&amp;ullist=1#seedlist">16</a> <img class="arrowdown" alt="Torrents leeching" title="当前下载" src="pic/trans.gif" />0)</span></td></tr></table></td></tr></table>
+</body></html>`
+
+// userdetails.php 正文表格：标签为简体（加入日期 / 最近动向 / 传输 / 等级）；
+// 「传输」行是内嵌 table，标签写作 <strong>上传量</strong> + 半角冒号 + 两个空格，
+// 实际上传/下载没有「量」字；「原积分」行只有历史链接、没有数值，魔力值只能取自 UCoin 行。
+const u2dmhyUserdetailsFixture = `<html><body>
+<h1 align="center">fixture_target 的详细资料</h1>
+<table width="100%" border="1" cellspacing="0" cellpadding="5">
+<tr><td width = '1%' class="rowhead nowrap" valign="top" align="right">加入日期</td><td width = '99%' class="rowfollow" valign="top" align="left"><time>2018-01-24 20:00:03</time> (<time title="2018-01-24 20:00:03">8&shy;年&shy;6&shy;月&shy;前</time>/443 周 4 天 前)</td></tr>
+<tr><td width = '1%' class="rowhead nowrap" valign="top" align="right">最近动向</td><td width = '99%' class="rowfollow" valign="top" align="left"><time>2026-07-27 15:12:31</time> (<time title="2026-07-27 15:12:31">现在</time>)</td></tr>
+<tr><td width = '1%' class="rowhead nowrap" valign="top" align="right">传输<br />[<a class="faqlink" href="traffichistory.php?id=90042">历史</a>]</td><td width = '99%' class="rowfollow" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>分享率</strong>:  <font color="">4.639</font></td><td class="embedded">&nbsp;&nbsp;<img src="pic/smilies/5.gif" alt="" /></td></tr><tr><td class="embedded"><strong>上传量</strong>:  13.923 TiB</td><td class="embedded">&nbsp;&nbsp;<strong>下载量</strong>:  3.001 TiB</td></tr><tr><td class="embedded"><strong>实际上传</strong>: 7.375 TiB</td><td class="embedded">&nbsp;&nbsp;<strong>实际下载</strong>: 18.151 TiB</td></tr></table></td></tr>
+<tr><td width = '1%' class="rowhead nowrap" valign="top" align="right">BT时间</td><td width = '99%' class="rowfollow" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>做种时间</strong>:  38852&shy;天&nbsp;17:48:04</td><td class="embedded">&nbsp;&nbsp;<strong>下载时间</strong>:  101&shy;天&nbsp;01:55:29</td></tr></table></td></tr>
+<tr><td width = '1%' class="rowhead nowrap" valign="top" align="right">等级</td><td width = '99%' class="rowfollow" valign="top" align="left"><img alt="宅神" title="宅神" src="pic/nexus.gif" /></td></tr>
+<tr><td width = '1%' class="rowhead nowrap" valign="top" align="right">经验值</td><td width = '99%' class="rowfollow" valign="top" align="left"><b>魔法使 LV1</b> EXP: 16/100<br /></td></tr>
+<tr><td width = '1%' class="rowhead nowrap" valign="top" align="right">原积分</td><td width = '99%' class="rowfollow" valign="top" align="left"><a class="faqlink" href="bonushistory.php?id=90042">历史</a></td></tr>
+<tr><td width = '1%' class="rowhead nowrap" valign="top" align="right">UCoin<br />[<a href="ucoin.php?id=90042" class="faqlink">详情</a>]</td><td width = '99%' class="rowfollow" valign="top" align="left"><span class="ucoin-notation" title="9,692,300.77"><span class="ucoin-symbol ucoin-gem">9</span><span class="ucoin-symbol ucoin-gold">69</span><span class="ucoin-symbol ucoin-silver">23</span></span><br />(9,692,300.771)</td></tr>
+<tr><td width = '1%' class="rowhead nowrap" valign="top" align="right">种子评论</td><td width = '99%' class="rowfollow" valign="top" align="left">0</td></tr>
+</table>
+</body></html>`
+
+// --- Helpers ---
+
+func getU2DMHYDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("u2dmhy")
+	require.True(t, ok, "u2dmhy definition not found")
+	return def
+}
+
+// --- Suite: Search ---
+
+func testU2DMHYSearch(t *testing.T) {
+	def := getU2DMHYDef(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(u2dmhySearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{
+		BaseURL:   server.URL,
+		Cookie:    "test_cookie=1",
+		Selectors: def.Selectors,
+	})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: "GET"})
+	require.NoError(t, err)
+
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 4, "should parse 4 torrent rows")
+
+	twoXFree := items[0]
+	assert.Equal(t, "770001", twoXFree.ID)
+	assert.Equal(t, "[示例动画剧场版][Sample Anime Movie][サンプル劇場版][BDMV][1080p][MOVIE][AVC FLAC][JPN]", twoXFree.Title)
+	assert.Equal(t, "虚构副标题一 | 自购自抓", twoXFree.Subtitle)
+	// pro_free 是 pro_free2up 的前缀，必须判成 2X Free 而不是 Free
+	assert.Equal(t, v2.Discount2xFree, twoXFree.DiscountLevel)
+	// 促销结束时间取名称子表内的 [剩余 <time title>]，不能误取第 4 列的生存时间
+	require.False(t, twoXFree.DiscountEndTime.IsZero(), "discount end time should come from [剩余 <time title>]")
+	assert.Equal(t, 2026, twoXFree.DiscountEndTime.Year())
+	assert.Equal(t, 7, int(twoXFree.DiscountEndTime.Month()))
+	assert.Equal(t, 28, twoXFree.DiscountEndTime.Day())
+	// 46.717 GiB，大小列的数字与单位被 <br /> 分开
+	assert.Equal(t, int64(50161996791), twoXFree.SizeBytes)
+	assert.Equal(t, 74, twoXFree.Seeders)
+	assert.Equal(t, 7, twoXFree.Leechers)
+	assert.Equal(t, 142, twoXFree.Snatched)
+	assert.Positive(t, twoXFree.UploadedAt)
+
+	twoXUp := items[1]
+	assert.Equal(t, "770002", twoXUp.ID)
+	assert.Equal(t, "虚构副标题二｜禁转", twoXUp.Subtitle)
+	assert.Equal(t, v2.Discount2xUp, twoXUp.DiscountLevel)
+	assert.True(t, twoXUp.DiscountEndTime.IsZero(), "permanent 2X has no [剩余] marker")
+	assert.Equal(t, int64(10015863734), twoXUp.SizeBytes)
+	assert.Equal(t, 28, twoXUp.Seeders)
+	assert.Equal(t, 0, twoXUp.Leechers)
+	assert.Equal(t, 220, twoXUp.Snatched)
+
+	half := items[2]
+	assert.Equal(t, "770003", half.ID)
+	assert.Equal(t, v2.DiscountPercent50, half.DiscountLevel)
+	assert.Empty(t, half.Subtitle, "empty <span class=tooltip> yields empty subtitle")
+	assert.Equal(t, int64(855952588), half.SizeBytes)
+	assert.Equal(t, 74, half.Seeders)
+	assert.Equal(t, 10, half.Leechers)
+	assert.Equal(t, 189, half.Snatched)
+
+	plain := items[3]
+	assert.Equal(t, "770004", plain.ID)
+	assert.Equal(t, v2.DiscountNone, plain.DiscountLevel)
+	assert.Equal(t, "虚构副标题四", plain.Subtitle)
+	assert.Equal(t, int64(2116345135), plain.SizeBytes)
+	assert.Equal(t, 5, plain.Seeders)
+	assert.Equal(t, 1, plain.Leechers)
+	assert.Equal(t, 33, plain.Snatched)
+}
+
+// --- Suite: Detail ---
+
+func testU2DMHYDetail(t *testing.T) {
+	def := getU2DMHYDef(t)
+	parser := v2.NewNexusPHPParserFromDefinition(def)
+
+	t.Run("TitleFromTextFallback", func(t *testing.T) {
+		doc := FixtureDoc(t, "u2dmhy_detail", u2dmhyDetailFixture)
+		info := parser.ParseAll(doc.Selection)
+
+		assert.Equal(t, "770002", info.TorrentID)
+		// 无 input[name='torrent_name']，标题只能来自 h1#top 文本
+		require.NotEmpty(t, info.Title, "title must come from the h1#top text fallback")
+		assert.Equal(t, "[示例特别篇][Sample TV Special][サンプルSP][HDTVraw][1440x1080i][MPEG2-TS AAC][Sample-Team]", info.Title)
+		assert.Equal(t, v2.Discount2xUp, info.DiscountLevel)
+		assert.True(t, info.DiscountEnd.IsZero())
+		// 「基本信息」行首字段是发布时间，须跳过它找到半角冒号的「大小:」与二进制单位
+		assert.InDelta(t, 9.328*1024, info.SizeMB, 0.001)
+		assert.False(t, info.HasHR, "site has no H&R marker")
+	})
+
+	t.Run("PromoSuffixStripped", func(t *testing.T) {
+		doc := FixtureDoc(t, "u2dmhy_detail_promo", u2dmhyDetailPromoFixture)
+		info := parser.ParseAll(doc.Selection)
+
+		assert.Equal(t, "770001", info.TorrentID)
+		// 尾部 [免费] 是促销标记，由共享解析器剥离
+		assert.Equal(t, "[示例动画剧场版][Sample Anime Movie][BDMV][1080p][JPN]", info.Title)
+		assert.Equal(t, v2.Discount2xFree, info.DiscountLevel)
+		require.False(t, info.DiscountEnd.IsZero(), "促销剩余时间应从「流量优惠」行的 time[title] 解析")
+		assert.Equal(t, 2026, info.DiscountEnd.Year())
+		assert.Equal(t, 7, int(info.DiscountEnd.Month()))
+		assert.Equal(t, 28, info.DiscountEnd.Day())
+		assert.InDelta(t, 46.717*1024, info.SizeMB, 0.001)
+	})
+
+	t.Run("PlainTitleKeepsBracket", func(t *testing.T) {
+		doc := FixtureDoc(t, "u2dmhy_detail_plain", u2dmhyDetailPlainFixture)
+		info := parser.ParseAll(doc.Selection)
+
+		assert.Equal(t, "770003", info.TorrentID)
+		// 尾部方括号是规格信息而非促销标记，不能被剥离
+		assert.Equal(t, "[示例电视动画 第一季 / Sample Show S01]中日双语字幕  [1080p BluRay]", info.Title)
+		assert.Equal(t, v2.DiscountNone, info.DiscountLevel)
+		assert.InDelta(t, 816.30, info.SizeMB, 0.001)
+		assert.False(t, info.HasHR)
+	})
+}
+
+// --- Suite: UserInfo ---
+
+func testU2DMHYUserInfo(t *testing.T) {
+	def := getU2DMHYDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	t.Run("IndexPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "u2dmhy_index", u2dmhyIndexFixture)
+		fields := map[string]string{
+			"id":   "90042",
+			"name": "fixture_user",
+			// 做种数在 <a ...ullist=1>，下载数是 img.arrowdown 之后的裸文本
+			"seeding":  "16",
+			"leeching": "0",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+	})
+
+	t.Run("UserdetailsPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "u2dmhy_userdetails", u2dmhyUserdetailsFixture)
+		fields := map[string]string{
+			// 13.923 TiB / 3.001 TiB / 7.375 TiB / 18.151 TiB 按二进制单位换算为字节
+			"uploaded":       "15308500393525",
+			"downloaded":     "3299634394955",
+			"trueUploaded":   "8108898254848",
+			"trueDownloaded": "19957235555762",
+			"ratio":          "4.639",
+			"levelName":      "宅神",
+			// 站点货币是 UCoin，parseNumber 的大数结果以科学计数法字符串返回
+			"bonus": "9.692300771e+06",
+			// parseTime 按站点 TimezoneOffset(+0800) 解析
+			"joinTime":     "1516795203",
+			"lastAccessAt": "1785136351",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+
+		// 保号探测只读取 UserInfo.LastAccess，必须为正的 Unix 秒
+		got := driver.ExtractFieldValuePublic(doc, def.UserInfo.Selectors["lastAccessAt"])
+		require.NotEmpty(t, got, "lastAccessAt must be parsed for the login probe")
+		assert.Regexp(t, `^\d+$`, got)
+		assert.Greater(t, got, "0")
+	})
+}
+
+// --- Standalone Tests ---
+
+func TestU2dmhy_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":       u2dmhySearchFixture,
+		"detail":       u2dmhyDetailFixture,
+		"detail_promo": u2dmhyDetailPromoFixture,
+		"detail_plain": u2dmhyDetailPlainFixture,
+		"index":        u2dmhyIndexFixture,
+		"userdetails":  u2dmhyUserdetailsFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			RequireNoSecrets(t, name, data)
+		})
+	}
+}

--- a/tools/browser-extension/src/core/constants.ts
+++ b/tools/browser-extension/src/core/constants.ts
@@ -571,6 +571,33 @@ export const KNOWN_SITES: KnownSite[] = [
     cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
     syncField: "cookie",
   },
+  {
+    id: "cspt",
+    name: "财神",
+    domains: ["cspt.top"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
+  {
+    id: "hhanclub",
+    name: "HHCLUB",
+    domains: ["hhanclub.net"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
+  {
+    id: "u2dmhy",
+    name: "U2分享園@動漫花園",
+    domains: ["u2.dmhy.org"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
 ];
 
 export const PAGE_PATTERNS: Array<{ pattern: RegExp; pageType: PageType }> = [


### PR DESCRIPTION
## Summary

新增三个 NexusPHP 站点适配（issue #492、#497、#499）。这是站点请求批量适配的第三批，也是难度最高的一批——三站均偏离经典表格布局。

| 站点 | ID | 域名 | Issue |
|---|---|---|---|
| 财神 | `cspt` | cspt.top | #499 |
| HHCLUB | `hhanclub` | hhanclub.net | #492 |
| U2分享園@動漫花園 | `u2dmhy` | u2.dmhy.org | #497 |

**未修改任何共享解析代码**——三站的非标准结构全部通过站点自身的选择器配置解决。

## 关键结论：`TableRows` 不限于表格

勘查阶段确认驱动并未硬编码 `<table>`/`<td>`：`SiteSelectors.TableRows` 只是一个可被站点覆盖的 CSS 选择器，`nth-child` 对 div 兄弟节点同样适用。这推翻了「div 布局需要扩展共享层」的初始判断，也是本批无需改动共享代码的原因。

## 各站难点与解法

**财神（cspt.top）** — 列表 div 布局，详情页标准表格

行选择器 `div.torrent-table-sub-info:has(a[href*='details.php'])`。三个单元格（`torrent-cat` / `torrent-title` / `torrent-info` 包装层）的公共父元素带 `torrent-table-sub-info`，而表头行不带该 class，因此天然排除表头。

**HHCLUB（hhanclub.net）** — 列表与详情页**均为** div 布局，本批最难

三个难点：

1. **页面完全没有 `class="torrents"` 锚点**。改用 `div.torrent-table-sub-info`（100 次，与 100 个 `download.php?id=` 一一对应）。外层 `torrent-table-for-spider` 是 101 次，会连表头一起命中，不可用。
2. **优惠标记是自定义 span 而非标准 `img.pro_*`**。站点自己的 tailwindcss 块声明了 `promotion-tag-free` / `-2xfree` / `-50` / `-30`。映射键用**完整 class 名**，因为搜索侧走子串匹配——若键名只写 `free` / `2xfree`，`free` 会成为 `2xfree` 的子串，Go map 遍历顺序随机会导致 2X 免费被概率性误判。
3. **详情页体积在嵌套 div 中**。`ParseSizeMB` 读 `.Next()` 兄弟节点，所以 `SizeSelector` 必须指向内层 `span.font-bold`（其下一兄弟正是数值），不能指向 `基本信息` 标签 div（其兄弟是整个 grid 容器）。相应地正则不再带 `大小：` 前缀。

**U2（u2.dmhy.org）** — 列表标准表格，但详情页无隐藏标题域

`input[name='torrent_name']` **0 次出现**，标题走 v0.44.0 的文本回退路径（`h1#top`）。体积行还有三处偏离默认值：冒号是**半角**、单位是 **IEC 二进制**（`GiB`）、且该行首字段是 `发布时间:` 而非 `大小:`，正则需以 `大小` 锚点跳过前缀。

`SiteSelectors.DiscountMapping` 刻意留空：搜索侧 `parseDiscountFromElement` 用子串遍历，而 `pro_free` 是 `pro_free2up` 的前缀，显式映射会因 map 顺序随机误判。驱动内置兜底按 `free2up → free → 50pct → 2up` 短路，结果确定。定义文件中有注释锁死该决策。

## Verification

**真实页面探针**（关键验证，非手写 fixture）

| 站点 | 详情 SizeMB | 换算 | 详情优惠 | 列表条数 | 期望 |
|---|---|---|---|---|---|
| 财神 | `13291.52` | 12.98×1024 | FREE | **100** | 100 |
| HHCLUB | `17745.92` | 17.33×1024 | FREE | **100** | 100 |
| U2 | `9551.87` | 9.328×1024 | 2XUP | **50** | 50 |

条数与各站 `download.php?id=` 出现次数完全吻合，证明行选择器正确排除了表头。三站空 ID、零大小均为 0，`lastAccessAt` 全部非空（保号探针可用）。

HHCLUB 的优惠映射有额外证据：FREE 39 / NONE 61，其中 **39 条促销行全部取到结束时间，61 条无促销行的 `DiscountEndTime` 全为零**——证明促销时间没有误取同为 `span[title]` 的发布时间。

U2 详情页标题完整解析，尾部制作组标记 `[Lupin-Lovers]` 被正确保留，未被促销剥离逻辑误伤（该逻辑只匹配已知优惠词表）。

**自动化检查**

- `node --experimental-strip-types scripts/check-sites.ts` → Go 与扩展**双侧 64**，`✅ in sync`
- `go test ./... -count=1` → exit 0，40 个包通过，0 FAIL
- `TestAllSites_FixtureCoverage/{cspt,hhanclub,u2dmhy}` → 三站全通过
- `make lint-go` → 0 issues
- `make fmt-check` → 通过

`docs/sites.md` 的 diff 较大（125 行）是因为新增备注较长触发 `oxfmt` 表格列宽重排。压缩空格后核对确认实质变更仅 5 处：两处计数、分隔行加宽、新增三行；其余为纯对齐。

fixture 全部脱敏，各站含 `NoSecrets` 测试。HHCLUB 的 fixture 显式包含表头行并断言其被排除。

## 已知限制（接受并上线）

**HHCLUB 搜索列表标题带 `[新]` 角标**（91/100 行）。角标是标题锚点内嵌的 `<span class='new'>[新]</span>`，而 `ParseSearch` 取标题走 `titleElem.Text()`，无 Attr/Filters 钩子——`SiteSelectors` 为副标题提供了 `SubtitleSelector *FieldSelector`，但标题没有对称能力，CSS 也无法排除子元素，该行亦无其他携带干净标题的元素。

影响面有限：详情页走隐藏域，标题干净，因此 **RSS 下载、免费到期监控、`.torrent` 文件名均不受影响**，仅搜索列表展示带角标。最小修复是给 `SiteSelectors` 增加对称的 `TitleSelector *FieldSelector`，但那会触及全部 60 个 NexusPHP 站点的代码路径，与收益不成比例，故本次不做。

## 未能从采集数据验证的项

- **U2**：`pro_free` / `pro_30pctdown` 未在样本出现（仅保留选择器与详情页精确映射）；详情页促销剩余时间选择器无样本可验（样本为永久 2X）
- **HHCLUB**：`2xfree` / `50` / `30` 三种优惠未在样本出现，映射键取自站点自身的 CSS 声明；`Category` 留空（分类图标 `alt` 恒为列头字样，配置会给所有行写入同一无意义取值）
- **U2**：`Category` 无法填充（分类格是纯文本链接，无 `img[alt]`，而驱动只读 `alt`）
- 三站均未设 H&R（`hitandrun` / `hit_run` / `Hit and Run` 在全部 9 个页面中 0 次出现）、均未配置 `LevelRequirements`（采集数据无等级门槛表）