### PR TITLE
feat(site): 新增 PTzone 站点适配并修复计数千分位解析

### DIFF
--- a/docs/sites.md
+++ b/docs/sites.md
@@ -1,8 +1,8 @@
 ## 支持站点
 
-当前已适配 **64** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
+当前已适配 **65** 个站点，覆盖 NexusPHP、mTorrent、Gazelle、HDDolby、Rousi 等主流 PT 架构。
 
-### NexusPHP 系列（60）
+### NexusPHP 系列（61）
 
 | 站点                  | 认证方式 | 支持功能                      | 适配情况 | 备注                                                                         |
 | --------------------- | -------- | ----------------------------- | -------- | ---------------------------------------------------------------------------- |
@@ -66,6 +66,7 @@
 | **财神**              | Cookie   | RSS、搜索、用户信息           | ✅       | cspt.top（种子列表为 div 布局，issue #499）                                  |
 | **HHCLUB**            | Cookie   | RSS、搜索、用户信息           | ✅       | hhanclub.net（列表与详情页均为 div 布局，优惠标签为自定义 span，issue #492） |
 | **U2分享園@動漫花園** | Cookie   | RSS、搜索、用户信息           | ✅       | U2 / 動漫花園（u2.dmhy.org，详情页无隐藏标题域，标题走文本解析，issue #497） |
+| **PTzone**            | Cookie   | RSS、搜索、用户信息           | ✅       | ptzone.xyz（繁体界面，tg群内提交）                                           |
 
 ### 其他架构（4）
 

--- a/site/v2/definitions/ptzone.go
+++ b/site/v2/definitions/ptzone.go
@@ -1,0 +1,267 @@
+package definitions
+
+import (
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+// PtzoneDefinition 描述 PTzone（ptzone.xyz）站点。
+//
+// 站点为标准 NexusPHP 架构，但整站使用**繁体中文**界面，所有标签与常见简体站点不同，
+// 选择器需要专门适配（与 discfan 高度一致）：
+//  1. 用户详情页的传输行标签是「傳送」，既不是简体「传输」也不是繁体「傳輸」；
+//     行内为嵌套 table 的合并单元格（分享率/上傳量/下載量/實際上傳量/實際下載量），需以 html + regex 拆分。
+//  2. 详情页体积行标签是「基本資訊」（非「基本信息」），且 ParseSizeMB 取的是标签单元格的
+//     下一个兄弟节点，因此 SizeSelector 必须指向标签列本身。
+//  3. 搜索页副标题是 <br /> 之后的裸文本节点，前面可能还有若干语言/来源标签 <span>
+//     （官方/国语/中字 等），无法用普通 CSS 选择器命中，需要走 SubtitleSelector。
+//  4. 种子名称单元格里存在一个审核状态图标 <span title="通過">（另有 title="未審"），
+//     它同样是 span[title]，因此促销结束时间的选择器必须收紧到 <font color> 之内，
+//     否则会把审核状态当成时间去解析。
+var PtzoneDefinition = &v2.SiteDefinition{
+	ID:             "ptzone",
+	Name:           "PTzone",
+	Description:    "综合性 PT 站点（繁体中文界面）",
+	Schema:         v2.SchemaNexusPHP,
+	URLs:           []string{"https://ptzone.xyz/"},
+	FaviconURL:     "https://ptzone.xyz/favicon.ico",
+	AuthMethod:     v2.AuthMethodCookie,
+	TimezoneOffset: "+0800",
+	RateLimit:      0.5,
+	RateBurst:      2,
+	UserInfo: &v2.UserInfoConfig{
+		PickLast:     []string{"id"},
+		RequestDelay: 500,
+		Process: []v2.UserInfoProcess{
+			{
+				RequestConfig: v2.RequestConfig{URL: "/index.php", ResponseType: "document"},
+				Fields:        []string{"id", "name", "seeding", "leeching", "bonus"},
+			},
+			{
+				RequestConfig: v2.RequestConfig{URL: "/userdetails.php", ResponseType: "document"},
+				Assertion:     map[string]string{"id": "params.id"},
+				Fields: []string{
+					"uploaded", "downloaded", "ratio",
+					"trueUploaded", "trueDownloaded",
+					"levelName", "joinTime", "lastAccessAt",
+				},
+			},
+		},
+		Selectors: map[string]v2.FieldSelector{
+			// #info_block 必须优先：用户详情页正文里还有「邀請」等其他 userdetails.php 链接
+			"id": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php'][class*='Name']",
+					"a[href*='userdetails.php']",
+				},
+				Attr:    "href",
+				Filters: []v2.Filter{{Name: "querystring", Args: []any{"id"}}},
+			},
+			"name": {
+				Selector: []string{
+					"#info_block a[href*='userdetails.php']",
+					"a[href*='userdetails.php'][class*='Name']",
+				},
+			},
+			// 做种/下载数：数字是 arrowup/arrowdown 图标之后的裸文本节点。
+			// 正则用 [^>]*> 而非 [^>]*/>，兼容渲染器是否输出自闭合斜杠
+			"seeding": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowup"[^>]*>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"leeching": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`class="arrowdown"[^>]*>\s*(\d+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			// 魔力值：<font class='color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 850,026.1
+			"bonus": {
+				Selector: []string{"#info_block"},
+				Attr:     "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`魔力值\s*</font>\s*\[[^\]]*\]\s*[:：]\s*([\d.,]+)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			// 传输行标签为繁体「傳送」；同时保留「傳輸」/「传输」兜底以适配站点改版。
+			// 注意：「邀請」行的链接带 title="傳送邀請"，但 :contains 只匹配文本节点，
+			// 该行 td.rowhead 的文本是「邀請」，不会误命中
+			"uploaded": {
+				Selector: []string{
+					"td.rowhead:contains('傳送') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('传输') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>上傳量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"downloaded": {
+				Selector: []string{
+					"td.rowhead:contains('傳送') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('传输') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>下載量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			// <strong>分享率</strong> 不会误命中 <strong>實際分享率</strong>（前缀不同）；
+			// 数值被 <font color="">包裹，需可选跳过该标签
+			"ratio": {
+				Selector: []string{
+					"td.rowhead:contains('傳送') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('传输') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>分享率</strong>[：:\s]*(?:<font[^>]*>)?([\d.,]+|∞|Inf)`}},
+					{Name: "parseNumber"},
+				},
+			},
+			"trueUploaded": {
+				Selector: []string{
+					"td.rowhead:contains('傳送') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('传输') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>實際上傳量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"trueDownloaded": {
+				Selector: []string{
+					"td.rowhead:contains('傳送') + td",
+					"td.rowhead:contains('傳輸') + td",
+					"td.rowhead:contains('传输') + td",
+				},
+				Attr: "html",
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`<strong>實際下載量</strong>[：:\s]*([\d.,]+\s*[KMGTP]?i?B)`}},
+					{Name: "parseSize"},
+				},
+			},
+			"levelName": {
+				Selector: []string{
+					"td.rowhead:contains('等級') + td img",
+					"td.rowhead:contains('等级') + td img",
+				},
+				Attr: "title",
+			},
+			"joinTime": {
+				Selector: []string{
+					"td.rowhead:contains('加入日期') + td",
+					"td.rowhead:contains('Join') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+			// 保号探测只读取 UserInfo.LastAccess，缺失会导致线上探测解析失败。
+			// 站点同时存在「最近動向」与「最近動向(地點)」两行（后者本例为空），
+			// 取值走 First()，文档顺序上时间行在前，因此不会误取地点行
+			"lastAccessAt": {
+				Selector: []string{
+					"td.rowhead:contains('最近動向') + td",
+					"td.rowhead:contains('最近动向') + td",
+					"td.rowhead:contains('最後活動') + td",
+					"td.rowhead:contains('上次訪問') + td",
+					"td.rowhead:contains('Last access') + td",
+				},
+				Filters: []v2.Filter{
+					{Name: "regex", Args: []any{`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})`}},
+					{Name: "parseTime"},
+				},
+			},
+		},
+	},
+	Selectors: &v2.SiteSelectors{
+		TableRows: "table.torrents > tbody > tr:has(table.torrentname), table.torrents > tr:has(table.torrentname)",
+		Title:     "table.torrentname a[href*='details.php']",
+		TitleLink: "table.torrentname a[href*='details.php']",
+		// 副标题是 <br /> 之后的裸文本节点，其前可能存在若干标签 <span>（官方/国语/中字 等），
+		// 因此正则先跳过连续的完整 <span>...</span> 块，再截取剩余纯文本。
+		// 选择器限定在含 details.php 链接的 td.embedded（名称单元格），
+		// 避免命中海报单元格或右侧的下载单元格（后者也含 <br />）
+		SubtitleSelector: &v2.FieldSelector{
+			Selector: []string{
+				"table.torrentname td.embedded:has(a[href*='details.php'])",
+				"table.torrentname td.embedded",
+			},
+			Attr: "html",
+			Filters: []v2.Filter{
+				{Name: "regex", Args: []any{`(?s)<br\s*/?>(?:\s*<span[^>]*>[^<]*</span>)*\s*([^<]+)`}},
+				// 走 html 取值会保留实体编码，需手动还原；&amp; 必须最后替换以避免二次解码
+				{Name: "replace", Args: []any{"&#39;", "'"}},
+				{Name: "replace", Args: []any{"&quot;", `"`}},
+				{Name: "replace", Args: []any{"&lt;", "<"}},
+				{Name: "replace", Args: []any{"&gt;", ">"}},
+				{Name: "replace", Args: []any{"&nbsp;", " "}},
+				{Name: "replace", Args: []any{"&amp;", "&"}},
+				{Name: "trim"},
+			},
+		},
+		// 列序取自 colhead：類型 / 標題 / 評論數 / 存活時間 / 大小 / 種子數 / 下載數 / 完成數 / 發佈者
+		Size:     "td.rowfollow:nth-child(5)",
+		Seeders:  "td.rowfollow:nth-child(6)",
+		Leechers: "td.rowfollow:nth-child(7)",
+		Snatched: "td.rowfollow:nth-child(8)",
+		// 实际抓取到 pro_free / pro_free2up，其余为 NexusPHP 通用促销图标类名。
+		// 不设置 DiscountMapping，交由驱动内置规则判定，
+		// 避免自定义 map 迭代顺序导致 pro_free2up 被 "free" 抢先命中
+		DiscountIcon: "img.pro_free, img.pro_free2up, img.pro_2up, img.pro_50pctdown, img.pro_50pctdown2up, img.pro_30pctdown",
+		// 限时促销在名称单元格里真实渲染为 <font color='#0000FF'>剩餘時間：<span title="...">，
+		// 必须限定在 font[color] 之内：同一单元格还有审核状态 <span title="通過">，
+		// 第 4 列也有发布时间 span[title]，不收紧会取错值。
+		// 永久促销既无该 span 也无 onmouseover，结束时间保持为零值；
+		// 若站点某些页面只渲染 tooltip，驱动会回退解析促销图标的 onmouseover 提示
+		DiscountEndTime:    "table.torrentname font[color] span[title]",
+		Category:           "td.rowfollow:nth-child(1) img[alt]",
+		UploadTime:         "td.rowfollow:nth-child(4) span[title]",
+		DetailDownloadLink: "td.rowhead:contains('下載') + td a[href*='download.php'], td.rowhead:contains('下载') + td a[href*='download.php']",
+		DetailSubtitle:     "td.rowhead:contains('副標題') + td, td.rowhead:contains('副标题') + td",
+	},
+	DetailParser: &v2.DetailParserConfig{
+		TimeLayout: "2006-01-02 15:04:05",
+		DiscountMapping: map[string]v2.DiscountLevel{
+			"free":          v2.DiscountFree,
+			"twoup":         v2.Discount2xUp,
+			"twoupfree":     v2.Discount2xFree,
+			"thirtypercent": v2.DiscountPercent30,
+			"halfdown":      v2.DiscountPercent50,
+			"twouphalfdown": v2.Discount2x50,
+		},
+		HRKeywords: []string{"hitandrun", "hit_run.gif", "Hit and Run", "Hit & Run"},
+		// 详情页存在隐藏域（字幕上传表单内），直接取 value，无需回退 h1 文本
+		TitleSelector: "input[name='torrent_name']",
+		IDSelector:    "input[name='detail_torrent_id']",
+		// h1#top 内的促销标记形如 <b>[<font class='twoupfree' >2X免費</font>]</b>，
+		// 也可能同时出现非促销的 <font class='hot'>，ParseDiscount 会跳过未映射的类名
+		DiscountSelector: "h1#top font[class]",
+		// 同样必须限定在 font[color] 内：h1#top 末尾还有审核状态 <span title="通過">
+		EndTimeSelector: "h1#top font[color] span[title]",
+		// ParseSizeMB 取该元素的下一个兄弟节点文本，所以必须指向标签列而非内容列；
+		// 站点使用繁体「基本資訊」+ 全角冒号「大小：」，单位组放宽到二进制单位以便站点改版后仍可解析
+		SizeSelector: "td.rowhead:contains('基本資訊'), td.rowhead:contains('基本信息')",
+		SizeRegex:    `大小[：:]\s*([\d.]+)\s*([KMGTP]i?B)`,
+	},
+}
+
+func init() {
+	v2.RegisterSiteDefinition(PtzoneDefinition)
+}

--- a/site/v2/definitions/ptzone_fixture_test.go
+++ b/site/v2/definitions/ptzone_fixture_test.go
@@ -1,0 +1,328 @@
+package definitions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/sunerpy/pt-tools/site/v2"
+)
+
+func init() {
+	RegisterFixtureSuite(FixtureSuite{
+		SiteID:   "ptzone",
+		Search:   testPtzoneSearch,
+		Detail:   testPtzoneDetail,
+		UserInfo: testPtzoneUserInfo,
+	})
+}
+
+// --- Fixtures ---
+//
+// 结构复刻真实采集页面（繁体界面、9 列种子表、名称单元格内的审核状态 <span title="通過">、
+// 傳送 合并单元格、基本資訊 体积行），用户名/用户 ID/种子 ID/图片地址均为虚构值。
+
+// 搜索页：3 行
+//  1. 2X 免费且为**永久**促销（图标只有 title，无 onmouseover、无「剩餘時間」），完成数带千分位；
+//  2. 限时免费（图标带 onmouseover + 可见的 <font color> 剩餘時間），副标题前有语言标签 <span>；
+//  3. 无促销（仅 [熱門] 标记），用于验证审核状态 <span title="通過"> 不会被当成促销结束时间。
+const ptzoneSearchFixture = `<html><body>
+<table class="torrents" cellspacing="0" cellpadding="5" width="100%">
+<tr>
+<td class="colhead" style="padding: 0px">類型</td>
+<td class="colhead"><a href="?sort=1&amp;type=asc">標題</a></td>
+<td class="colhead"><a href="?sort=3&amp;type=desc"><img class="comments" src="pic/trans.gif" alt="comments" title="評論數" /></a></td>
+<td class="colhead"><a href="?sort=4&amp;type=desc"><img class="time" src="pic/trans.gif" alt="time" title="存活時間" /></a></td>
+<td class="colhead"><a href="?sort=5&amp;type=desc"><img class="size" src="pic/trans.gif" alt="size" title="大小" /></a></td>
+<td class="colhead"><a href="?sort=7&amp;type=desc"><img class="seeders" src="pic/trans.gif" alt="seeders" title="種子數" /></a></td>
+<td class="colhead"><a href="?sort=8&amp;type=desc"><img class="leechers" src="pic/trans.gif" alt="leechers" title="下載數" /></a></td>
+<td class="colhead"><a href="?sort=6&amp;type=desc"><img class="snatched" src="pic/trans.gif" alt="snatched" title="完成數" /></a></td>
+<td class="colhead"><a href="?sort=9&amp;type=desc">發佈者</a></td>
+</tr>
+<tr style="background-color: #89c9e6">
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=408"><img class="c_others" src="pic/cattrans.gif" alt="Others(其它）" title="Others(其它）" /></a></td>
+<td class="rowfollow" width="100%" align="left" style='padding: 0px'><table class="torrentname" width="100%"><tr style="background-color: #89c9e6"><td class="embedded" style="text-align: center;width: 46px;height: 46px"><img src="pic/misc/spinner.svg" data-src="https://img.example.invalid/cover-a.jpg" class="nexus-lazy-load" /></td><td class="embedded" style='padding-left: 5px'><img class="sticky" src="pic/trans.gif" alt="Sticky" title="一級置頂" />&nbsp;<a title="Sample.Guide.PT.V1.0.PDF"  href="details.php?id=20001&amp;hit=1"><b>Sample.Guide.PT.V1.0.PDF</b></a> <b>[<font class='hot'>熱門</font>]</b> <img class="pro_free2up" src="pic/trans.gif" alt="2X Free" title="2X免費" /><span style="margin-left: 6px" title="通過"><svg t="1655145688503" class="icon" viewBox="0 0 1413 1024" version="1.1" width="16" height="16"><path d="M1381 107L1274 0 465 809 142 487 35 594l430 430z" fill="#1afa29"></path></svg></span><br />範例入門教材 保證學以致用 【新手必看】</td><td class="embedded" style="text-align: right; width: 40px;padding: 4px"><div><img src="pic/imdb2.png" alt="imdb" title="imdb" /><span>N/A</span></div></td><td width="20" class="embedded" style="text-align: right;padding-right: 5px" valign="middle"><a href="download.php?id=20001"><img class="download" src="pic/trans.gif" alt="download" title="下載本種" /></a><br /><a id="bookmark0"  href="javascript: bookmark(20001,0);" ><img class="delbookmark" src="pic/trans.gif" alt="Unbookmarked" title="收藏" /></a></td>
+</tr></table></td>
+<td class="rowfollow"><b><a href="details.php?id=20001&amp;hit=1&amp;cmtpage=1#startcomments" >60</a></b></td>
+<td class="rowfollow nowrap"><span title="2024-11-12 08:09:10">1年<br />8月</span></td>
+<td class="rowfollow">2.26<br />MB</td>
+<td class="rowfollow" align="center"><b><a href="details.php?id=20001&amp;hit=1&amp;dllist=1#seeders">12</a></b></td>
+<td class="rowfollow"><b><a href="details.php?id=20001&amp;hit=1&amp;dllist=1#leechers">1</a></b></td>
+<td class="rowfollow"><a href="viewsnatches.php?id=20001"><b>7,170</b></a></td>
+<td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr style="background-color: #aadbf3">
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=405"><img class="c_anime" src="pic/cattrans.gif" alt="Animations(动漫)" title="Animations(动漫)" /></a></td>
+<td class="rowfollow" width="100%" align="left" style='padding: 0px'><table class="torrentname" width="100%"><tr style="background-color: #aadbf3"><td class="embedded" style="text-align: center;width: 46px;height: 46px"><img src="pic/misc/spinner.svg" data-src="https://img.example.invalid/cover-b.jpg" class="nexus-lazy-load" /></td><td class="embedded" style='padding-left: 5px'><a title="Sample.Anime.2025.2160p.WEB-DL.H.265.DDP5.1-DEMO"  href="details.php?id=20002&amp;hit=1"><b>Sample.Anime.2025.2160p.WEB-DL.H.265.DDP5.1-DEMO</b></a> <img class="pro_free" src="pic/trans.gif" alt="Free"  onmouseover="domTT_activate(this, event, 'content', '&lt;b&gt;&lt;font class=&quot;free&quot;&gt;免費&lt;/font&gt;&lt;/b&gt;剩餘時間：&lt;b&gt;&lt;span title=&quot;2026-08-06 12:34:56&quot;&gt;2天21時&lt;/span&gt;&lt;/b&gt;', 'trail', false, 'delay',500);" /> <font color='#0000FF'>剩餘時間：<span title="2026-08-06 12:34:56">2天21時</span></font><span style="margin-left: 6px" title="未審"><svg t="1655184824967" class="icon" viewBox="0 0 1024 1024" version="1.1" width="16" height="16"><path d="M512 64l448 832H64z" fill="#f4ea2a"></path></svg></span><br /><span style="background-color:#0000ff;color:#ffffff;font-size:12px;padding:1px 2px" title="">官方</span><span style="background-color:#6a3906;color:#ffffff;font-size:12px;padding:1px 2px" title="">国语</span><span style="background-color:#006400;color:#ffffff;font-size:12px;padding:1px 2px" title="">中字</span>範例動畫 / 示例动画 | 类型：动画 / 奇幻 | 演员：甲乙丙 / 丁戊己</td><td width="20" class="embedded" style="text-align: right;padding-right: 5px" valign="middle"><a href="download.php?id=20002"><img class="download" src="pic/trans.gif" alt="download" title="下載本種" /></a><br /><a id="bookmark1"  href="javascript: bookmark(20002,1);" ><img class="delbookmark" src="pic/trans.gif" alt="Unbookmarked" title="收藏" /></a></td>
+</tr></table></td>
+<td class="rowfollow"><b><a href="details.php?id=20002&amp;hit=1&amp;cmtpage=1#startcomments" >3</a></b></td>
+<td class="rowfollow nowrap"><span title="2026-07-30 10:00:00">4天<br />6時</span></td>
+<td class="rowfollow">12.34<br />GB</td>
+<td class="rowfollow" align="center"><b><a href="details.php?id=20002&amp;hit=1&amp;dllist=1#seeders">34</a></b></td>
+<td class="rowfollow"><b><a href="details.php?id=20002&amp;hit=1&amp;dllist=1#leechers"><font color="#550000">2</font></a></b></td>
+<td class="rowfollow"><a href="viewsnatches.php?id=20002"><b>56</b></a></td>
+<td class="rowfollow"><i>匿名</i></td>
+</tr>
+<tr style="background-color: #aadbf3">
+<td class="rowfollow nowrap" valign="middle" style='padding: 0px'><a href="?cat=401"><img class="c_movies" src="pic/cattrans.gif" alt="Movies(电影)" title="Movies(电影)" /></a></td>
+<td class="rowfollow" width="100%" align="left" style='padding: 0px'><table class="torrentname" width="100%"><tr style="background-color: #aadbf3"><td class="embedded" style="text-align: center;width: 46px;height: 46px"><img src="pic/misc/spinner.svg" data-src="" class="nexus-lazy-load" /></td><td class="embedded" style='padding-left: 5px'><a title="Sample.Movie.1979.1080p.Blu-ray.AVC.DTS-HD.MA.2.0-DEMO"  href="details.php?id=20003&amp;hit=1"><b>Sample.Movie.1979.1080p.Blu-ray.AVC.DTS-HD.MA.2.0-DEMO</b></a> <b>[<font class='hot'>熱門</font>]</b><span style="margin-left: 6px" title="通過"><svg t="1655145688503" class="icon" viewBox="0 0 1413 1024" version="1.1" width="16" height="16"><path d="M1381 107L1274 0 465 809 142 487 35 594l430 430z" fill="#1afa29"></path></svg></span><br />範例電影</td><td width="20" class="embedded" style="text-align: right;padding-right: 5px" valign="middle"><a href="download.php?id=20003"><img class="download" src="pic/trans.gif" alt="download" title="下載本種" /></a><br /><a id="bookmark2"  href="javascript: bookmark(20003,2);" ><img class="delbookmark" src="pic/trans.gif" alt="Unbookmarked" title="收藏" /></a></td>
+</tr></table></td>
+<td class="rowfollow"><b><a href="details.php?id=20003&amp;hit=1&amp;cmtpage=1#startcomments" >1</a></b></td>
+<td class="rowfollow nowrap"><span title="2026-07-31 11:22:33">3天<br />5時</span></td>
+<td class="rowfollow">700.00<br />MB</td>
+<td class="rowfollow" align="center"><b><a href="details.php?id=20003&amp;hit=1&amp;dllist=1#seeders">5</a></b></td>
+<td class="rowfollow">0</td>
+<td class="rowfollow"><a href="viewsnatches.php?id=20003"><b>9</b></a></td>
+<td class="rowfollow"><i>匿名</i></td>
+</tr>
+</table>
+</body></html>`
+
+// 详情页（真实采集页面对应形态）：h1#top 内为标题文本 + [2X免費] 促销标记 + 审核状态图标；
+// 标题/种子 ID 取自字幕上传表单内的隐藏域；体积行标签为繁体「基本資訊」且单位为 MB。
+const ptzoneDetailFixture = `<html><body>
+<h1 align="center" id="top">Sample.Guide.PT.V1.0.PDF&nbsp;&nbsp;&nbsp; <b>[<font class='twoupfree' >2X免費</font>]</b><span style="margin-left: 6px" title="通過"><svg t="1655145688503" class="icon" viewBox="0 0 1413 1024" version="1.1" width="16" height="16"><path d="M1381 107L1274 0 465 809 142 487 35 594l430 430z" fill="#1afa29"></path></svg></span></h1>
+<table width="97%" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead" width="13%">下載</td><td class="rowfollow" width="87%" align="left"><a class="index" href="download.php?id=20001">[PTzone]Sample.Guide.PT.V1.0.PDF.torrent</a>&nbsp;&nbsp;&nbsp;由&nbsp;<i>匿名</i>發布於<span title="2024-11-12 08:09:10">1年8月前</span></td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">副標題</td><td class="rowfollow" valign="top" align="left">範例入門教材 保證學以致用 【新手必看】</td></tr>
+<tr><td class="rowhead nowrap" valign="top" align="right">基本資訊</td><td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>2.26 MB&nbsp;&nbsp;&nbsp;<b>類別:</b>&nbsp;Others(其它）&nbsp;&nbsp;&nbsp;<b>媒介: </b>CD&nbsp;&nbsp;&nbsp;<b>編碼: </b>Other</td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Sample.Guide.PT.V1.0.PDF" /><input type="hidden" name="detail_torrent_id" value="20001" /><input type="hidden" name="in_detail" value="in_detail" /><input type="submit" value="上傳字幕" /></form></td></tr>
+</table>
+</body></html>`
+
+// 详情页（限时免费 + H&R 标记 + GB 体积）：验证 EndTimeSelector、HRKeywords，
+// 以及 [熱門] 这类未映射的 font class 会被 ParseDiscount 跳过。
+const ptzoneDetailFreeTimedFixture = `<html><body>
+<h1 align="center" id="top">Sample.Anime.2025.2160p.WEB-DL.H.265.DDP5.1-DEMO&nbsp;&nbsp;&nbsp; <b>[<font class='hot'>熱門</font>]</b> <b>[<font class='free' >免費</font>]</b> <font color='#0000FF'>剩餘時間：<span title="2026-08-06 12:34:56">2天21時</span></font><span style="margin-left: 6px" title="通過"><svg viewBox="0 0 1413 1024" width="16" height="16"><path d="M1381 107L1274 0 465 809z" fill="#1afa29"></path></svg></span></h1>
+<table width="97%" cellspacing="0" cellpadding="5">
+<tr><td class="rowhead nowrap" valign="top" align="right">基本資訊</td><td class="rowfollow" valign="top" align="left"><b><b>大小：</b></b>8.50 GB&nbsp;&nbsp;&nbsp;<b>類別:</b>&nbsp;Animations(动漫)</td></tr>
+<tr><td class="rowhead" valign="top">字幕</td><td class="rowfollow" align="left" valign="top"><form method="post" action="subtitles.php"><input type="hidden" name="torrent_name" value="Sample.Anime.2025.2160p.WEB-DL.H.265.DDP5.1-DEMO" /><input type="hidden" name="detail_torrent_id" value="20002" /></form></td></tr>
+</table>
+<img src="pic/hit_run.gif" alt="Hit and Run" />
+</body></html>`
+
+// index.php 顶部 #info_block（每页共用，userdetails.php 同样带此块）。
+const ptzoneIndexFixture = `<html><body>
+<table id="info_block" cellpadding="4" cellspacing="0" border="0" width="100%"><tr>
+	<td><table width="100%" cellspacing="0" cellpadding="0" border="0"><tr>
+		<td class="bottom" align="left">
+			<span class="medium">
+				歡迎回來, <span class="nowrap"><a  href="https://ptzone.xyz/userdetails.php?id=99001" class='PowerUser_Name'><b>ptuser01</b></a></span>                [<a href="logout.php">退出</a>]
+				[<a href="usercp.php">&nbsp;控制面板&nbsp;</a>]
+				<font class = 'color_bonus'>魔力值 </font>[<a href="mybonus.php">使用</a>]: 123,456.7                 <a href="attendance.php" class="faqlink">[簽到得魔力]</a>                <a href="medal.php">[勛章]</a>
+				<font class = 'color_invite'>邀請 </font>[<a href="invite.php?id=99001">發送</a>]: 11(0)                                <br />
+				<font class="color_ratio">分享率：</font> 2.500                <font class='color_uploaded'>上傳量：</font> 300.00 GB                <font class='color_downloaded'> 下載量：</font> 120.00 GB                <font class='color_active'>當前活動：</font> <img class="arrowup" alt="Torrents seeding" title="當前做種" src="pic/trans.gif" />42  <img class="arrowdown" alt="Torrents leeching" title="當前下載" src="pic/trans.gif" />3&nbsp;&nbsp;
+				<font class='color_connectable'>可連接：</font><b><font color="green">是</font></b> <font class='color_slots'>連接數：</font>無限制
+			</span>
+		</td>
+	</tr></table></td>
+</tr></table>
+</body></html>`
+
+// userdetails.php 正文：传输行标签是繁体「傳送」，且为嵌套 table 的合并单元格；
+// 「最近動向」与「最近動向(地點)」两行同时存在（后者真实站点为空），取 First() 必须命中时间行。
+const ptzoneUserdetailsFixture = `<html><body>
+<h1 style='margin:0px'><span class="nowrap"><b>ptuser01</b></span></h1>
+<table width="100%" border="1" cellspacing="0" cellpadding="5">
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">用戶ID/UID</td><td width="99%" class="rowfollow" valign="top" align="left">99001</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">邀請</td><td width="99%" class="rowfollow" valign="top" align="left"><a href="invite.php?id=99001" title="傳送邀請">11(0)</a></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">加入日期</td><td width="99%" class="rowfollow" valign="top" align="left">2024-03-04 05:06:07 (<span title="2024-03-04 05:06:07">2年5月前</span>, 125.2周)</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">最近動向</td><td width="99%" class="rowfollow" valign="top" align="left">2026-07-30 09:08:07 (<span title="2026-07-30 09:08:07">&lt; 1分前</span>)</td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">最近動向(地點)</td><td width="99%" class="rowfollow" valign="top" align="left"></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">傳送</td><td width="99%" class="rowfollow" valign="top" align="left"><table border="0" cellspacing="0" cellpadding="0"><tr><td class="embedded"><strong>分享率</strong>:  <font color="">2.500</font>（<strong>實際分享率</strong>：0.048）</td><td class="embedded">&nbsp;&nbsp;<img src="pic/smilies/3.gif" alt="" /></td></tr><tr><td class="embedded"><strong>上傳量</strong>:  300.00 GB</td><td class="embedded">&nbsp;&nbsp;<strong>下載量</strong>:  120.00 GB</td></tr><tr><td class="embedded"><strong>實際上傳量</strong>:  50.00 GB</td><td class="embedded">&nbsp;&nbsp;<strong>實際下載量</strong>:  1.500 TB</td><td class="embedded text-muted">&nbsp;&nbsp;實際上傳/下載量 (僅用於記錄, 不參與分享率計算)</td></tr></table></td></tr>
+<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">等級</td><td width="99%" class="rowfollow" valign="top" align="left"><img alt="Power User" title="Power User" src="pic/power.gif" /> </td></tr>
+</table>
+</body></html>`
+
+// --- Helpers ---
+
+func getPtzoneDef(t *testing.T) *v2.SiteDefinition {
+	t.Helper()
+	def, ok := v2.GetDefinitionRegistry().Get("ptzone")
+	require.True(t, ok, "ptzone definition not found")
+	return def
+}
+
+// --- Suite: Search ---
+
+func testPtzoneSearch(t *testing.T) {
+	def := getPtzoneDef(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(ptzoneSearchFixture))
+	}))
+	defer server.Close()
+
+	driver := v2.NewNexusPHPDriver(v2.NexusPHPDriverConfig{
+		BaseURL:   server.URL,
+		Cookie:    "test_cookie=1",
+		Selectors: def.Selectors,
+	})
+	driver.SetSiteDefinition(def)
+
+	res, err := driver.Execute(context.Background(), v2.NexusPHPRequest{Path: "/torrents.php", Method: "GET"})
+	require.NoError(t, err)
+
+	items, err := driver.ParseSearch(res)
+	require.NoError(t, err)
+	require.Len(t, items, 3, "should parse 3 torrent rows (colhead row excluded)")
+
+	permanent2xFree := items[0]
+	assert.Equal(t, "20001", permanent2xFree.ID)
+	assert.Equal(t, "Sample.Guide.PT.V1.0.PDF", permanent2xFree.Title)
+	assert.Equal(t, "範例入門教材 保證學以致用 【新手必看】", permanent2xFree.Subtitle)
+	assert.Equal(t, v2.Discount2xFree, permanent2xFree.DiscountLevel, "pro_free2up 必须先于 free 命中")
+	// 永久促销：图标无 onmouseover，单元格内也没有 <font color> 剩餘時間；
+	// 同时验证审核状态 <span title="通過"> 不会被误当成结束时间
+	assert.True(t, permanent2xFree.DiscountEndTime.IsZero(), "permanent promotion has no end time")
+	assert.Equal(t, int64(2369781), permanent2xFree.SizeBytes) // 2.26 MB（size 单元格被 <br /> 分成两行）
+	assert.Equal(t, 12, permanent2xFree.Seeders)
+	assert.Equal(t, 1, permanent2xFree.Leechers)
+	// 完成数为带千分位的「7,170」：共享驱动先经 extractNumber 去除分隔符再转换，
+	// 因此能正确解析。真实采集页面 50 行中有 12 行是这种写法，
+	// 此处保留该样本作为共享层千分位解析的回归守卫
+	assert.Equal(t, 7170, permanent2xFree.Snatched)
+	assert.Equal(t, "Others(其它）", permanent2xFree.Category)
+	assert.Equal(t, int64(1731398950), permanent2xFree.UploadedAt)
+
+	timedFree := items[1]
+	assert.Equal(t, "20002", timedFree.ID)
+	assert.Equal(t, v2.DiscountFree, timedFree.DiscountLevel)
+	// 副标题前有三个语言/来源标签 <span>，需被正则跳过
+	assert.Equal(t, "範例動畫 / 示例动画 | 类型：动画 / 奇幻 | 演员：甲乙丙 / 丁戊己", timedFree.Subtitle)
+	require.False(t, timedFree.DiscountEndTime.IsZero(), "timed promotion should expose an end time")
+	assert.Equal(t, "2026-08-06 12:34:56", timedFree.DiscountEndTime.Format("2006-01-02 15:04:05"))
+	assert.Equal(t, int64(13249974108), timedFree.SizeBytes) // 12.34 GB
+	assert.Equal(t, 34, timedFree.Seeders)
+	assert.Equal(t, 2, timedFree.Leechers)
+	assert.Equal(t, 56, timedFree.Snatched)
+
+	plain := items[2]
+	assert.Equal(t, "20003", plain.ID)
+	assert.Equal(t, v2.DiscountNone, plain.DiscountLevel, "[熱門] 不是促销标记")
+	assert.Equal(t, "範例電影", plain.Subtitle)
+	assert.True(t, plain.DiscountEndTime.IsZero(), "審核狀態 span[title] 不能被当成促销结束时间")
+	assert.Equal(t, 5, plain.Seeders)
+	assert.Equal(t, 0, plain.Leechers)
+	assert.Equal(t, 9, plain.Snatched)
+}
+
+// --- Suite: Detail ---
+
+func testPtzoneDetail(t *testing.T) {
+	def := getPtzoneDef(t)
+
+	t.Run("TwoUpFree", func(t *testing.T) {
+		doc := FixtureDoc(t, "ptzone_detail", ptzoneDetailFixture)
+		parser := v2.NewNexusPHPParserFromDefinition(def)
+		info := parser.ParseAll(doc.Selection)
+
+		assert.Equal(t, "20001", info.TorrentID)
+		assert.Equal(t, "Sample.Guide.PT.V1.0.PDF", info.Title)
+		// 促销标记是 <font class='twoupfree' >（单引号 + 尾随空格），不是普通 free
+		assert.Equal(t, v2.Discount2xFree, info.DiscountLevel)
+		// 该页无「剩餘時間」，且 h1#top 末尾的 <span title="通過"> 不能被当成结束时间
+		assert.True(t, info.DiscountEnd.IsZero(), "審核狀態 span[title] 不能被解析成结束时间")
+		// 繁体「基本資訊」标签列 + 全角冒号「大小：」+ MB 为 ParseSizeMB 的基准单位
+		assert.InDelta(t, 2.26, info.SizeMB, 0.001)
+		assert.False(t, info.HasHR)
+	})
+
+	t.Run("TimedFreeWithHR", func(t *testing.T) {
+		doc := FixtureDoc(t, "ptzone_detail_free_timed", ptzoneDetailFreeTimedFixture)
+		parser := v2.NewNexusPHPParserFromDefinition(def)
+		info := parser.ParseAll(doc.Selection)
+
+		assert.Equal(t, "20002", info.TorrentID)
+		assert.Equal(t, "Sample.Anime.2025.2160p.WEB-DL.H.265.DDP5.1-DEMO", info.Title)
+		assert.Equal(t, v2.DiscountFree, info.DiscountLevel, "font.hot 未映射，应继续查找 font.free")
+		require.False(t, info.DiscountEnd.IsZero(), "discount end time should be parsed")
+		assert.Equal(t, "2026-08-06 12:34:56", info.DiscountEnd.Format("2006-01-02 15:04:05"))
+		assert.InDelta(t, 8704.0, info.SizeMB, 0.1) // 8.50 GB → 8.50*1024 MB
+		assert.True(t, info.HasHR, "should detect HR from hit_run.gif")
+	})
+}
+
+// --- Suite: UserInfo ---
+
+func testPtzoneUserInfo(t *testing.T) {
+	def := getPtzoneDef(t)
+	driver := newTestNexusPHPDriver(def)
+
+	t.Run("IndexPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "ptzone_index", ptzoneIndexFixture)
+		fields := map[string]string{
+			"id":       "99001",
+			"name":     "ptuser01",
+			"seeding":  "42",
+			"leeching": "3",
+			"bonus":    "123456.7",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+	})
+
+	t.Run("UserdetailsPage", func(t *testing.T) {
+		doc := FixtureDoc(t, "ptzone_userdetails", ptzoneUserdetailsFixture)
+		fields := map[string]string{
+			"uploaded":       "322122547200",
+			"downloaded":     "128849018880",
+			"ratio":          "2.5",
+			"trueUploaded":   "53687091200",
+			"trueDownloaded": "1649267441664",
+			"levelName":      "Power User",
+			"joinTime":       "1709499967",
+			"lastAccessAt":   "1785373687",
+		}
+		for field, expected := range fields {
+			t.Run(field, func(t *testing.T) {
+				sel, ok := def.UserInfo.Selectors[field]
+				require.True(t, ok, "selector %q not found", field)
+				assert.Equal(t, expected, driver.ExtractFieldValuePublic(doc, sel))
+			})
+		}
+	})
+}
+
+// --- Standalone Tests ---
+
+// 保号探测只读取 UserInfo.LastAccess，缺失或解析失败会导致线上探测报错。
+func TestPtzone_UserInfo_LastAccessParsed(t *testing.T) {
+	def := getPtzoneDef(t)
+	driver := newTestNexusPHPDriver(def)
+	doc := FixtureDoc(t, "ptzone_userdetails", ptzoneUserdetailsFixture)
+
+	sel, ok := def.UserInfo.Selectors["lastAccessAt"]
+	require.True(t, ok, "lastAccessAt selector is required for the login-state probe")
+
+	raw := driver.ExtractFieldValuePublic(doc, sel)
+	ts, err := strconv.ParseInt(raw, 10, 64)
+	require.NoError(t, err, "lastAccessAt should be a unix timestamp, got %q", raw)
+	assert.Greater(t, ts, int64(0), "lastAccessAt must be > 0")
+}
+
+func TestPtzone_Fixtures_NoSecrets(t *testing.T) {
+	fixtures := map[string]string{
+		"search":           ptzoneSearchFixture,
+		"detail":           ptzoneDetailFixture,
+		"detail_freetimed": ptzoneDetailFreeTimedFixture,
+		"index":            ptzoneIndexFixture,
+		"userdetails":      ptzoneUserdetailsFixture,
+	}
+	for name, data := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			RequireNoSecrets(t, name, data)
+		})
+	}
+}

--- a/site/v2/nexusphp_driver.go
+++ b/site/v2/nexusphp_driver.go
@@ -446,16 +446,18 @@ func (d *NexusPHPDriver) ParseSearch(res NexusPHPResponse) ([]TorrentItem, error
 		item.SizeBytes = parseSize(sizeText)
 
 		// Parse seeders
+		// 部分站点渲染带千分位分隔符的计数（如 <b>7,170</b>），直接 Atoi 会静默得到 0，
+		// 因此统一先用 extractNumber 提取并去掉分隔符（与 ParseUserDetails 中做种积分的处理一致）
 		seedersText := strings.TrimSpace(s.Find(d.Selectors.Seeders).Text())
-		item.Seeders, _ = strconv.Atoi(seedersText)
+		item.Seeders, _ = strconv.Atoi(extractNumber(seedersText))
 
 		// Parse leechers
 		leechersText := strings.TrimSpace(s.Find(d.Selectors.Leechers).Text())
-		item.Leechers, _ = strconv.Atoi(leechersText)
+		item.Leechers, _ = strconv.Atoi(extractNumber(leechersText))
 
 		// Parse snatched
 		snatchedText := strings.TrimSpace(s.Find(d.Selectors.Snatched).Text())
-		item.Snatched, _ = strconv.Atoi(snatchedText)
+		item.Snatched, _ = strconv.Atoi(extractNumber(snatchedText))
 
 		// Parse discount level
 		discountElem := s.Find(d.Selectors.DiscountIcon)

--- a/site/v2/nexusphp_driver_count_test.go
+++ b/site/v2/nexusphp_driver_count_test.go
@@ -1,0 +1,151 @@
+package v2
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildNexusPHPCountRow 构造一行标准 NexusPHP 搜索结果表格。
+// 列顺序与 DefaultNexusPHPSelectors 一致：第 5 列为体积，第 6/7/8 列分别为
+// 做种数 / 下载数 / 完成数。三个计数列接收原始 HTML 片段，用于模拟真实站点
+// 里 <b>7,170</b> 这类带千分位分隔符的 markup。
+func buildNexusPHPCountRow(seeders, leechers, snatched string) string {
+	return fmt.Sprintf(`
+	<html>
+	<body>
+	<table class="torrents">
+		<tbody>
+			<tr><td>Header</td></tr>
+			<tr>
+				<td><img alt="Movie" /></td>
+				<td><a href="details.php?id=99001">Count Separator Repro 2026</a></td>
+				<td></td>
+				<td><span>2026-01-01</span></td>
+				<td>1.5 GB</td>
+				<td>%s</td>
+				<td>%s</td>
+				<td>%s</td>
+			</tr>
+		</tbody>
+	</table>
+	</body>
+	</html>
+	`, seeders, leechers, snatched)
+}
+
+// TestNexusPHPDriver_ParseSearch_CountSeparators 覆盖共享 NexusPHP 驱动里
+// 做种数 / 下载数 / 完成数的解析。
+//
+// 回归背景：这三个字段原先直接调用 strconv.Atoi 且丢弃 error，遇到站点渲染的
+// 千分位分隔符（如 ptzone.xyz 的 <b>7,170</b>）会静默得到 0，导致依赖计数的
+// RSS 过滤规则失效。
+func TestNexusPHPDriver_ParseSearch_CountSeparators(t *testing.T) {
+	driver := NewNexusPHPDriver(NexusPHPDriverConfig{
+		BaseURL: "https://example.com",
+		Cookie:  "test-cookie",
+	})
+
+	tests := []struct {
+		name         string
+		seeders      string
+		leechers     string
+		snatched     string
+		wantSeeders  int
+		wantLeechers int
+		wantSnatched int
+	}{
+		{
+			// THE BUG：取自 ptzone.xyz 真实抓包 markup，修复前 Snatched 为 0
+			name:         "千分位分隔符（完成数）",
+			seeders:      "12",
+			leechers:     "3",
+			snatched:     "<b>7,170</b>",
+			wantSeeders:  12,
+			wantLeechers: 3,
+			wantSnatched: 7170,
+		},
+		{
+			// 三列都带分隔符，证明修复覆盖全部三个字段而非只有一个
+			name:         "千分位分隔符（三列同时）",
+			seeders:      "1,024",
+			leechers:     "2,048",
+			snatched:     "3,072",
+			wantSeeders:  1024,
+			wantLeechers: 2048,
+			wantSnatched: 3072,
+		},
+		{
+			name:         "多组分隔符",
+			seeders:      "1,234,567",
+			leechers:     "12,345",
+			snatched:     "9,876,543",
+			wantSeeders:  1234567,
+			wantLeechers: 12345,
+			wantSnatched: 9876543,
+		},
+		{
+			// 回归保护：普通整数必须与修复前完全一致
+			name:         "普通整数",
+			seeders:      "42",
+			leechers:     "7",
+			snatched:     "99",
+			wantSeeders:  42,
+			wantLeechers: 7,
+			wantSnatched: 99,
+		},
+		{
+			name:         "零值",
+			seeders:      "0",
+			leechers:     "0",
+			snatched:     "0",
+			wantSeeders:  0,
+			wantLeechers: 0,
+			wantSnatched: 0,
+		},
+		{
+			// 回归保护：空单元格行为不变，仍为 0
+			name:         "空单元格",
+			seeders:      "",
+			leechers:     "",
+			snatched:     "",
+			wantSeeders:  0,
+			wantLeechers: 0,
+			wantSnatched: 0,
+		},
+		{
+			// 回归保护：无数字的占位文本行为不变，仍为 0
+			name:         "无数字占位文本",
+			seeders:      "N/A",
+			leechers:     "--",
+			snatched:     "暂无",
+			wantSeeders:  0,
+			wantLeechers: 0,
+			wantSnatched: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := goquery.NewDocumentFromReader(
+				strings.NewReader(buildNexusPHPCountRow(tt.seeders, tt.leechers, tt.snatched)),
+			)
+			require.NoError(t, err)
+
+			items, err := driver.ParseSearch(NexusPHPResponse{Document: doc})
+			require.NoError(t, err)
+			require.Len(t, items, 1)
+
+			assert.Equal(t, tt.wantSeeders, items[0].Seeders, "Seeders")
+			assert.Equal(t, tt.wantLeechers, items[0].Leechers, "Leechers")
+			assert.Equal(t, tt.wantSnatched, items[0].Snatched, "Snatched")
+
+			// 体积解析走独立路径，此处仅作旁路回归保护
+			assert.Positive(t, items[0].SizeBytes, "SizeBytes 不应受计数解析改动影响")
+		})
+	}
+}

--- a/tools/browser-extension/src/core/constants.ts
+++ b/tools/browser-extension/src/core/constants.ts
@@ -598,6 +598,15 @@ export const KNOWN_SITES: KnownSite[] = [
     cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
     syncField: "cookie",
   },
+  {
+    id: "ptzone",
+    name: "PTzone",
+    domains: ["ptzone.xyz"],
+    schema: "NexusPHP",
+    authMethod: "cookie",
+    cookieNames: ["c_secure_uid", "c_secure_pass", "c_secure_tracker_ssl"],
+    syncField: "cookie",
+  },
 ];
 
 export const PAGE_PATTERNS: Array<{ pattern: RegExp; pageType: PageType }> = [


### PR DESCRIPTION
## Summary

新增 PTzone（`ptzone.xyz`）站点适配，并修复一个影响全部 NexusPHP 站点的计数解析缺陷。

采集数据来源为 Telegram 群提交，无对应 GitHub issue。

## 缺陷修复：计数千分位被解析为零

`ParseSearch` 中做种数、下载数、完成数三处直接调用 `strconv.Atoi`，而错误被 `_` 丢弃：

```go
item.Snatched, _ = strconv.Atoi(snatchedText)   // "7,170" → 0
```

带千分位分隔符的计数（如 `<b>7,170</b>`）会静默变成 0。

### 实测影响

对 `ptzone.xyz` 真实采集页（50 行）探测，**5 个单元格含逗号，全部被解析为 0**。

这会破坏用户的过滤规则：「只下载做种数 ≥ N 的种子」在遇到 `1,234` 这类热门种子时，实际拿到的是 0，导致误判且无任何错误提示。

### 修复方式

复用同文件既有的 `extractNumber`（内部 `strings.ReplaceAll(match, ",", "")`），使搜索路径与用户详情页 `Seeding` 字段（第 866 行）的既有写法一致。这是补上遗漏，不是新增机制。

改动仅三行 + 注释，未改动 `extractNumber` 实现、未改函数签名、未重构 `ParseSearch`。

### 行为对照（实测）

| 输入 | 修复前 | 修复后 | 性质 |
|---|---|---|---|
| `7,170` | 0 | **7170** | 目标修复 |
| `1,234,567` | 0 | **1234567** | 目标修复 |
| `100 (50%)` | 0 | **100** | 顺带改善（0 本就是错的）|
| `-3` | -3 | 3 | 理论回归，计数无负值故不可达 |
| `42` / `0` / `""` / `N/A` / `1.5` / `  88  ` | — | 不变 | 向后兼容 |

新增 7 条用例覆盖千分位、多组分隔符、三列同时、普通整数、零值、空单元格、无数字占位文本。

向后兼容的最强证据：**其余 64 个站点的 fixture 套件全部通过且无需改动**，每个都跑过这段代码路径。

## 新增站点：PTzone

**繁体界面**是其主要特征，标签与仓库内主流简体站点全不相同：

| 用途 | 本站标签 | 常见简体形式 |
|---|---|---|
| 体积行 | `基本資訊` | `基本信息` |
| 传输行 | **`傳送`** | `传输` |
| 上传量 | `上傳量` | `上传量` |
| 最近访问 | `最近動向` | `最近动向` |

传输行标签是 `傳送`（送），既非简体 `传输` 也非繁体 `傳輸` —— 与 `discfan` 完全一致，两站疑似同源模板。照搬 `:contains('传输')` 会静默取不到值。所有选择器均为繁体优先 + 简体兜底。

规避的一处陷阱：`邀請` 行链接的 `title="傳送邀請"` 含「傳送」二字，但选择器限定 `td.rowhead`，该行 rowhead 文本是「邀請」，不会误命中。

其他要点：

- 详情页含 `torrent_name` / `detail_torrent_id` 隐藏域，走 input-based 解析
- 详情样本优惠类名是 `twoupfree`（2X 免費）而非 `free`，单引号 + 尾随空格
- 优惠结束时间限定在 `font[color]` 内，避免误取同为 `span[title]` 的审核状态图标（`title="通過"` / `title="未審"`）与第 4 列发布时间
- 50 行中 48 行有促销，其中 45 行限时、3 行永久，故 `DiscountEndTime` 必须设置（与 `et8` 以永久促销为主的情况不同）

## Verification

**真实页面探针**

```
SEARCH: parsed 50 items
SEARCH: emptyID=0 zeroSize=0 emptySubtitle=0 withEndTime=45
SEARCH: discount FREE => 45 | 2XFREE => 3 | NONE => 2
DETAIL: id="2573" sizeMB=2.26 discount=2XFREE hasHR=false
USERINFO: lastAccessAt=1785739278 (>0，保号探针可用)
```

体积 `2.26 MB` 正确保持为 2.26（`ParseSizeMB` 以 MB 为基准单位，不换算），未被错误放大 1024 倍。

**自动化检查**

- `node --experimental-strip-types scripts/check-sites.ts` → Go 与扩展**双侧 65**，`✅ in sync`
- `go test ./... -count=1` → exit 0，40 个包通过，0 FAIL
- `make lint-go` → 0 issues
- `make fmt-check` → 全部文件格式正确
- 扩展 `pnpm typecheck` / `pnpm test` → 通过（19 项）

fixture 已脱敏，含 `TestPtzone_Fixtures_NoSecrets`。其中带千分位的那行现已成为共享层修复的端到端回归守卫。

## 已知未验证项

- `pro_2up` / `pro_50pctdown` / `pro_30pctdown` 促销图标在采集样本中不存在，按 NexusPHP 通用类名写入选择器但未经数据验证
- 未设 H&R：`hitandrun` / `hit_run` / `Hit and Run` / `Hit & Run` 在三个页面均为 0 次（`HRKeywords` 刻意不含裸 `H&R`，以免误命中导航栏计数器）
- 未设 `Aka` / `LevelRequirements`：页面无别名证据（`-PTZWeb` 是压制组标记非站名），也无等级阈值数据