### PR TITLE
feat(web): 任务列表新增清理已删除/已过期任务功能并修复全选异常

### DIFF
--- a/web/api_torrent_management.go
+++ b/web/api_torrent_management.go
@@ -310,6 +310,59 @@ func (s *Server) apiDeleteTasks(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// apiCleanupTasks 清理所有"已删除"（种子已从下载器中删除）和"已过期"（免费期结束）的任务记录
+// POST /api/tasks/cleanup
+func (s *Server) apiCleanupTasks(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	db := global.GlobalDB.DB
+
+	// 查询所有"已删除"或"已过期"的任务记录
+	const removedMark = "种子已从下载器中删除"
+	var torrents []models.TorrentInfo
+	if err := db.Where("is_expired = ? OR last_error = ?", true, removedMark).Find(&torrents).Error; err != nil {
+		http.Error(w, "查询失败: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if len(torrents) == 0 {
+		writeJSON(w, DeleteTasksResponse{Success: 0, Failed: 0})
+		return
+	}
+
+	var success, failed int
+	var failedIDs []uint
+	var failedErrors []string
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		for _, t := range torrents {
+			if delErr := tx.Delete(&t).Error; delErr != nil {
+				failed++
+				failedIDs = append(failedIDs, t.ID)
+				failedErrors = append(failedErrors, t.Title+": "+delErr.Error())
+				continue
+			}
+			success++
+			global.GetSlogger().Infof("已清理任务记录: %s (ID:%d)", t.Title, t.ID)
+		}
+		return nil
+	})
+	if err != nil {
+		http.Error(w, "事务处理失败: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, DeleteTasksResponse{
+		Success:      success,
+		Failed:       failed,
+		FailedIDs:    failedIDs,
+		FailedErrors: failedErrors,
+	})
+}
+
 // apiArchiveTorrents 获取归档种子列表
 // GET /api/torrents/archive
 func (s *Server) apiArchiveTorrents(w http.ResponseWriter, r *http.Request) {

--- a/web/api_torrent_management_test.go
+++ b/web/api_torrent_management_test.go
@@ -544,6 +544,85 @@ func TestApiDeleteTasks_SkipsPushed(t *testing.T) {
 	assert.Equal(t, 1, resp.Success)
 }
 
+func TestApiCleanupTasks(t *testing.T) {
+	server, db := setupTestServer(t)
+	require.NoError(t, db.AutoMigrate(&models.TorrentInfo{}))
+
+	// 场景数据：
+	// 1. 已过期（is_expired=true）→ 应清理
+	// 2. 已删除（last_error="种子已从下载器中删除"）→ 应清理
+	// 3. 已过期且已推送 → 应清理（清理不区分推送状态）
+	// 4. 正常记录（未过期、无错误）→ 保留
+	// 5. 有错误但不是"已删除"标记 → 保留
+	pushed := true
+	require.NoError(t, db.Create(&models.TorrentInfo{
+		SiteName: "hdsky", TorrentID: "1", Title: "Expired", IsExpired: true,
+	}).Error)
+	require.NoError(t, db.Create(&models.TorrentInfo{
+		SiteName: "hdsky", TorrentID: "2", Title: "Removed",
+		LastError: "种子已从下载器中删除",
+	}).Error)
+	require.NoError(t, db.Create(&models.TorrentInfo{
+		SiteName: "hdsky", TorrentID: "3", Title: "ExpiredAndPushed",
+		IsExpired: true, IsPushed: &pushed,
+	}).Error)
+	require.NoError(t, db.Create(&models.TorrentInfo{
+		SiteName: "hdsky", TorrentID: "4", Title: "Normal",
+	}).Error)
+	require.NoError(t, db.Create(&models.TorrentInfo{
+		SiteName: "hdsky", TorrentID: "5", Title: "OtherError", LastError: "下载失败",
+	}).Error)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/cleanup", nil)
+	server.apiCleanupTasks(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeleteTasksResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 3, resp.Success)
+	assert.Equal(t, 0, resp.Failed)
+
+	// 验证数据库：只剩 2 条正常记录
+	var remaining []models.TorrentInfo
+	require.NoError(t, db.Order("id ASC").Find(&remaining).Error)
+	require.Len(t, remaining, 2)
+	assert.Equal(t, "Normal", remaining[0].Title)
+	assert.Equal(t, "OtherError", remaining[1].Title)
+}
+
+func TestApiCleanupTasks_NoMatches(t *testing.T) {
+	server, db := setupTestServer(t)
+	require.NoError(t, db.AutoMigrate(&models.TorrentInfo{}))
+
+	require.NoError(t, db.Create(&models.TorrentInfo{
+		SiteName: "hdsky", TorrentID: "1", Title: "Normal",
+	}).Error)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/cleanup", nil)
+	server.apiCleanupTasks(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeleteTasksResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 0, resp.Success)
+	assert.Equal(t, 0, resp.Failed)
+
+	var count int64
+	db.Model(&models.TorrentInfo{}).Count(&count)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestApiCleanupTasks_MethodNotAllowed(t *testing.T) {
+	server, _ := setupTestServer(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks/cleanup", nil)
+	server.apiCleanupTasks(w, req)
+	require.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
 // ==== merged from api_torrent_management_test.go ====
 // TestApiDeleteTasks 测试批量删除任务API
 func TestApiDeleteTasks(t *testing.T) {

--- a/web/frontend/src/api/index.ts
+++ b/web/frontend/src/api/index.ts
@@ -276,6 +276,7 @@ export const sitesApi = {
 export const tasksApi = {
   list: (params: URLSearchParams) => api.get<TaskListResponse>(`/api/tasks?${params.toString()}`),
   batchDelete: (ids: number[]) => api.post<DeleteTasksResponse>("/api/tasks/batch-delete", { ids }),
+  cleanup: () => api.post<DeleteTasksResponse>("/api/tasks/cleanup"),
 };
 
 export const logsApi = {

--- a/web/frontend/src/views/TaskList.vue
+++ b/web/frontend/src/views/TaskList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type TaskItem, type TaskListResponse, tasksApi } from "@/api";
-import { Delete, Refresh, Search } from "@element-plus/icons-vue";
-import { ElMessage, ElMessageBox } from "element-plus";
+import { Brush, Delete, Refresh, Search } from "@element-plus/icons-vue";
+import { ElMessage, ElMessageBox, type TableInstance } from "element-plus";
 import { computed, onMounted, ref } from "vue";
 
 const loading = ref(false);
@@ -9,6 +9,7 @@ const tasks = ref<TaskItem[]>([]);
 const total = ref(0);
 const page = ref(1);
 const pageSize = ref(20);
+const tableRef = ref<TableInstance>();
 
 const filters = ref({
   q: "",
@@ -78,6 +79,60 @@ function handleSizeChange(newSize: number) {
 
 function handleSelectionChange(selection: TaskItem[]) {
   selectedIds.value = selection.map((t) => t.id);
+}
+
+// ---- 全选（表头复选框）----
+// Element Plus 内置表头全选在存在 :selectable 时会把 isAllSelected 无条件置为 true，
+// 导致当前页全部行不可选（如全部已推送）时表头显示"全选"却没有任何行被选中。
+// 这里用自定义表头复选框，状态基于"当前页所有可选行"实时计算，保证表头与勾选一致。
+const selectableRows = computed(() => tasks.value.filter((t) => !t.isPushed));
+const isHeaderChecked = computed(() => {
+  const rows = selectableRows.value;
+  return rows.length > 0 && rows.every((t) => selectedIds.value.includes(t.id));
+});
+const isHeaderIndeterminate = computed(
+  () => selectedIds.value.length > 0 && !isHeaderChecked.value,
+);
+
+function handleHeaderSelectAll(val: string | number | boolean) {
+  const table = tableRef.value;
+  if (!table) return;
+  if (val) {
+    selectableRows.value.forEach((row) => {
+      if (!selectedIds.value.includes(row.id)) {
+        table.toggleRowSelection(row, true);
+      }
+    });
+  } else {
+    table.clearSelection();
+  }
+}
+
+async function handleCleanup() {
+  try {
+    await ElMessageBox.confirm(
+      "将删除所有「已删除」（种子已从下载器中删除）和「已过期」（免费期结束）的任务记录，此操作不可恢复，确认继续吗？",
+      "清理任务",
+      {
+        type: "warning",
+        confirmButtonText: "清理",
+        cancelButtonText: "取消",
+      },
+    );
+
+    const res = await tasksApi.cleanup();
+    if (res.failed > 0) {
+      ElMessage.warning(`清理完成：成功 ${res.success} 条，失败 ${res.failed} 条`);
+    } else {
+      ElMessage.success(`已清理 ${res.success} 条已删除/已过期任务`);
+    }
+    selectedIds.value = [];
+    await loadTasks();
+  } catch (e: unknown) {
+    if ((e as string) !== "cancel") {
+      ElMessage.error((e as Error).message || "清理失败");
+    }
+  }
 }
 
 async function handleBatchDelete() {
@@ -258,6 +313,10 @@ function getDiscountTag(task: TaskItem): {
           </el-tag>
         </div>
         <div class="table-card-header-actions">
+          <el-button type="warning" size="small" plain class="cleanup-btn" @click="handleCleanup">
+            <el-icon class="mr-1"><Brush /></el-icon>
+            清理所有已删除和已过期任务
+          </el-button>
           <el-button
             type="danger"
             size="small"
@@ -279,6 +338,7 @@ function getDiscountTag(task: TaskItem): {
 
       <div class="table-wrapper">
         <el-table
+          ref="tableRef"
           :data="tasks"
           style="width: 100%"
           class="pt-table"
@@ -287,7 +347,16 @@ function getDiscountTag(task: TaskItem): {
           <el-table-column
             type="selection"
             width="55"
-            :selectable="(row: Record<string, any>) => !row.isPushed" />
+            :selectable="(row: Record<string, any>) => !row.isPushed">
+            <template #header>
+              <el-checkbox
+                :model-value="isHeaderChecked"
+                :indeterminate="isHeaderIndeterminate"
+                :disabled="selectableRows.length === 0"
+                aria-label="全选"
+                @change="handleHeaderSelectAll" />
+            </template>
+          </el-table-column>
           <el-table-column label="站点" prop="siteName" width="120" align="center">
             <template #default="{ row }">
               <el-tag size="small" type="primary" effect="light" class="site-tag">{{

--- a/web/server.go
+++ b/web/server.go
@@ -84,6 +84,7 @@ func (s *Server) Serve(addr string) error {
 	mux.HandleFunc("/api/password", s.auth(s.apiPassword))
 	mux.HandleFunc("/api/tasks", s.auth(s.apiTasks))
 	mux.HandleFunc("/api/tasks/batch-delete", s.auth(s.apiDeleteTasks))
+	mux.HandleFunc("/api/tasks/cleanup", s.auth(s.apiCleanupTasks))
 	mux.HandleFunc("/api/logs", s.auth(s.apiLogs))
 	mux.HandleFunc("/api/control/stop", s.auth(s.apiStopAll))
 	mux.HandleFunc("/api/control/start", s.auth(s.apiStartAll))


### PR DESCRIPTION
## 变更内容

### 1. 新增清理功能
任务列表页新增「清理所有已删除和已过期任务」按钮（工具栏，带二次确认框）：
- 后端新增 `POST /api/tasks/cleanup`，删除所有**已过期**（`is_expired=true`）或**已从下载器中删除**（`last_error="种子已从下载器中删除"`）的任务记录
- 清理不区分推送状态（已推送的过期记录同样清理），前端清理完成后自动刷新列表

### 2. 修复全选功能异常
- **根因**：Element Plus 表头全选在存在 `:selectable`（已推送行不可选）时，`_toggleAllSelection` 会无条件将 `isAllSelected` 置为 `true`。当当前页全部行不可选（如全部已推送）时，出现**表头显示"全选"但没有任何行被选中**的矛盾状态；部分行不可选时表头状态也与实际勾选不一致
- **修复**：改用自定义表头复选框（`#header` 插槽），选中/半选状态基于当前页所有可选行实时计算，表头勾选与行勾选始终一致；全部行不可选时复选框置灰

## 测试验证
- 后端：新增 3 个单元测试（`TestApiCleanupTasks` / `TestApiCleanupTasks_NoMatches` / `TestApiCleanupTasks_MethodNotAllowed`），`go test ./web/` 全部通过
- 前端：`pnpm build`（vue-tsc 类型检查 + vite 构建）、oxlint、oxfmt 全部通过
- 端到端：启动服务登录后调用清理 API，已删除/已过期记录被正确清理，正常记录保留；未认证请求返回 401

## 涉及文件
- `web/api_torrent_management.go`：新增 `apiCleanupTasks`
- `web/server.go`：注册 `/api/tasks/cleanup` 路由
- `web/api_torrent_management_test.go`：新增 3 个测试
- `web/frontend/src/api/index.ts`：`tasksApi.cleanup`
- `web/frontend/src/views/TaskList.vue`：清理按钮 + 全选修复